### PR TITLE
Start work on production builds (#1)

### DIFF
--- a/.build/import-meta.js
+++ b/.build/import-meta.js
@@ -1,0 +1,15 @@
+import { createReplacePlugin } from "./replace.js";
+
+const MODE = process.env.MODE ?? "development";
+const DEV = MODE === "development";
+const PROD = MODE === "production";
+
+export default createReplacePlugin(
+  (id) => /\.(j|t)sx?$/.test(id),
+  {
+    "import.meta.env.MODE": process.env.MODE ?? "development",
+    "import.meta.env.DEV": DEV ? "true" : "false",
+    "import.meta.env.PROD": PROD ? "true" : "false",
+  },
+  true
+);

--- a/.build/replace.js
+++ b/.build/replace.js
@@ -1,0 +1,58 @@
+// originally from: https://github.com/vitejs/vite/blob/51e9c83458e30e3ce70abead14e02a7b353322d9/src/node/build/buildPluginReplace.ts
+
+// import type { Plugin, TransformResult } from "rollup";
+import MagicString from "magic-string";
+
+/**
+ * @param {(id: string) => boolean} test
+ * @param {Record<string, string>} replacements
+ * @param {boolean} sourcemap
+ * @returns {import("rollup").Plugin}
+ */
+export function createReplacePlugin(test, replacements, sourcemap) {
+  const pattern = new RegExp(
+    "\\b(" +
+      Object.keys(replacements)
+        .map((str) => {
+          return str.replace(/[-[\]/{}()*+?.\\^$|]/g, "\\$&");
+        })
+        .join("|") +
+      ")\\b",
+    "g"
+  );
+
+  return {
+    name: "starbeam:replace",
+    /**
+     * @param {string} code
+     * @param {string} id
+     * @returns {import("rollup").TransformResult}
+     */
+    transform(code, id) {
+      if (test(id)) {
+        const s = new MagicString(code);
+        let hasReplaced = false;
+        let match;
+
+        while ((match = pattern.exec(code))) {
+          hasReplaced = true;
+          const start = match.index;
+          const end = start + match[0].length;
+          const replacement = replacements[match[1]];
+          s.overwrite(start, end, replacement);
+        }
+
+        if (!hasReplaced) {
+          return null;
+        }
+
+        /** @type { import("rollup").TransformResult} */
+        const result = { code: s.toString() };
+        if (sourcemap) {
+          result.map = s.generateMap({ hires: true });
+        }
+        return result;
+      }
+    },
+  };
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,6 @@
 {
   "root": true,
-  "plugins": [
-    "prettier",
-    "unused-imports",
-    "simple-import-sort"
-  ],
+  "plugins": ["prettier", "unused-imports", "simple-import-sort"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "project": false,
@@ -107,7 +103,10 @@
       }
     },
     {
-      "files": ["framework/react/use-resource/scripts/**/*"],
+      "files": [
+        "framework/react/use-resource/scripts/**/*",
+        "rollup.config.js"
+      ],
       "env": {
         "node": true
       }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,8 @@
     "*.jsx": "${capture}.js",
     "*.tsx": "${capture}.ts",
     "tsconfig.json": "tsconfig.*",
-    "package.json": "package-lock.json, yarn.lock, pnpm-lock.yaml, .editorconfig, .eslintrc.json, .gitignore, .npmrc, .quokka, pnpm-workspace.yaml, vite.config.ts"
+    "package.json": "package-lock.json, yarn.lock, pnpm-lock.yaml, .pnpm-debug.log, .editorconfig, .eslintrc.json, .gitignore, .npmrc, .quokka, pnpm-workspace.yaml",
+    "vite.config.ts": "rollup.config.js, .env.*"
   },
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
   "vitest.enable": true,
@@ -29,6 +30,9 @@
     "editor.defaultFormatter": "redhat.vscode-xml"
   },
   "[ignore]": {
+    "editor.defaultFormatter": "foxundermoon.shell-format"
+  },
+  "[dotenv]": {
     "editor.defaultFormatter": "foxundermoon.shell-format"
   }
 }

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,47 @@
+MIT License
+
+Copyright (c) 20222-present, Yehuda Katz and Starbeam contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+Some additional code with the following licenses is included.
+
+MIT License
+
+Copyright (c) 2019-present, Yuxi (Evan) You
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/framework/react/use-resource/src/resource.ts
+++ b/framework/react/use-resource/src/resource.ts
@@ -278,16 +278,16 @@ export function useResource(): {
     options?: LifecycleOptions
   ) => Resource<T, void>;
 } {
-  return useResource.with(undefined as void);
+  return useResource.withState(undefined as void);
 }
 
 useResource.create = <T>(
   create: CreateResource<T, void>
 ): Resource<T, void> => {
-  return useResource.with(undefined as void).create(create);
+  return useResource.withState(undefined as void).create(create);
 };
 
-useResource.with = <A>(
+useResource.withState = <A>(
   state: A
 ): {
   create: <T>(

--- a/framework/react/use-resource/tests/use-resource.spec.ts
+++ b/framework/react/use-resource/tests/use-resource.spec.ts
@@ -16,7 +16,7 @@ testModes("useResource", (mode) => {
       const [count, setCount] = useState(0);
 
       const resource = useResource
-        .with({ count })
+        .withState({ count })
         .create(({ count }) => TestResource.initial(count))
         .update((resource, { count }) => resource.transition("updated", count))
         .on({
@@ -74,7 +74,7 @@ testModes("useResource (nested)", (mode) => {
       const [count, setCount] = useState(0);
 
       const resource = useResource
-        .with({ count })
+        .withState({ count })
         .create(({ count }) => TestResource.initial(count))
         .update((resource, { count }) => resource.transition("updated", count))
         .on({
@@ -136,7 +136,7 @@ testModes("useResource (nested, stability across remounting)", (mode) => {
       const [count, setCount] = useState(0);
 
       const resource = useResource
-        .with({ count })
+        .withState({ count })
         .create(({ count }) => TestResource.initial(count))
         .update((resource, { count }) => resource.transition("updated", count))
         .on({

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "types": "src/index.ts",
   "main": "src/index.ts",
   "private": true,
+  "license": "MIT",
   "publishConfig": {
     "registry": "http://localhost:4873/"
   },
@@ -15,6 +16,7 @@
     "serve": "vite preview",
     "test": "vitest",
     "typecheck": "tsc --build",
+    "test:prod": "vitest --mode production",
     "demos:react:store": "vite --port 3001 -c ./demos/react-store/vite.config.ts"
   },
   "devDependencies": {
@@ -23,6 +25,7 @@
     "@domtree/any": "workspace:*",
     "@domtree/flavors": "workspace:*",
     "@domtree/minimal": "workspace:*",
+    "@import-meta-env/unplugin": "^0.1.8",
     "@rollup/plugin-sucrase": "^4.0.4",
     "@rollup/plugin-typescript": "^8.3.3",
     "@swc/core": "^1.2.203",
@@ -33,6 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^5.27.0",
     "@typescript-eslint/parser": "^5.27.0",
     "@vitest/ui": "^0.14.1",
+    "dotenv": "^16.0.1",
     "esbuild": "^0.14.46",
     "eslint": "^8.16.0",
     "eslint-config-prettier": "^8.5.0",
@@ -45,6 +49,7 @@
     "esno": "^0.16.3",
     "fast-glob": "^3.2.11",
     "jsdom": "^19.0.0",
+    "magic-string": "^0.26.2",
     "postcss": "^8.4.14",
     "prettier": "^2.6.2",
     "rollup": "^2.75.6",

--- a/packages/env.d.ts
+++ b/packages/env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite/client" />
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/packages/verify/index.ts
+++ b/packages/verify/index.ts
@@ -10,10 +10,14 @@ export {
 } from "./src/assertions/basic.js";
 export { isOneOf } from "./src/assertions/multi.js";
 export { type TypeOf, hasType } from "./src/assertions/types.js";
-export {
-  type Expectation,
-  expected,
-  VerificationError,
-  verified,
-  verify,
-} from "./src/verify.js";
+export { type Expectation, expected, VerificationError } from "./src/verify.js";
+
+import { verify as verifyDev } from "./src/verify.js";
+export const verify: typeof verifyDev["noop"] = import.meta.env.DEV
+  ? verifyDev
+  : verifyDev.noop;
+
+import { verified as verifiedDev } from "./src/verify.js";
+export const verified: typeof verifiedDev["noop"] = import.meta.env.DEV
+  ? verifiedDev
+  : verifiedDev.noop;

--- a/packages/verify/src/verify.ts
+++ b/packages/verify/src/verify.ts
@@ -35,6 +35,14 @@ export function verify<T, U extends T>(
   }
 }
 
+verify.noop = <T, U extends T>(
+  value: T,
+  _check: ((input: T) => input is U) | ((input: T) => boolean),
+  _error?: Expectation<T>
+): asserts value is U => {
+  return;
+};
+
 export function verified<T, U extends T>(
   value: T,
   check: (input: T) => input is U,
@@ -43,6 +51,14 @@ export function verified<T, U extends T>(
   verify(value, check, error);
   return value;
 }
+
+verified.noop = <T, U extends T>(
+  value: T,
+  _check: (input: T) => input is U,
+  _error?: Expectation<T>
+): U => {
+  return value as U;
+};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class Expectation<In = any> {

--- a/packages/verify/tests/basic.spec.ts
+++ b/packages/verify/tests/basic.spec.ts
@@ -3,7 +3,9 @@ import "./support.js";
 import { expected, isEqual, isPresent, verify } from "@starbeam/verify";
 import { describe, expect, test } from "vitest";
 
-describe("basic verification", () => {
+const isProd = import.meta.env.PROD;
+
+describe.skipIf(isProd)("basic verification", () => {
   test("isPresent", () => {
     expect((value: unknown) => verify(value, isPresent)).toFail(
       null,

--- a/packages/verify/tests/verify.spec.ts
+++ b/packages/verify/tests/verify.spec.ts
@@ -1,7 +1,9 @@
 import { expected, verify } from "@starbeam/verify";
 import { describe, expect, test } from "vitest";
 
-describe("verify", () => {
+const isProd = import.meta.env.PROD;
+
+describe.skipIf(isProd)("verify", () => {
   test("default verify message", () => {
     const isPresent = <T>(input: T | null | undefined): input is T => {
       return input !== null && input !== undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ importers:
       '@domtree/any': workspace:*
       '@domtree/flavors': workspace:*
       '@domtree/minimal': workspace:*
+      '@import-meta-env/unplugin': ^0.1.8
       '@rollup/plugin-sucrase': ^4.0.4
       '@rollup/plugin-typescript': ^8.3.3
       '@swc/core': ^1.2.203
@@ -29,6 +30,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.27.0
       '@typescript-eslint/parser': ^5.27.0
       '@vitest/ui': ^0.14.1
+      dotenv: ^16.0.1
       esbuild: ^0.14.46
       eslint: ^8.16.0
       eslint-config-prettier: ^8.5.0
@@ -41,6 +43,7 @@ importers:
       esno: ^0.16.3
       fast-glob: ^3.2.11
       jsdom: ^19.0.0
+      magic-string: ^0.26.2
       postcss: ^8.4.14
       prettier: ^2.6.2
       rollup: ^2.75.6
@@ -60,6 +63,7 @@ importers:
       '@domtree/any': link:@types/@domtree/any
       '@domtree/flavors': link:@types/@domtree/flavors
       '@domtree/minimal': link:@types/@domtree/minimal
+      '@import-meta-env/unplugin': 0.1.8_qyqavhxsy6dzc3xcfnsab7uxuy
       '@rollup/plugin-sucrase': 4.0.4_rollup@2.75.6
       '@rollup/plugin-typescript': 8.3.3_rqgbr5uopfiucphy7ckzhieyka
       '@swc/core': 1.2.203
@@ -70,6 +74,7 @@ importers:
       '@typescript-eslint/eslint-plugin': 5.28.0_p7dpmbng2fwzidrcb7adceb33q
       '@typescript-eslint/parser': 5.28.0_aycqmkwbwxl3m4pnvl44sjixha
       '@vitest/ui': 0.14.2
+      dotenv: 16.0.1
       esbuild: 0.14.46
       eslint: 8.18.0
       eslint-config-prettier: 8.5.0_eslint@8.18.0
@@ -82,6 +87,7 @@ importers:
       esno: 0.16.3
       fast-glob: 3.2.11
       jsdom: 19.0.0
+      magic-string: 0.26.2
       postcss: 8.4.14
       prettier: 2.7.1
       rollup: 2.75.6
@@ -1717,6 +1723,23 @@ packages:
 
   /@humanwhocodes/object-schema/1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    dev: true
+
+  /@import-meta-env/unplugin/0.1.8_qyqavhxsy6dzc3xcfnsab7uxuy:
+    resolution: {integrity: sha512-BSMxFokncqHijsdMztRg/xv20LAr5FdJ+hhKFZ1wJNYRhSoF28DsMlQ119B52XKWycj5okuAQO4Bh69Lb7729Q==}
+    engines: {node: ^12.20.0 || >= 14}
+    peerDependencies:
+      dotenv: ^11.0.0 || ^12.0.4 || ^13.0.1 || ^14.3.2 || ^15.0.1 || ^16.0.0
+    dependencies:
+      dotenv: 16.0.1
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      unplugin: 0.3.3_alb2oewjl62jflpa6tdsfn4mjy
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - vite
+      - webpack
     dev: true
 
   /@istanbuljs/load-nyc-config/1.1.0:
@@ -3774,6 +3797,11 @@ packages:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+    dev: true
+
+  /dotenv/16.0.1:
+    resolution: {integrity: sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==}
+    engines: {node: '>=12'}
     dev: true
 
   /electron-to-chromium/1.4.160:
@@ -6705,6 +6733,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /object-hash/3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+    dev: true
+
   /object-inspect/1.12.2:
     resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
     dev: true
@@ -8502,6 +8535,29 @@ packages:
       - rollup
       - vite
       - webpack
+    dev: true
+
+  /unplugin/0.3.3_alb2oewjl62jflpa6tdsfn4mjy:
+    resolution: {integrity: sha512-WjZWpUqqcYPQ/efR00Zm2m1+J1LitwoZ4uhHV4VdZ+IpW0Nh/qnDYtVf+nLhozXdGxslMPecOshVR7NiWFl4gA==}
+    peerDependencies:
+      esbuild: '>=0.13'
+      rollup: ^2.50.0
+      vite: ^2.3.0
+      webpack: 4 || 5
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+    dependencies:
+      esbuild: 0.14.46
+      rollup: 2.75.6
+      vite: 2.9.12
+      webpack-virtual-modules: 0.4.3
     dev: true
 
   /unplugin/0.6.3_alb2oewjl62jflpa6tdsfn4mjy:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,12 +30,12 @@
     "packages",
     "framework",
     "demos",
+    "build/**/*.ts",
     ".scripts/**/*.ts",
     "vite.config.ts",
     "**/vite.config.ts",
-    "rollup.config.ts",
     "rollup.config.js",
-    "**/.eslintrc.cjs"
+    ".build/*.js"
   ],
   "exclude": [
     "**/node_modules/**",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,4 @@
-import { dirname, resolve } from "path";
-import { fileURLToPath } from "url";
 import { defineConfig } from "vitest/config";
-
-const dir = fileURLToPath(import.meta.url);
-const root = dirname(resolve(dir));
 
 const BUNDLED_EXTERNAL_PACKAGES = [
   "stacktracey",


### PR DESCRIPTION
Note that this is about reducing the runtime overhead of dev-mode
constructs, not (yet) about eliminating them from the build.

1. use import.meta.env.PROD in user code
2. add `pnpm test:prod`, which runs the tests in prod mode
3. Make verify() and verified() noops in production
4. Update rollup.config.js to mirror how vite replaces import.meta.env

Note that the reason we have rollup.config.ts is because we need the
feature of rollup that allows us to create separate, distinct configs,
because we don't want the packages to share chunks with each other.
See [this vite issue].

[this vite issue]: https://github.com/vitejs/vite/discussions/1736