### PR TITLE
per-project linting.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,6 +36,14 @@
   },
   "overrides": [
     {
+      "files": [
+        "**/.eslintrc.cjs"
+      ],
+      "env": {
+        "node": true
+      }
+    },
+    {
       "files": ["**/*.{ts,tsx}"],
       "parser": "@typescript-eslint/parser",
       "plugins": [

--- a/@types/@domtree/any/.eslintrc.cjs
+++ b/@types/@domtree/any/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/@types/@domtree/any/tsconfig.json
+++ b/@types/@domtree/any/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.package.json"
+}

--- a/@types/@domtree/browser/.eslintrc.cjs
+++ b/@types/@domtree/browser/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/@types/@domtree/browser/tsconfig.json
+++ b/@types/@domtree/browser/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.package.json"
+}

--- a/@types/@domtree/flavors/.eslintrc.cjs
+++ b/@types/@domtree/flavors/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/@types/@domtree/flavors/tsconfig.json
+++ b/@types/@domtree/flavors/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.package.json"
+}

--- a/@types/@domtree/interface/.eslintrc.cjs
+++ b/@types/@domtree/interface/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/@types/@domtree/interface/tsconfig.json
+++ b/@types/@domtree/interface/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.package.json"
+}

--- a/@types/@domtree/minimal/.eslintrc.cjs
+++ b/@types/@domtree/minimal/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/@types/@domtree/minimal/tsconfig.json
+++ b/@types/@domtree/minimal/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.package.json"
+}

--- a/@types/shell-escape-tag/.eslintrc.cjs
+++ b/@types/shell-escape-tag/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/@types/shell-escape-tag/tsconfig.json
+++ b/@types/shell-escape-tag/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/demos/jsnation/.eslintrc.cjs
+++ b/demos/jsnation/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/demos/jsnation/src/lib/people.ts
+++ b/demos/jsnation/src/lib/people.ts
@@ -1,5 +1,4 @@
-import type { Row, Table } from "./table.js";
-import type { Query } from "./table.js";
+import type { Query, Row, Table } from "./table.js";
 
 export interface Person {
   name: string;

--- a/demos/jsnation/tsconfig.json
+++ b/demos/jsnation/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/demos/react-store/.eslintrc.cjs
+++ b/demos/react-store/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/demos/react-store/tsconfig.json
+++ b/demos/react-store/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/demos/react/.eslintrc.cjs
+++ b/demos/react/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/demos/react/tsconfig.json
+++ b/demos/react/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/framework/react/react/.eslintrc.cjs
+++ b/framework/react/react/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/framework/react/react/src/element.ts
+++ b/framework/react/react/src/element.ts
@@ -1,8 +1,11 @@
 import type { browser } from "@domtree/flavors";
-import type { Linkable, Resource } from "@starbeam/core";
-import type { Cell, Reactive } from "@starbeam/core";
-import type { Renderable } from "@starbeam/timeline";
-import type { DebugListener, OnCleanup, Unsubscribe } from "@starbeam/timeline";
+import type { Cell, Linkable, Reactive, Resource } from "@starbeam/core";
+import type {
+  DebugListener,
+  OnCleanup,
+  Renderable,
+  Unsubscribe,
+} from "@starbeam/timeline";
 import { LIFETIME } from "@starbeam/timeline";
 import type { ReactElement } from "react";
 

--- a/framework/react/react/tsconfig.json
+++ b/framework/react/react/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.package.json"
+}

--- a/framework/react/use-resource/.eslintrc.cjs
+++ b/framework/react/use-resource/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/framework/react/use-resource/tsconfig.json
+++ b/framework/react/use-resource/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.package.json"
+}

--- a/packages/bundle/.eslintrc.cjs
+++ b/packages/bundle/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/packages/bundle/tsconfig.json
+++ b/packages/bundle/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/packages/core-utils/.eslintrc.cjs
+++ b/packages/core-utils/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/packages/core-utils/tsconfig.json
+++ b/packages/core-utils/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/packages/core/.eslintrc.cjs
+++ b/packages/core/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/packages/core/src/reactive-core/formula/state.ts
+++ b/packages/core/src/reactive-core/formula/state.ts
@@ -1,11 +1,12 @@
 import type { DescriptionArgs } from "@starbeam/debug";
 import {
   type FinalizedFrame,
+  type MutableInternals,
   type ReactiveInternals,
   type ReactiveProtocol,
   REACTIVE,
+  TIMELINE,
 } from "@starbeam/timeline";
-import { type MutableInternals, TIMELINE } from "@starbeam/timeline";
 
 /**
  * {@link FormulaState} represents the an instance of a formula and an

--- a/packages/core/src/storage/composite.ts
+++ b/packages/core/src/storage/composite.ts
@@ -1,6 +1,9 @@
 import { isArray } from "@starbeam/core-utils";
-import { type DescriptionArgs, FormulaDescription } from "@starbeam/debug";
-import { TimestampValidatorDescription } from "@starbeam/debug";
+import {
+  type DescriptionArgs,
+  FormulaDescription,
+  TimestampValidatorDescription,
+} from "@starbeam/debug";
 import {
   type ReactiveInternals,
   type ReactiveProtocol,

--- a/packages/core/src/storage/mutable.ts
+++ b/packages/core/src/storage/mutable.ts
@@ -1,11 +1,11 @@
-import { inspector } from "@starbeam/debug";
 import {
   type DescriptionArgs,
   type DescriptionType,
   CellDescription,
   Description,
+  inspector,
+  TimestampValidatorDescription,
 } from "@starbeam/debug";
-import { TimestampValidatorDescription } from "@starbeam/debug";
 import type { Timestamp } from "@starbeam/timeline";
 import {
   type ReactiveProtocol,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/packages/debug/.eslintrc.cjs
+++ b/packages/debug/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/packages/debug/src/stack.ts
+++ b/packages/debug/src/stack.ts
@@ -4,10 +4,8 @@ import StackTracey from "stacktracey";
 import {
   type CreateDescription,
   type DescriptionArgs,
-  Description,
-} from "./description/reactive-value.js";
-import {
   type ImplementationDetails,
+  Description,
   ImplementationDescription,
 } from "./description/reactive-value.js";
 import { describeModule } from "./module.js";

--- a/packages/debug/tsconfig.json
+++ b/packages/debug/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/packages/js/.eslintrc.cjs
+++ b/packages/js/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/packages/js/src/iterable.ts
+++ b/packages/js/src/iterable.ts
@@ -1,5 +1,4 @@
-import { type Equality, Marker, Reactive } from "@starbeam/core";
-import { Cell } from "@starbeam/core";
+import { type Equality, Cell, Marker, Reactive } from "@starbeam/core";
 import type { Description, DescriptionArgs } from "@starbeam/debug";
 
 class Entry<V> {

--- a/packages/js/tsconfig.json
+++ b/packages/js/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/packages/modifier/.eslintrc.cjs
+++ b/packages/modifier/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/packages/modifier/tsconfig.json
+++ b/packages/modifier/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/packages/peer/.eslintrc.cjs
+++ b/packages/peer/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/packages/peer/tsconfig.json
+++ b/packages/peer/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/packages/test-utils/.eslintrc.cjs
+++ b/packages/test-utils/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/packages/timeline/.eslintrc.cjs
+++ b/packages/timeline/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/packages/timeline/tsconfig.json
+++ b/packages/timeline/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/packages/verify/.eslintrc.cjs
+++ b/packages/verify/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/packages/verify/index.ts
+++ b/packages/verify/index.ts
@@ -12,12 +12,11 @@ export { isOneOf } from "./src/assertions/multi.js";
 export { type TypeOf, hasType } from "./src/assertions/types.js";
 export { type Expectation, expected, VerificationError } from "./src/verify.js";
 
-import { verify as verifyDev } from "./src/verify.js";
+import { verified as verifiedDev, verify as verifyDev } from "./src/verify.js";
 export const verify: typeof verifyDev["noop"] = import.meta.env.DEV
   ? verifyDev
   : verifyDev.noop;
 
-import { verified as verifiedDev } from "./src/verify.js";
 export const verified: typeof verifiedDev["noop"] = import.meta.env.DEV
   ? verifiedDev
   : verifiedDev.noop;

--- a/packages/verify/tsconfig.json
+++ b/packages/verify/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/packages/x-devtool/.eslintrc.cjs
+++ b/packages/x-devtool/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/packages/x-devtool/tsconfig.json
+++ b/packages/x-devtool/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/packages/x-devtools-extension/.eslintrc.cjs
+++ b/packages/x-devtools-extension/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/packages/x-devtools-extension/tsconfig.json
+++ b/packages/x-devtools-extension/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/packages/x-headless-form/.eslintrc.cjs
+++ b/packages/x-headless-form/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/packages/x-headless-form/tsconfig.json
+++ b/packages/x-headless-form/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/packages/x-store/.eslintrc.cjs
+++ b/packages/x-store/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/packages/x-store/tsconfig.json
+++ b/packages/x-store/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/packages/x-vanilla/.eslintrc.cjs
+++ b/packages/x-vanilla/.eslintrc.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  root: false,
+};

--- a/packages/x-vanilla/tsconfig.json
+++ b/packages/x-vanilla/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,5 +42,5 @@
     "node_modules/**",
     "**/dist/**",
     "packages/x-devtools-extension"
-  ]
+  ],
 }


### PR DESCRIPTION
In some editors / using vanilla LSP servers,  eslint resolves the tsconfig.json relative to the package root. This means that each package needs an eslint config and tsconfig.json.

Things to review:
 - if each package is extending the right tsconfig.json (they are all tsconfig.package atm)
 - the list --fix updates
 
 The .eslintrc.cjs files are all the same
 