### PR TITLE
Try delegating build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           root_of_repo=$(git rev-parse --show-toplevel)
           echo "::set-output name=workspaces::'$(\
                   pnpm ls -r --depth -1 --json \
-                  | sed 's~$()~.~g' \
+                  | sed 's~$root_of_repo~.~g' \
                 )'"
   temp:
     name: "temp"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,6 @@ jobs:
             | sed 's~$root_of_repo~.~g' \
           )
           echo "::set-output name=workspaces::'$(echo $workspaces)'"
-  temp:
-    name: "temp"
-    runs-on: "ubuntu-latest"
-    needs: ['preflight']
-    steps:
-      - name: 'Show workspaces'
-        run: echo " ${{ fromJson( needs.preflight.outputs.workspaces )}} "
 
   test:
     name: "Tests"
@@ -67,7 +60,7 @@ jobs:
     needs: ['preflight']
     strategy:
       fail-fast: true
-      matrix: ${{fromJson(needs.preflight.outputs.workspaces)}}
+      matrix: ${{(needs.preflight.outputs.workspaces)}}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,10 @@ jobs:
         # the sed command changes the absolute path to a relative path
         run: |
           root_of_repo=$(git rev-parse --show-toplevel)
-          workspaces=$( \
-            pnpm ls -r --depth -1 --json \
-            | sed "s~$root_of_repo~.~g" \
-          )
-          echo "::set-output name=workspaces::$(echo $workspaces)"
+          echo "::set-output name=workspaces::$(\
+                  pnpm ls -r --depth -1 --json \
+                  | sed 's~$root_of_repo~.~g' \
+                )"
   temp:
     name: "temp"
     runs-on: "ubuntu-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
             pnpm ls -r --depth -1 --json \
             | sed 's~$root_of_repo~.~g' \
           )
-          echo "::set-output name=workspaces::'$(echo $workspaces)'"
+          echo "::set-output name=workspaces::$(echo $workspaces)"
 
   test:
     name: "Tests"
@@ -60,7 +60,7 @@ jobs:
     needs: ['preflight']
     strategy:
       fail-fast: true
-      matrix: ${{(needs.preflight.outputs.workspaces)}}
+      matrix: ${{fromJson(needs.preflight.outputs.workspaces)}}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,10 @@ jobs:
         # the sed command changes the absolute path to a relative path
         run: |
           root_of_repo=$(git rev-parse --show-toplevel)
-          echo "::set-output name=workspaces::$(\
+          echo "::set-output name=workspaces::'$(\
                   pnpm ls -r --depth -1 --json \
-                  | sed 's~$root_of_repo~.~g' \
-                )"
+                  | sed 's~$()~.~g' \
+                )'"
   temp:
     name: "temp"
     runs-on: "ubuntu-latest"
@@ -61,12 +61,12 @@ jobs:
       - run: pnpm test
 
   typecheck:
-    name: "Typecheck"
+    name: "Types ${{ matrix.path }}"
     runs-on: "ubuntu-latest"
     needs: ['preflight']
     strategy:
       fail-fast: true
-      matrix: ${{ fromJson(needs.preflight.outputs.workspaces) }}
+      matrix: ${{fromJson(needs.preflight.outputs.workspaces)}}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,13 @@ jobs:
       - run: pnpm test
 
   typecheck:
-    name: "Types ${{ matrix.path }}"
+    name: "Types ${{ matrix.workspace.path }}"
     runs-on: "ubuntu-latest"
     needs: ['preflight']
     strategy:
       fail-fast: true
-      matrix: ${{needs.preflight.outputs.workspaces}}
+      matrix:
+        workspace: ${{fromJson(needs.preflight.outputs.workspaces)}}
 
     steps:
       - uses: actions/checkout@v2
@@ -68,7 +69,7 @@ jobs:
         uses: ./.github/actions/setup-node-and-install
       - name: "Check types"
         run: pnpm tsc --build
-        working-directory: ${{matrix.path}}
+        working-directory: ${{matrix.workspace.path}}
 
   lint:
     name: "Lint"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
         run: |
           root_of_repo=$(git rev-parse --show-toplevel)
           workspaces=$(\
-            pnpm ls -r --depth -1 --json \
-            | sed 's~$root_of_repo~.~g' \
+            pnpm ls -r --depth -1 --json
+            | sed "s~$root_of_repo~.~g" \
           )
           echo "::set-output name=workspaces::$(echo $workspaces)"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           root_of_repo=$(git rev-parse --show-toplevel)
           workspaces=$(\
-            pnpm ls -r --depth -1 --json
+            pnpm ls -r --depth -1 --json \
             | sed "s~$root_of_repo~.~g" \
           )
           echo "::set-output name=workspaces::$(echo $workspaces)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: "Setup"
     runs-on: "ubuntu-latest"
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      workspaces: ${{ steps.find-workspaces.outputs.workspaces }}
 
     steps:
       - uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
         # currently not used - as tests, lints, etc are all top-level commands / projects
         # if we were to make each workspace isolated, we'd first need to copy tsc/eslint/vitest
         # configs into each package -- but that would be slower than what today's setup is.
-      - id: set-matrix
+      - id: find-workspaces
         name: "Find workspaces"
         # generates a list of root-relative paths to each workspace
         #
@@ -36,7 +36,8 @@ jobs:
             | sed "s~$root_of_repo~~g" \
             | sed '/^[[:space:]]*$/d' \
             | sed 's~^/~~g')
-          echo "::set-output name=matrix::$(echo $workspaces)"
+          echo $workspaces
+          echo "::set-output name=workspaces::$(echo $workspaces)"
 
   test:
     name: "Tests"
@@ -54,7 +55,7 @@ jobs:
     needs: ['install_dependencies']
     strategy:
       fail-fast: true
-      matrix: ${{ needs.install_dependencies.outputs.matrix }}
+      matrix: ${{ needs.install_dependencies.outputs.workspaces }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,11 @@ jobs:
         # the sed command changes the absolute path to a relative path
         run: |
           root_of_repo=$(git rev-parse --show-toplevel)
-          echo "::set-output name=workspaces::'$(\
-                  pnpm ls -r --depth -1 --json \
-                  | sed \'s~$root_of_repo~.~g\' \
-                )'"
+          workspaces=$(\
+            pnpm ls -r --depth -1 --json \
+            | sed 's~$root_of_repo~.~g' \
+          )
+          echo "::set-output name=workspaces::'$(echo $workspaces)'"
   temp:
     name: "temp"
     runs-on: "ubuntu-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: ['preflight']
     strategy:
-      fail-fast: true
+      # fail-fast: true
       matrix: ${{ fromJson(needs.preflight.outputs.workspaces) }}
 
     steps:
@@ -79,7 +79,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: ['preflight', 'lint', 'typecheck', 'test']
+    needs: ['lint', 'typecheck', 'test']
     steps:
       - uses: actions/checkout@v2
       - name: "Setup node and install dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     needs: ['preflight']
     strategy:
       fail-fast: true
-      matrix: ${{fromJson(needs.preflight.outputs.workspaces)}}
+      matrix: ${{needs.preflight.outputs.workspaces}}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
             | sed 's~^/~~g')
           echo $workspaces
           echo "::set-output name=workspaces::$(echo $workspaces)"
+      - name: 'Show workspaces'
+        run: |
+          echo " ${{ steps.find-workspaces.outputs.workspaces }}"
+          echo " ${{ fromJson( steps.find-workspaces.outputs.workspaces )}}"
 
   test:
     name: "Tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: "ubuntu-latest"
     outputs:
       workspaces: ${{ steps.find-workspaces.outputs.workspaces }}
+      ts_workspaces: ${{ steps.find-workspaces.outputs.ts_workspaces }}
 
     steps:
       - uses: actions/checkout@v2
@@ -58,10 +59,6 @@ jobs:
     name: "Types ${{ matrix.workspace.path }}"
     runs-on: "ubuntu-latest"
     needs: ['preflight']
-    strategy:
-      fail-fast: true
-      matrix:
-        workspace: ${{fromJson(needs.preflight.outputs.workspaces)}}
 
     steps:
       - uses: actions/checkout@v2
@@ -69,7 +66,6 @@ jobs:
         uses: ./.github/actions/setup-node-and-install
       - name: "Check types"
         run: pnpm tsc --build
-        working-directory: ${{matrix.workspace.path}}
 
   lint:
     name: "Lint"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,29 +22,34 @@ jobs:
         # configs into each package -- but that would be slower than what today's setup is.
       - id: find-workspaces
         name: "Find workspaces"
-        # generates a list of root-relative paths to each workspace
         #
-        # the pipes line-by-line:
-        #   Remove version information
-        #   Remove the current directory
-        #   Remove empty lines
-        #   Remove leading slashes
+        # json looks like:
+        #
+        # [
+        #   {
+        #      "name": "@starbeam/cocre"
+        #      "version": "...",
+        #      "path": "/absolute path from root of drive",
+        #      "private": false,
+        #   }
+        #   ...
+        # ]
+        #
+        # the sed command changes the absolute path to a relative path
         run: |
           root_of_repo=$(git rev-parse --show-toplevel)
-          workspaces=$(pnpm ls -r --depth -1 --long --parseable \
-            | cut -f1 -d':' \
-            | sed "s~$root_of_repo~~g" \
-            | sed '/^[[:space:]]*$/d' \
-            | sed 's~^/~~g')
-          echo $workspaces
-          echo "::set-output name=workspaces::$(echo $workspaces)"
+          workspaces=$( \
+            pnpm ls -r --depth -1 --json \
+            | sed "s~$root_of_repo~.~g" \
+          )
+          echo "::set-output name=workspaces::$()"
   temp:
-    name: "Tests"
+    name: "temp"
     runs-on: "ubuntu-latest"
     needs: ['preflight']
     steps:
       - name: 'Show workspaces'
-        run: echo " ${{ needs.preflight.outputs.workspaces }} " && echo " ${{ fromJson( needs.preflight.outputs.workspaces )}} "
+        run: echo " ${{ fromJson( needs.preflight.outputs.workspaces )}} "
 
   test:
     name: "Tests"
@@ -61,7 +66,7 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: ['preflight']
     strategy:
-      # fail-fast: true
+      fail-fast: true
       matrix: ${{ fromJson(needs.preflight.outputs.workspaces) }}
 
     steps:
@@ -70,7 +75,7 @@ jobs:
         uses: ./.github/actions/setup-node-and-install
       - name: "Check types"
         run: pnpm tsc --build
-        working-directory: ${{matrix}}
+        working-directory: ${{matrix.path}}
 
   lint:
     name: "Lint"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,7 @@ jobs:
           echo $workspaces
           echo "::set-output name=workspaces::$(echo $workspaces)"
       - name: 'Show workspaces'
-        run: |
-          echo " ${{ steps.find-workspaces.outputs.workspaces }}"
-          echo " ${{ fromJson( steps.find-workspaces.outputs.workspaces )}}"
+        run: echo " ${{ steps.find-workspaces.outputs.workspaces }} " && echo " ${{ fromJson( steps.find-workspaces.outputs.workspaces )}} "
 
   test:
     name: "Tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           root_of_repo=$(git rev-parse --show-toplevel)
           echo "::set-output name=workspaces::'$(\
                   pnpm ls -r --depth -1 --json \
-                  | sed 's~$root_of_repo~.~g' \
+                  | sed \'s~$root_of_repo~.~g\' \
                 )'"
   temp:
     name: "temp"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,17 @@ jobs:
     name: "Typecheck"
     runs-on: "ubuntu-latest"
     needs: ['install_dependencies']
+    strategy:
+      fail-fast: true
+      matrix: ${{ needs.install_dependencies.outputs.matrix }}
+
     steps:
       - uses: actions/checkout@v2
       - name: "Setup node and install dependencies"
         uses: ./.github/actions/setup-node-and-install
-      - run: pnpm typecheck
+      - name: "Check types"
+        run: pnpm tsc --build
+        working-directory: ${{matrix}}
 
   lint:
     name: "Lint"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
             pnpm ls -r --depth -1 --json \
             | sed "s~$root_of_repo~.~g" \
           )
-          echo "::set-output name=workspaces::$()"
+          echo "::set-output name=workspaces::$(echo $workspaces)"
   temp:
     name: "temp"
     runs-on: "ubuntu-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,13 @@ jobs:
             | sed 's~^/~~g')
           echo $workspaces
           echo "::set-output name=workspaces::$(echo $workspaces)"
+  temp:
+    name: "Tests"
+    runs-on: "ubuntu-latest"
+    needs: ['preflight']
+    steps:
       - name: 'Show workspaces'
-        run: echo " ${{ steps.find-workspaces.outputs.workspaces }} " && echo " ${{ fromJson( steps.find-workspaces.outputs.workspaces )}} "
+        run: echo " ${{ needs.preflight.outputs.workspaces }} " && echo " ${{ fromJson( needs.preflight.outputs.workspaces )}} "
 
   test:
     name: "Tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  install_dependencies:
+  preflight:
     name: "Setup"
     runs-on: "ubuntu-latest"
     outputs:
@@ -42,7 +42,7 @@ jobs:
   test:
     name: "Tests"
     runs-on: "ubuntu-latest"
-    needs: ['install_dependencies']
+    needs: ['preflight']
     steps:
       - uses: actions/checkout@v2
       - name: "Setup node and install dependencies"
@@ -52,10 +52,10 @@ jobs:
   typecheck:
     name: "Typecheck"
     runs-on: "ubuntu-latest"
-    needs: ['install_dependencies']
+    needs: ['preflight']
     strategy:
       fail-fast: true
-      matrix: ${{ needs.install_dependencies.outputs.workspaces }}
+      matrix: ${{ fromJson(needs.preflight.outputs.workspaces) }}
 
     steps:
       - uses: actions/checkout@v2
@@ -68,7 +68,7 @@ jobs:
   lint:
     name: "Lint"
     runs-on: "ubuntu-latest"
-    needs: ['install_dependencies']
+    needs: ['preflight']
     steps:
       - uses: actions/checkout@v2
       - name: "Setup node and install dependencies"
@@ -79,7 +79,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: ['install_dependencies', 'lint', 'typecheck', 'test']
+    needs: ['preflight', 'lint', 'typecheck', 'test']
     steps:
       - uses: actions/checkout@v2
       - name: "Setup node and install dependencies"

--- a/@types/globals/index.d.ts
+++ b/@types/globals/index.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+declare global {
+  interface StarbeamShellEnv extends ImportMetaEnv {
+    // additional env vars here
+    DEBUG: boolean;
+  }
+
+  interface ImportMeta {
+    readonly env: StarbeamShellEnv;
+  }
+}

--- a/@types/globals/package.json
+++ b/@types/globals/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@types/globals",
+  "private": true,
+  "types": "index.d.ts",
+  "dependencies": {
+    "vite": "^2.9.9"
+  }
+}

--- a/@types/globals/tsconfig.json
+++ b/@types/globals/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.package.json"
+}

--- a/packages/core-utils/index.ts
+++ b/packages/core-utils/index.ts
@@ -1,3 +1,3 @@
-export { UNINITIALIZED } from "../peer/src/constants.js";
+export { UNINITIALIZED } from "@starbeam/peer/src/constants.js";
 export { isArray } from "./src/array.js";
 export { isObject } from "./src/object.js";

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -3,7 +3,9 @@
   "version": "0.5.1",
   "type": "module",
   "main": "index.ts",
-  "dependencies": {},
+  "dependencies": {
+    "@starbeam/peer": "workspace:*"
+  },
   "devDependencies": {},
   "publishConfig": {
     "main": "dist/index.cjs",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tsconfig.package.json"
+  "extends": "../../tsconfig.package.json",
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
 }

--- a/packages/env.d.ts
+++ b/packages/env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="vite/client" />
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}

--- a/packages/verify/index.ts
+++ b/packages/verify/index.ts
@@ -1,3 +1,5 @@
+import 'globals';
+
 export {
   exhaustive,
   hasItems,

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -4,6 +4,9 @@
   "main": "index.ts",
   "version": "0.5.1",
   "dependencies": {},
+  "devDependencies": {
+    "@types/globals": "*"
+  },
   "publishConfig": {
     "main": "dist/index.cjs",
     "types": "dist/index.d.ts",

--- a/packages/x-store/tsconfig.json
+++ b/packages/x-store/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tsconfig.package.json"
+  "extends": "../../tsconfig.package.json",
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,15 @@ importers:
     dependencies:
       '@domtree/interface': link:../interface
 
+  '@types/globals':
+    specifiers:
+      vite: ^2.9.9
+    dependencies:
+      vite: 2.9.12
+
+  '@types/shell-escape-tag':
+    specifiers: {}
+
   demos/jsnation:
     specifiers:
       '@esbuild-plugins/node-globals-polyfill': ^0.1.1
@@ -384,7 +393,10 @@ importers:
       '@starbeam/verify': link:../verify
 
   packages/core-utils:
-    specifiers: {}
+    specifiers:
+      '@starbeam/peer': workspace:*
+    dependencies:
+      '@starbeam/peer': link:../peer
 
   packages/core-utils/tests:
     specifiers:
@@ -490,7 +502,10 @@ importers:
       '@starbeam/timeline': link:..
 
   packages/verify:
-    specifiers: {}
+    specifiers:
+      '@types/globals': '*'
+    devDependencies:
+      '@types/globals': link:../../@types/globals
 
   packages/verify/tests:
     specifiers:
@@ -3914,7 +3929,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-android-arm64/0.14.38:
@@ -3941,7 +3955,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-darwin-64/0.14.38:
@@ -3968,7 +3981,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-darwin-arm64/0.14.38:
@@ -3995,7 +4007,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-freebsd-64/0.14.38:
@@ -4022,7 +4033,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-freebsd-arm64/0.14.38:
@@ -4049,7 +4059,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-32/0.14.38:
@@ -4076,7 +4085,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-64/0.14.38:
@@ -4103,7 +4111,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-arm/0.14.38:
@@ -4130,7 +4137,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-arm64/0.14.38:
@@ -4157,7 +4163,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-mips64le/0.14.38:
@@ -4184,7 +4189,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-ppc64le/0.14.38:
@@ -4211,7 +4215,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-riscv64/0.14.38:
@@ -4238,7 +4241,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-s390x/0.14.38:
@@ -4265,7 +4267,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-netbsd-64/0.14.38:
@@ -4292,7 +4293,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-openbsd-64/0.14.38:
@@ -4319,7 +4319,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-sunos-64/0.14.38:
@@ -4346,7 +4345,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-windows-32/0.14.38:
@@ -4373,7 +4371,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-windows-64/0.14.38:
@@ -4400,7 +4397,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-windows-arm64/0.14.38:
@@ -4427,7 +4423,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild/0.14.38:
@@ -4512,7 +4507,6 @@ packages:
       esbuild-windows-32: 0.14.46
       esbuild-windows-64: 0.14.46
       esbuild-windows-arm64: 0.14.46
-    dev: true
 
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -5078,12 +5072,10 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /function-bind/1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
-    dev: true
 
   /function.prototype.name/1.1.5:
     resolution: {integrity: sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==}
@@ -5284,7 +5276,6 @@ packages:
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
-    dev: true
 
   /he/1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
@@ -5536,7 +5527,6 @@ packages:
     resolution: {integrity: sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==}
     dependencies:
       has: 1.0.3
-    dev: true
 
   /is-date-object/1.0.5:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
@@ -6667,7 +6657,6 @@ packages:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -6963,7 +6952,6 @@ packages:
 
   /path-parse/1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: true
 
   /path-type/4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -6976,7 +6964,6 @@ packages:
 
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-    dev: true
 
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -7379,7 +7366,6 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: true
 
   /preact/10.8.1:
     resolution: {integrity: sha512-p5CKQ0MCEXTGKGOHiFaNE2V2nDq2hvDHykXvIlz+4lbfJ9umLZr8JS/fa1bXUwRcHXK+Ljk8zqmDhr25n0LtVg==}
@@ -7666,7 +7652,6 @@ packages:
       is-core-module: 2.9.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-    dev: true
 
   /reusify/1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
@@ -7809,7 +7794,6 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -7969,7 +7953,6 @@ packages:
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /source-map-support/0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
@@ -8189,7 +8172,6 @@ packages:
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /svgo/2.8.0:
     resolution: {integrity: sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==}
@@ -8676,7 +8658,6 @@ packages:
       rollup: 2.75.6
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /vitest/0.14.2_7hzvxbovfebwiykl4wbvsrid2q:
     resolution: {integrity: sha512-vXQUl8OUCqHmxKWscMGL+6Xl1pBJmYHZ8N85iNpLGrirAC2vhspu7b73ShRcLonmZT44BYZW+LBAVvn0L4jyVA==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 packages:
   - "@types/@domtree/*"
-  - "@types/"
+  - "@types/*"
   - packages/*
   - packages/*/tests
   - framework/*/*

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -63,7 +63,7 @@ export default packages.map((pkg) =>
             },
           },
         },
-        tsconfig: resolve(root, "tsconfig.package.json"),
+        tsconfig: resolve(pkg.root, "tsconfig.json"),
       }),
     ],
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,5 @@
+// This is a convinience tsconfig.json and is
+// not needed for bundling / type checking
 {
   "compilerOptions": {
     "jsx": "preserve",
@@ -26,19 +28,19 @@
     "inlineSources": true
   },
 
-  "include": [
-    "build/**/*.ts",
-    ".scripts/**/*.ts",
-    "vite.config.ts",
-    "**/vite.config.ts",
-    "rollup.config.js",
-    ".build/*.js"
-  ],
-  "exclude": [
-    "**/node_modules/**",
-    "node_modules/**",
-    "**/dist/**",
-  ],
+  // "include": [
+  //   "build/**/*.ts",
+  //   ".scripts/**/*.ts",
+  //   "vite.config.ts",
+  //   "**/vite.config.ts",
+  //   "rollup.config.js",
+  //   ".build/*.js"
+  // ],
+  // "exclude": [
+  //   "**/node_modules/**",
+  //   "node_modules/**",
+  //   "**/dist/**",
+  // ],
   "references": [
     // references + composite projects --
     // each project allow the individual projects to define their own

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,9 +27,6 @@
   },
 
   "include": [
-    "packages",
-    "framework",
-    "demos",
     "build/**/*.ts",
     ".scripts/**/*.ts",
     "vite.config.ts",
@@ -41,6 +38,45 @@
     "**/node_modules/**",
     "node_modules/**",
     "**/dist/**",
-    "packages/x-devtools-extension"
   ],
+  "references": [
+    // references + composite projects --
+    // each project allow the individual projects to define their own
+    // tsconfig.jsons
+
+    // @types
+    { "path": "./@types/@domtree/any" },
+    { "path": "./@types/@domtree/browser" },
+    { "path": "./@types/@domtree/flavors" },
+    { "path": "./@types/@domtree/minimal" },
+    { "path": "./@types/@domtree/interface" },
+    { "path": "./@types/shell-escape-tag" },
+    { "path": "./@types/globals" },
+
+    // demos
+    { "path": "./demos/react" },
+    { "path": "./demos/jsnation" },
+    { "path": "./demos/react-store" },
+
+    // framework integrations
+    { "path": "./framework/react/react" },
+    { "path": "./framework/react/use-resource" },
+
+    // starbeam packages
+    { "path": "./packages/bundle" },
+    { "path": "./packages/core" },
+    { "path": "./packages/core-utils" },
+    { "path": "./packages/debug" },
+    { "path": "./packages/js" },
+    { "path": "./packages/modifier" },
+    { "path": "./packages/peer" },
+    { "path": "./packages/test-utils" },
+    { "path": "./packages/timeline" },
+    { "path": "./packages/verify" },
+    { "path": "./packages/x-devtool" },
+    // { "path": "./packages/x-devtools-extension" },
+    // { "path": "./packages/x-headless-form" },
+    { "path": "./packages/x-store" },
+    { "path": "./packages/x-vanilla" },
+  ]
 }

--- a/tsconfig.package.json
+++ b/tsconfig.package.json
@@ -1,11 +1,18 @@
 {
   "compilerOptions": {
     "composite": true,
+
+    "declarationDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+
+    "checkJs": false,
+    "allowJs": false,
+
     "jsx": "preserve",
     "target": "esnext",
     "strict": true,
-    "declaration": true,
-    "declarationMap": true,
     "useDefineForClassFields": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/tsconfig.package.json
+++ b/tsconfig.package.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "jsx": "preserve",
     "target": "esnext",
     "strict": true,


### PR DESCRIPTION
Before this PR, it's been required to build / typecheck the whole monorepo in unison, with everything using the same config.
In order to better support framework exploration and integrations, packages need to have their own tsconfig.jsons.

This PR:
 - tells rollup to use the project-local tsconfig.json
 - ~sets up C.I. to check packages' type correctness individually~ this isn't a good idea / won't work, because projects depend on other project's types to be built -- so the top-level tsconfig.json is maybe going to be a "references only" config
 - moves the `ImportMeta` augmentations to their own package for explicit, opt-in consumption 
 
 Why?:
  - helps us figure out where dependencies are, and is very strict
  - each package in the monorepo will function more like a real out-of-monorepo package -- allowing us to catch certain issues that would usually only be found by consumers sooner