### PR TITLE
Untracked consumption errors in React renderer

### DIFF
--- a/.changeset/four-singers-grow.md
+++ b/.changeset/four-singers-grow.md
@@ -1,0 +1,10 @@
+---
+"@starbeam/react": patch
+"@starbeam/core": patch
+"@starbeam/debug": patch
+"@starbeam/js": patch
+"@starbeam/timeline": patch
+"@starbeamx/store": patch
+---
+
+Added untracked consumption errors and infrastructure for tracking reads and writes to cells

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,6 +35,5 @@
     "editor.defaultFormatter": "foxundermoon.shell-format"
   },
   "editor.fontWeight": "normal",
-  "workbench.colorTheme": "Visual Studio Light",
-  "testing.automaticallyOpenPeekView": "never"
+  "workbench.colorTheme": "Visual Studio Light"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,6 +11,13 @@
         "kind": "build",
         "isDefault": true
       }
+    },
+    {
+      "type": "typescript",
+      "tsconfig": "tsconfig.json",
+      "problemMatcher": ["$tsc"],
+      "group": "build",
+      "label": "typecheck"
     }
   ]
 }

--- a/demos/jsnation/src/lib/table.ts
+++ b/demos/jsnation/src/lib/table.ts
@@ -1,3 +1,4 @@
+import { TIMELINE } from "@starbeam/core";
 import { reactive } from "@starbeam/js";
 
 export type Row<T> = {
@@ -57,14 +58,16 @@ export class Query<T> {
   }
 
   get rows(): Row<T>[] {
-    const filtered = this.#table.rows.filter((row) =>
-      this.#filters.every((filter) => filter(row))
-    );
+    return TIMELINE.entryPoint(() => {
+      const filtered = this.#table.rows.filter((row) =>
+        this.#filters.every((filter) => filter(row))
+      );
 
-    if (this.#sort) {
-      return filtered.sort(this.#sort);
-    } else {
-      return filtered;
-    }
+      if (this.#sort) {
+        return filtered.sort(this.#sort);
+      } else {
+        return filtered;
+      }
+    });
   }
 }

--- a/demos/react-store/src/components/DataTable.tsx
+++ b/demos/react-store/src/components/DataTable.tsx
@@ -1,6 +1,6 @@
 import { Cell } from "@starbeam/core";
 import { LOGGER, LogLevel } from "@starbeam/debug";
-import { useProp, useStarbeam } from "@starbeam/react";
+import { useProp, useReactive, useSetup } from "@starbeam/react";
 import { DevTools } from "@starbeamx/devtool";
 import { Table } from "@starbeamx/store";
 import type { FormEvent } from "react";
@@ -12,113 +12,122 @@ LOGGER.level = LogLevel.Debug;
 export default function (props: { locale: string }) {
   const locale = useProp(props.locale, "props.locale");
 
-  return useStarbeam((component) => {
-    component.attach(DevTools);
+  const { people, append, filter, total, rows, table } = useSetup(
+    (component) => {
+      component.attach(DevTools);
 
-    const table = Table.create<Person>({
-      columns: ["name", "location"],
-      name: "people",
-    });
+      const table = Table.create<Person>({
+        columns: ["name", "location"],
+        name: "people",
+      });
 
-    table.append({ name: "Tom Dale", location: "NYC" });
-    table.append({ name: "Chirag Patel", location: "NYC" });
-    table.append({ name: "Yehuda Katz", location: "Portland" });
-    table.append({ name: "Ärne Ärni", location: "Germany" });
+      table.append({ name: "Tom Dale", location: "NYC" });
+      table.append({ name: "Chirag Patel", location: "NYC" });
+      table.append({ name: "Yehuda Katz", location: "Portland" });
+      table.append({ name: "Ärne Ärni", location: "Germany" });
 
-    const people = new People(table);
+      const people = new People(table);
 
-    function append(e: FormEvent<HTMLFormElement>) {
-      e.preventDefault();
+      function append(e: FormEvent<HTMLFormElement>) {
+        e.preventDefault();
 
-      const form = e.currentTarget;
-      const data = Object.fromEntries(new FormData(form)) as {
-        name: string;
-        location: string;
+        const form = e.currentTarget;
+        const data = Object.fromEntries(new FormData(form)) as {
+          name: string;
+          location: string;
+        };
+
+        table.append(data);
+        form.reset();
+      }
+
+      const filter = Cell("", "filter");
+
+      const query = () => {
+        return people.filter(filter.current).sort("name", locale.current);
       };
 
-      table.append(data);
-      form.reset();
-    }
-
-    const filter = Cell("", "filter");
-
-    const query = () => {
-      return people.filter(filter.current).sort("name", locale.current);
-    };
-
-    function rows() {
-      return query().rows;
-    }
-
-    function total() {
-      const filteredCount = rows().length;
-      const totalCount = table.rows.length;
-
-      if (filteredCount === totalCount) {
-        return `items: ${totalCount}`;
-      } else {
-        return `items: ${filteredCount} filtered / ${totalCount} total`;
+      function rows() {
+        return query().rows;
       }
+
+      function total() {
+        const filteredCount = rows().length;
+        const totalCount = table.rows.length;
+
+        if (filteredCount === totalCount) {
+          return `items: ${totalCount}`;
+        } else {
+          return `items: ${filteredCount} filtered / ${totalCount} total`;
+        }
+      }
+
+      return () => ({
+        append,
+        filter,
+        total,
+        rows,
+        people,
+        table,
+      });
     }
+  );
 
-    return () => {
-      return (
-        <>
-          <details>
-            <summary>Create a new user</summary>
-            <form onSubmit={append}>
-              <label>
-                <span>Name*</span>
-                <input type="text" name="name" required />
-                <span data-field="name" />
-              </label>
-              <label>
-                <span>Location*</span>
-                <input type="text" name="location" required />
-                <span data-field="location" />
-              </label>
-              <label>
-                <button type="submit">append</button>
-              </label>
-            </form>
-          </details>
+  return (
+    <>
+      <details>
+        <summary>Create a new user</summary>
+        <form onSubmit={append}>
           <label>
-            <span>Filter</span>
-            <input
-              type="text"
-              defaultValue={filter.current}
-              onInput={(e) => filter.set(e.currentTarget.value)}
-            />
+            <span>Name*</span>
+            <input type="text" name="name" required />
+            <span data-field="name" />
           </label>
-          <table>
-            <thead>
-              <tr>
-                {table.columns.map((p) => (
-                  <th key={p}>{p}</th>
-                ))}
-                <th className="action">
-                  <button onClick={() => table.clear()}>✂️</button>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows().map((person) => (
-                <tr key={person.id}>
-                  <td>{person.name}</td>
-                  <td>{person.location}</td>
-                  <td className="actions">
-                    <button onClick={() => table.delete(person.id)}>✂️</button>
-                  </td>
-                </tr>
-              ))}
+          <label>
+            <span>Location*</span>
+            <input type="text" name="location" required />
+            <span data-field="location" />
+          </label>
+          <label>
+            <button type="submit">append</button>
+          </label>
+        </form>
+      </details>
+      <label>
+        <span>Filter</span>
+        <input
+          type="text"
+          defaultValue={useReactive(() => filter.current)}
+          onInput={(e) => filter.set(e.currentTarget.value)}
+        />
+      </label>
+      <table>
+        <thead>
+          <tr>
+            {useReactive(() => table.columns).map((p) => (
+              <th key={p}>{p}</th>
+            ))}
+            <th className="action">
+              <button onClick={() => table.clear()}>✂️</button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {useReactive(rows).map((person) => (
+            <tr key={person.id}>
+              <td>{person.name}</td>
+              <td>{person.location}</td>
+              <td className="actions">
+                <button onClick={() => table.delete(person.id)}>✂️</button>
+              </td>
+            </tr>
+          ))}
 
-              <tr className="summary" data-items={people.rows.length}>
-                <td colSpan={3}>{total()}</td>
-              </tr>
-            </tbody>
-          </table>
-        </>
-      );
-    };
-  }, "DataTable");
+          <tr className="summary" data-items={people.rows.length}>
+            <td colSpan={3}>{useReactive(total)}</td>
+          </tr>
+        </tbody>
+      </table>
+    </>
+  );
 }

--- a/framework/react/react/index.ts
+++ b/framework/react/react/index.ts
@@ -1,6 +1,6 @@
 export * from "./src/element.js";
 export * from "./src/ref.js";
-export { useReactive, useReactiveMemo } from "./src/use-reactive.js";
+export { useReactive } from "./src/use-reactive.js";
 export { useResource } from "./src/use-resource.js";
 export { useSetup } from "./src/use-setup.js";
 export { component, useStarbeam } from "./src/use-starbeam.js";

--- a/framework/react/react/src/element.ts
+++ b/framework/react/react/src/element.ts
@@ -1,6 +1,7 @@
 import type { browser } from "@domtree/flavors";
 import type { Cell, Linkable, Reactive, Resource } from "@starbeam/core";
 import type {
+  CleanupTarget,
   DebugListener,
   OnCleanup,
   Renderable,
@@ -137,7 +138,9 @@ export interface DebugLifecycle {
  * {@link useReactiveElement} API (when a {@link useReactElement} definition is
  * instantiated, it is passed a {@link ReactiveElement}).
  */
-export class ReactiveElement {
+export class ReactiveElement implements CleanupTarget {
+  static stack: ReactiveElement[] = [];
+
   static create(notify: () => void): ReactiveElement {
     return new ReactiveElement(
       notify,
@@ -193,6 +196,10 @@ export class ReactiveElement {
   }
 
   readonly on: OnLifecycle;
+
+  link(child: object): Unsubscribe {
+    return LIFETIME.link(this, child);
+  }
 
   attach(lifecycle: DebugLifecycle): void {
     this.#debugLifecycle = lifecycle;

--- a/framework/react/react/src/use-reactive.ts
+++ b/framework/react/react/src/use-reactive.ts
@@ -14,58 +14,16 @@ import { useState } from "react";
  * If you also want to memoize the value, you can use {@linkcode useReactiveMemo}.
  */
 export function useReactive<T>(compute: () => T, description?: string): T {
-  const desc = Stack.description(description);
+  const desc = Stack.description({
+    type: "formula",
+    api: "useReactive",
+    fromUser: description,
+  });
 
   const [, setNotify] = useState({});
 
   const formula = useLifecycle(compute, (lifecycle) => {
     const formula = PolledFormula(() => {
-      return compute();
-    }, desc);
-
-    lifecycle.on.update((compute) => {
-      formula.update(compute);
-    });
-
-    lifecycle.on.layout(() => {
-      const renderer = TIMELINE.on.change(
-        formula,
-        () => {
-          setNotify({});
-        },
-        desc
-      );
-
-      lifecycle.on.cleanup(() => {
-        LIFETIME.finalize(renderer);
-      });
-    });
-
-    return formula;
-  });
-
-  return formula.current;
-}
-
-/**
- * {@linkcode useReactive} is a Starbeam renderer that computes a value from reactive values and
- * automatically notifies React when the inputs change.
- *
- * It doesn't memoize the value, so if the component re-renders, the value will be recomputed. This
- * means that you can use normal React values in the formula without declaring any dependencies, but
- * still get notified if Starbeam dependencies change.
- */
-export function useReactiveMemo<T>(
-  compute: () => T,
-  dependencies: unknown[],
-  description?: string
-): T {
-  const desc = Stack.description(description);
-
-  const [, setNotify] = useState({});
-
-  const formula = useLifecycle(compute, (lifecycle) => {
-    const formula = PolledFormula.memo(() => {
       return compute();
     }, desc);
 

--- a/framework/react/react/src/use-setup.ts
+++ b/framework/react/react/src/use-setup.ts
@@ -1,12 +1,7 @@
 import { Formula, Reactive } from "@starbeam/core";
 import { isObject } from "@starbeam/core-utils";
-import {
-  type DescriptionArgs,
-  Stack,
-  Description,
-  Block,
-  Message,
-} from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
+import { Message, Stack } from "@starbeam/debug";
 import { isDebug, LIFETIME, TIMELINE } from "@starbeam/timeline";
 import { isRendering, useLifecycle } from "@starbeam/use-strict-lifecycle";
 import { unsafeTrackedElsewhere } from "@starbeam/use-strict-lifecycle/src/react.js";

--- a/framework/react/react/src/use-starbeam.ts
+++ b/framework/react/react/src/use-starbeam.ts
@@ -1,5 +1,5 @@
 import { Formula, PolledFormula } from "@starbeam/core";
-import type { DescriptionArgs } from "@starbeam/debug";
+import type { Description, DescriptionArgs } from "@starbeam/debug";
 import { Stack } from "@starbeam/debug";
 import type { Renderable } from "@starbeam/timeline";
 import { LIFETIME, TIMELINE } from "@starbeam/timeline";
@@ -104,9 +104,13 @@ type AnyRecord<T = any> = Record<PropertyKey, T>;
  */
 export function useStarbeam<_T>(
   definition: ReactiveDefinition<ReactElement, void>,
-  description?: string | DescriptionArgs
+  description?: string | Description
 ): ReactElement {
-  const desc = Stack.description(description);
+  const desc = Stack.description({
+    type: "resource",
+    api: "useStarbeam",
+    fromUser: description,
+  });
   const [, setNotify] = useState({});
   const last = useRef(null as ReactiveElement | null);
 
@@ -119,9 +123,6 @@ export function useStarbeam<_T>(
     last.current = element;
 
     setup.link(element);
-
-    setup.layout(() => ReactiveElement.layout(element));
-    setup.effect(() => ReactiveElement.idle(element));
 
     return PolledFormula(definition(element));
   });
@@ -228,10 +229,14 @@ export function useStarbeam<_T>(
 
 export function component<Props>(
   component: (component: ReactiveElement) => (props: Props) => ReactElement,
-  description?: string | DescriptionArgs
+  description?: string | Description
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): (props: Props, context?: any) => ReactElement {
-  const desc = Stack.description(description);
+  const desc = Stack.description({
+    type: "resource",
+    api: "starbeam.component",
+    fromUser: description,
+  });
 
   function Component(props: Props) {
     return useStarbeam((element) => {
@@ -241,11 +246,7 @@ export function component<Props>(
   }
 
   Object.defineProperty(Component, "name", {
-    value:
-      desc.name ??
-      desc.description?.name ??
-      desc.stack?.caller?.display ??
-      "Component",
+    value: desc.describe(),
   });
 
   return Component;

--- a/framework/react/react/src/use-starbeam.ts
+++ b/framework/react/react/src/use-starbeam.ts
@@ -1,5 +1,5 @@
 import { Formula, PolledFormula } from "@starbeam/core";
-import type { Description, DescriptionArgs } from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
 import { Stack } from "@starbeam/debug";
 import type { Renderable } from "@starbeam/timeline";
 import { LIFETIME, TIMELINE } from "@starbeam/timeline";

--- a/framework/react/react/src/utils.ts
+++ b/framework/react/react/src/utils.ts
@@ -1,5 +1,6 @@
 import { type Reactive, Cell, Marker } from "@starbeam/core";
-import { Description, Stack } from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
+import { Stack } from "@starbeam/debug";
 import { reactive } from "@starbeam/js";
 import { useUpdatingVariable } from "@starbeam/use-strict-lifecycle";
 import type { Dispatch, SetStateAction } from "react";

--- a/framework/react/react/tests/use-reactive.spec.ts
+++ b/framework/react/react/tests/use-reactive.spec.ts
@@ -26,12 +26,15 @@ describe("useReactive", () => {
               cell.set(cell.current + 1);
             }
 
-            return () => ({ cell, increment });
-          });
-
-          test.value(cell.current);
+            return () => {
+              debugger;
+              return { cell, increment };
+            };
+          }, "first useSetup");
 
           return useReactive(() => {
+            test.value(cell.current);
+
             return react.fragment(
               html.p(String(cell.current)),
               html.button({ onClick: increment }, "++")
@@ -142,10 +145,10 @@ describe("useReactive", () => {
             });
           });
 
-          test.value({ starbeam: count.current, react: reactCount });
+          return useReactive(() => {
+            test.value({ starbeam: count.current, react: reactCount });
 
-          return useReactive(() =>
-            react.fragment(
+            return react.fragment(
               html.p(
                 count.current,
                 " + ",
@@ -161,8 +164,8 @@ describe("useReactive", () => {
                   "++React++"
                 )
               )
-            )
-          );
+            );
+          });
         });
 
       expect(result.value).toEqual({ starbeam: 0, react: 0 });

--- a/framework/react/react/tests/use-reactive.spec.ts
+++ b/framework/react/react/tests/use-reactive.spec.ts
@@ -26,10 +26,7 @@ describe("useReactive", () => {
               cell.set(cell.current + 1);
             }
 
-            return () => {
-              debugger;
-              return { cell, increment };
-            };
+            return () => ({ cell, increment });
           }, "first useSetup");
 
           return useReactive(() => {

--- a/framework/react/react/tests/use-setup.spec.ts
+++ b/framework/react/react/tests/use-setup.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { Cell, TIMELINE } from "@starbeam/core";
-import { useSetup } from "@starbeam/react";
+import { useSetup, useReactive } from "@starbeam/react";
 import {
   entryPoint,
   html,
@@ -43,9 +43,9 @@ describe("useSetup", () => {
         )
         .render((test) => {
           const state = useSetup((setup) => {
-            const state = Cell({ state: "rendering" } as State);
+            const state = Cell({ state: "rendering" } as State, "outer cell");
 
-            setup.effect(() => {
+            setup.on.idle(() => {
               const channel = Channel.subscribe("test");
               state.set({ state: "connected" });
 
@@ -61,12 +61,14 @@ describe("useSetup", () => {
             return state;
           });
 
-          test.value(state);
+          return useReactive(() => {
+            test.value(state);
 
-          return react.fragment(
-            html.span(state.state),
-            state.state === "message" ? html.span(state.lastMessage) : null
-          );
+            return react.fragment(
+              html.span(state.state),
+              state.state === "message" ? html.span(state.lastMessage) : null
+            );
+          });
         });
 
       function send(message: string) {

--- a/framework/react/react/tests/use-setup.spec.ts
+++ b/framework/react/react/tests/use-setup.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { Cell, TIMELINE } from "@starbeam/core";
-import { useSetup, useReactive } from "@starbeam/react";
+import { useReactive, useSetup } from "@starbeam/react";
 import {
   entryPoint,
   html,

--- a/framework/react/react/tests/use-starbeam.spec.ts
+++ b/framework/react/react/tests/use-starbeam.spec.ts
@@ -116,9 +116,9 @@ describe("useStarbeam", () => {
             return () => ({ cell, increment });
           });
 
-          test.value(cell.current);
-
           return useReactive(() => {
+            test.value(cell.current);
+
             return react.fragment(
               html.p(String(cell.current)),
               html.button({ onClick: increment }, "++")
@@ -229,10 +229,10 @@ describe("useStarbeam", () => {
             });
           });
 
-          test.value({ starbeam: count.current, react: reactCount });
+          return useReactive(() => {
+            test.value({ starbeam: count.current, react: reactCount });
 
-          return useReactive(() =>
-            react.fragment(
+            return react.fragment(
               html.p(
                 count.current,
                 " + ",
@@ -248,8 +248,8 @@ describe("useStarbeam", () => {
                   "++React++"
                 )
               )
-            )
-          );
+            );
+          });
         });
 
       expect(result.value).toEqual({ starbeam: 0, react: 0 });

--- a/framework/react/use-strict-lifecycle/index.ts
+++ b/framework/react/use-strict-lifecycle/index.ts
@@ -1,4 +1,4 @@
-export { isRendering } from "./src/react.js";
+export { isRestrictedRead as isRendering } from "./src/react.js";
 export {
   beginReadonly as maskRendering,
   endReadonly as unmaskRendering,

--- a/framework/react/use-strict-lifecycle/src/react.ts
+++ b/framework/react/use-strict-lifecycle/src/react.ts
@@ -17,7 +17,34 @@ export function endReadonly() {
   IS_RESTRICTED = false;
 }
 
-export function isRendering() {
+/**
+ * If the current active render reads from a reactive value, and the reactive value is already set
+ * up to notify React in the context of another frame (that will **reliably** update as the same
+ * rate as the this read), then we can avoid the "untracked read" error by wrapping the consumption
+ * in {@linkcode unsafeTrackedElsewhere} and {@linkcode endUnsafeTrackedElsewhere}.
+ */
+let IS_UNRESTRICTED = false;
+
+export function unsafeTrackedElsewhere<T>(callback: () => T): T {
+  const current = IS_UNRESTRICTED;
+  IS_UNRESTRICTED = true;
+
+  try {
+    return callback();
+  } finally {
+    IS_UNRESTRICTED = current;
+  }
+}
+
+export function endUnsafeTrackedElsewhere() {
+  IS_RESTRICTED = true;
+}
+
+export function isRestrictedRead() {
+  if (IS_UNRESTRICTED) {
+    return false;
+  }
+
   return (
     // @ts-expect-error intentionally using React internals
     !!React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner

--- a/framework/react/use-strict-lifecycle/src/resource.ts
+++ b/framework/react/use-strict-lifecycle/src/resource.ts
@@ -220,9 +220,17 @@ class ResourceBuilder<A> {
   ): ResourceInstance<T, A> {
     const builder = new ResourceBuilder(build);
     beginReadonly();
-    const instance = new ResourceInstance(builder, build(builder, args, prev));
-    endReadonly();
-    return instance;
+    try {
+      const instance = new ResourceInstance(
+        builder,
+        build(builder, args, prev)
+      );
+      endReadonly();
+      return instance;
+    } catch (e) {
+      endReadonly();
+      throw e;
+    }
   }
 
   static remount<T, A>(

--- a/packages/core/src/debug-renderer.ts
+++ b/packages/core/src/debug-renderer.ts
@@ -1,4 +1,4 @@
-import { type DescriptionArgs, Stack } from "@starbeam/debug";
+import { type DescriptionArgs, Stack, Description } from "@starbeam/debug";
 import type { Renderable } from "@starbeam/timeline";
 import { TIMELINE } from "@starbeam/timeline";
 
@@ -13,9 +13,16 @@ export const DEBUG_RENDERER = {
       render: () => T;
       debug: (value: T) => void;
     },
-    description?: DescriptionArgs | string
+    description?: Description | string
   ): Renderable<T> {
-    const formula = Formula(render, Stack.description(description));
+    const formula = Formula(
+      render,
+      Stack.description({
+        type: "renderer",
+        api: "DEBUG_RENDERER",
+        fromUser: description,
+      })
+    );
     return TIMELINE.render(formula, () => {
       debug(formula.current);
     });

--- a/packages/core/src/debug-renderer.ts
+++ b/packages/core/src/debug-renderer.ts
@@ -1,4 +1,5 @@
-import { type DescriptionArgs, Stack, Description } from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
+import { Stack } from "@starbeam/debug";
 import type { Renderable } from "@starbeam/timeline";
 import { TIMELINE } from "@starbeam/timeline";
 

--- a/packages/core/src/reactive-core/cell.ts
+++ b/packages/core/src/reactive-core/cell.ts
@@ -1,10 +1,6 @@
 import { isObject } from "@starbeam/core-utils";
-import {
-  type DescriptionArgs,
-  DisplayStruct,
-  Stack,
-  Description,
-} from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
+import { DisplayStruct, Stack } from "@starbeam/debug";
 import { type ReactiveInternals, INSPECT, REACTIVE } from "@starbeam/timeline";
 
 import type { Reactive } from "../reactive.js";
@@ -61,13 +57,13 @@ export class ReactiveCell<T> implements Reactive<T> {
     return this.read(Stack.fromCaller());
   }
 
+  set current(value: T) {
+    this.#set(value);
+  }
+
   read(caller: Stack): T {
     this.#internals.consume(caller);
     return this.#value;
-  }
-
-  set current(value: T) {
-    this.#set(value);
   }
 
   /**

--- a/packages/core/src/reactive-core/fn.ts
+++ b/packages/core/src/reactive-core/fn.ts
@@ -1,3 +1,4 @@
+import { Stack } from "@starbeam/debug";
 import { type Reactive, REACTIVE } from "@starbeam/timeline";
 
 export interface ReactiveFn<T> extends Reactive<T> {
@@ -6,7 +7,7 @@ export interface ReactiveFn<T> extends Reactive<T> {
 
 export function ReactiveFn<T>(reactive: Reactive<T>): ReactiveFn<T> {
   function Reactive() {
-    return reactive.current;
+    return reactive.read(Stack.fromCaller());
   }
 
   Object.defineProperty(Reactive, REACTIVE, {
@@ -16,7 +17,15 @@ export function ReactiveFn<T>(reactive: Reactive<T>): ReactiveFn<T> {
 
   Object.defineProperty(Reactive, "current", {
     configurable: true,
-    get: () => reactive.current,
+    get: () => reactive.read(Stack.fromCaller()),
+  });
+
+  Object.defineProperty(Reactive, "read", {
+    configurable: true,
+    enumerable: false,
+    value: function (caller: Stack) {
+      return reactive.read(caller);
+    },
   });
 
   return Reactive as ReactiveFn<T>;

--- a/packages/core/src/reactive-core/formula/formula.ts
+++ b/packages/core/src/reactive-core/formula/formula.ts
@@ -1,4 +1,5 @@
-import { type DescriptionArgs, Stack, Description } from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
+import { Stack } from "@starbeam/debug";
 import { UNINITIALIZED } from "@starbeam/peer";
 import type { FinalizedFrame, ReactiveInternals } from "@starbeam/timeline";
 import { REACTIVE, TIMELINE } from "@starbeam/timeline";

--- a/packages/core/src/reactive-core/formula/polled-formula.ts
+++ b/packages/core/src/reactive-core/formula/polled-formula.ts
@@ -1,4 +1,4 @@
-import type { Description, DescriptionArgs } from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
 import { Stack } from "@starbeam/debug";
 import { UNINITIALIZED } from "@starbeam/peer";
 import type { FinalizedFrame, ReactiveInternals } from "@starbeam/timeline";

--- a/packages/core/src/reactive-core/formula/polled-formula.ts
+++ b/packages/core/src/reactive-core/formula/polled-formula.ts
@@ -1,4 +1,4 @@
-import type { DescriptionArgs } from "@starbeam/debug";
+import type { Description, DescriptionArgs } from "@starbeam/debug";
 import { Stack } from "@starbeam/debug";
 import { UNINITIALIZED } from "@starbeam/peer";
 import type { FinalizedFrame, ReactiveInternals } from "@starbeam/timeline";
@@ -28,7 +28,7 @@ interface LastEvaluation<T> {
 export class ReactivePolledFormula<T> implements Reactive<T> {
   static create<T>(
     formula: () => T,
-    description: DescriptionArgs
+    description: Description
   ): ReactivePolledFormula<T> {
     return new ReactivePolledFormula(
       UNINITIALIZED,
@@ -40,7 +40,7 @@ export class ReactivePolledFormula<T> implements Reactive<T> {
 
   static memo<T>(
     formula: () => T,
-    description: DescriptionArgs
+    description: Description
   ): ReactivePolledFormula<T> {
     return new ReactivePolledFormula(UNINITIALIZED, true, formula, description);
   }
@@ -49,13 +49,13 @@ export class ReactivePolledFormula<T> implements Reactive<T> {
   #shouldMemo: boolean;
   #last: LastEvaluation<T> | UNINITIALIZED;
   #formula: () => T;
-  readonly #description: DescriptionArgs;
+  readonly #description: Description;
 
   private constructor(
     last: LastEvaluation<T> | UNINITIALIZED,
     shouldMemo: boolean,
     formula: () => T,
-    description: DescriptionArgs
+    description: Description
   ) {
     this.#last = last;
     this.#shouldMemo = shouldMemo;
@@ -73,7 +73,11 @@ export class ReactivePolledFormula<T> implements Reactive<T> {
   }
 
   get current(): T {
-    return this.#evaluate();
+    return this.#evaluate(Stack.fromCaller());
+  }
+
+  read(caller: Stack): T {
+    return this.#evaluate(caller);
   }
 
   update(formula: () => T): void {
@@ -84,20 +88,21 @@ export class ReactivePolledFormula<T> implements Reactive<T> {
     TIMELINE.update(this);
   }
 
-  #evaluate(): T {
+  #evaluate(caller: Stack): T {
     if (this.#shouldMemo && this.#last !== UNINITIALIZED) {
       const validation = this.#last.frame.validate();
       if (validation.status === "valid") {
-        TIMELINE.didConsume(this.#last.frame);
+        TIMELINE.didConsume(this.#last.frame, caller);
         return validation.value;
       }
     }
 
     const { value, frame } = TIMELINE.evaluateFormula(
       this.#formula,
-      this.#description
+      this.#description,
+      caller
     );
-    TIMELINE.didConsume(frame);
+    TIMELINE.didConsume(frame, caller);
     this.#last = { value, frame };
 
     // Update any renderables that depend on this formula.
@@ -129,16 +134,19 @@ export class ReactivePolledFormula<T> implements Reactive<T> {
  */
 export function PolledFormula<T>(
   formula: () => T,
-  description?: string | DescriptionArgs
+  description?: string | Description
 ): Reactive<T> & { update(formula: () => T): void } {
-  return ReactivePolledFormula.create(formula, Stack.description(description));
+  return ReactivePolledFormula.create(
+    formula,
+    Stack.description({
+      type: "formula",
+      api: {
+        package: "@starbeam/core",
+        name: "PolledFormula",
+      },
+      fromUser: description,
+    })
+  );
 }
-
-PolledFormula.memo = <T>(
-  formula: () => T,
-  description?: string | DescriptionArgs
-): Reactive<T> & { update(formula: () => T): void } => {
-  return ReactivePolledFormula.memo(formula, Stack.description(description));
-};
 
 export type Formula<T> = ReactiveFn<T>;

--- a/packages/core/src/reactive-core/formula/resource.ts
+++ b/packages/core/src/reactive-core/formula/resource.ts
@@ -13,7 +13,7 @@
  * worrying about its lifetime.
  */
 
-import type { Description, DescriptionArgs } from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
 import { Stack } from "@starbeam/debug";
 import { UNINITIALIZED } from "@starbeam/peer";
 import {

--- a/packages/core/src/reactive-core/formula/resource.ts
+++ b/packages/core/src/reactive-core/formula/resource.ts
@@ -13,7 +13,7 @@
  * worrying about its lifetime.
  */
 
-import type { DescriptionArgs } from "@starbeam/debug";
+import type { Description, DescriptionArgs } from "@starbeam/debug";
 import { Stack } from "@starbeam/debug";
 import { UNINITIALIZED } from "@starbeam/peer";
 import {
@@ -44,7 +44,7 @@ interface ResourceState<T> {
 export class ReactiveResource<T> implements Reactive<T> {
   static create<T>(
     create: ResourceBlueprint<T>,
-    description: DescriptionArgs
+    description: Description
   ): ReactiveResource<T> {
     return new ReactiveResource(
       create,
@@ -60,13 +60,13 @@ export class ReactiveResource<T> implements Reactive<T> {
    */
   #initialized: Marker;
   #state: ResourceState<T> | UNINITIALIZED;
-  #description: DescriptionArgs;
+  #description: Description;
 
   private constructor(
     create: ResourceBlueprint<T>,
     initialized: Marker,
     state: ResourceState<T> | UNINITIALIZED,
-    description: DescriptionArgs
+    description: Description
   ) {
     this.#create = create;
     this.#initialized = initialized;
@@ -85,26 +85,30 @@ export class ReactiveResource<T> implements Reactive<T> {
     }
   }
 
-  get current(): T {
+  get current() {
+    return this.read(Stack.fromCaller());
+  }
+
+  read(caller: Stack): T {
     if (this.#state === UNINITIALIZED) {
       this.#initialized.update();
-      const formula = this.#initialize();
-      return formula.current;
+      const formula = this.#initialize({ caller });
+      return formula.read(caller);
     } else {
       const { creation, formula, lifetime } = this.#state;
 
-      const result = creation.validate();
+      const result = creation.validate(caller);
 
       if (result.state === "valid") {
-        return formula.current;
+        return formula.read(caller);
       } else {
-        const formula = this.#initialize({ last: lifetime });
-        return formula.current;
+        const formula = this.#initialize({ last: lifetime, caller });
+        return formula.read(caller);
       }
     }
   }
 
-  #initialize(options?: { last: object | undefined }) {
+  #initialize(options: { last?: object; caller: Stack }) {
     if (options?.last) {
       LIFETIME.finalize(options.last);
     }
@@ -113,14 +117,14 @@ export class ReactiveResource<T> implements Reactive<T> {
 
     const { state, value: definition } = FormulaState.evaluate(
       () => this.#create(build),
-      this.#description
+      this.#description,
+      options.caller
     );
 
-    const formula = Formula(definition, {
-      ...this.#description,
-      transform: (description) =>
-        description.implementation({ reason: "constructor formula" }),
-    });
+    const formula = Formula(
+      definition,
+      this.#description.implementation({ reason: "constructor formula" })
+    );
 
     const lifetime = BuildResource.lifetime(build);
 
@@ -168,12 +172,19 @@ class BuildResource implements CleanupTarget {
 
 export function Resource<T>(
   create: ResourceBlueprint<T>,
-  description?: string | DescriptionArgs
+  description?: string | Description
 ): ResourceConstructor<T> {
   return Linkable.create((owner) => {
     const resource = ReactiveResource.create(
       create,
-      Stack.description(description)
+      Stack.description({
+        type: "resource",
+        api: {
+          package: "@starbeam/core",
+          name: "Resource",
+        },
+        fromUser: description,
+      })
     );
 
     LIFETIME.link(owner, resource);

--- a/packages/core/src/reactive-core/formula/state.ts
+++ b/packages/core/src/reactive-core/formula/state.ts
@@ -1,4 +1,4 @@
-import type { Description, DescriptionArgs, Stack } from "@starbeam/debug";
+import type { Description, Stack } from "@starbeam/debug";
 import {
   type FinalizedFrame,
   type MutableInternals,

--- a/packages/core/src/reactive-core/higher-level/formula-list.ts
+++ b/packages/core/src/reactive-core/higher-level/formula-list.ts
@@ -1,4 +1,5 @@
-import { type DescriptionArgs, Stack, Description } from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
+import { Stack } from "@starbeam/debug";
 import { type ReactiveInternals, REACTIVE } from "@starbeam/timeline";
 
 import { Reactive } from "../../reactive.js";
@@ -26,6 +27,7 @@ class ReactiveFormulaList<T, U> implements Reactive<U[]> {
         package: "@starbeam/core",
         name: "ReactiveFormulaList",
       },
+      fromUser: desc,
     });
 
     const list = Formula(

--- a/packages/core/src/reactive-core/higher-level/mapped-formula.ts
+++ b/packages/core/src/reactive-core/higher-level/mapped-formula.ts
@@ -1,4 +1,4 @@
-import { type DescriptionArgs, Stack } from "@starbeam/debug";
+import { type DescriptionArgs, Stack, Description } from "@starbeam/debug";
 import { UNINITIALIZED } from "@starbeam/peer";
 import { isNotEqual, verified } from "@starbeam/verify";
 
@@ -34,12 +34,18 @@ function normalizeOptions<T, U>(
 
 export function FormulaFn<T, U>(
   options: FormulaFnOptions<T, U>,
-  description?: DescriptionArgs | string
+  description?: Description | string
 ): (value: T) => U {
   const { equals, fn } = normalizeOptions(options);
 
   const cell = Cell<T | UNINITIALIZED>(UNINITIALIZED, {
-    ...Stack.description(description),
+    description: Stack.description({
+      type: "formula",
+      api: {
+        package: "@starbeam/core",
+        name: "FormulaFn",
+      },
+    }),
     equals: (a: T | UNINITIALIZED, b: T | UNINITIALIZED) => {
       if (a === UNINITIALIZED || b === UNINITIALIZED) {
         return false;
@@ -51,13 +57,10 @@ export function FormulaFn<T, U>(
 
   const desc = Reactive.description(cell);
 
-  const formula = Formula(
-    () => {
-      const value = verified(cell.current, isNotEqual(UNINITIALIZED));
-      return fn(value);
-    },
-    { description: desc.implementation({ reason: "FormulaFn formula" }) }
-  );
+  const formula = Formula(() => {
+    const value = verified(cell.current, isNotEqual(UNINITIALIZED));
+    return fn(value);
+  }, desc.implementation({ reason: "FormulaFn formula" }));
 
   return (value: T) => {
     cell.set(value);

--- a/packages/core/src/reactive-core/higher-level/mapped-formula.ts
+++ b/packages/core/src/reactive-core/higher-level/mapped-formula.ts
@@ -1,4 +1,5 @@
-import { type DescriptionArgs, Stack, Description } from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
+import { Stack } from "@starbeam/debug";
 import { UNINITIALIZED } from "@starbeam/peer";
 import { isNotEqual, verified } from "@starbeam/verify";
 
@@ -45,6 +46,7 @@ export function FormulaFn<T, U>(
         package: "@starbeam/core",
         name: "FormulaFn",
       },
+      fromUser: description,
     }),
     equals: (a: T | UNINITIALIZED, b: T | UNINITIALIZED) => {
       if (a === UNINITIALIZED || b === UNINITIALIZED) {

--- a/packages/core/src/reactive-core/higher-level/mapped-resource.ts
+++ b/packages/core/src/reactive-core/higher-level/mapped-resource.ts
@@ -1,4 +1,4 @@
-import { type DescriptionArgs, Stack } from "@starbeam/debug";
+import { type DescriptionArgs, Stack, Description } from "@starbeam/debug";
 import { UNINITIALIZED } from "@starbeam/peer";
 import { LIFETIME } from "@starbeam/timeline";
 import { isNotEqual, verified } from "@starbeam/verify";
@@ -15,14 +15,18 @@ interface MappedResourceOptions<T, U> {
 
 export function ResourceFn<T, U>(
   options: MappedResourceOptions<T, U>,
-  description?: string | DescriptionArgs
+  description?: string | Description
 ): Linkable<(value: T) => U> {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return Linkable.create((owner) => {
     const equals = options.equals ?? Object.is;
 
     const cell = Cell<T | UNINITIALIZED>(UNINITIALIZED, {
-      ...Stack.description(description),
+      description: Stack.description({
+        type: "resource",
+        api: { package: "@starbeam/core", name: "ResourceFn" },
+        fromUser: description,
+      }),
       equals: (a: T | UNINITIALIZED, b: T | UNINITIALIZED) => {
         if (a === UNINITIALIZED || b === UNINITIALIZED) {
           return false;

--- a/packages/core/src/reactive-core/higher-level/mapped-resource.ts
+++ b/packages/core/src/reactive-core/higher-level/mapped-resource.ts
@@ -1,4 +1,5 @@
-import { type DescriptionArgs, Stack, Description } from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
+import { Stack } from "@starbeam/debug";
 import { UNINITIALIZED } from "@starbeam/peer";
 import { LIFETIME } from "@starbeam/timeline";
 import { isNotEqual, verified } from "@starbeam/verify";

--- a/packages/core/src/reactive-core/higher-level/resource-list.ts
+++ b/packages/core/src/reactive-core/higher-level/resource-list.ts
@@ -1,4 +1,5 @@
-import { type DescriptionArgs, Stack, Description } from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
+import { type DescriptionArgs, Stack } from "@starbeam/debug";
 import { type ReactiveInternals, LIFETIME, REACTIVE } from "@starbeam/timeline";
 
 import type { Reactive } from "../../reactive.js";

--- a/packages/core/src/reactive-core/marker.ts
+++ b/packages/core/src/reactive-core/marker.ts
@@ -1,4 +1,9 @@
-import type { DescriptionArgs, DescriptionType } from "@starbeam/debug";
+import type {
+  Description,
+  DescriptionArgs,
+  DescriptionType,
+  Stack,
+} from "@starbeam/debug";
 import {
   type MutableInternals,
   type ReactiveProtocol,
@@ -22,8 +27,8 @@ export class ReactiveMarker implements ReactiveProtocol {
     this.#internals.freeze();
   }
 
-  consume(): void {
-    this.#internals.consume();
+  consume(caller: Stack): void {
+    this.#internals.consume(caller);
   }
 
   update(): void {
@@ -37,12 +42,8 @@ export class ReactiveMarker implements ReactiveProtocol {
   }
 }
 
-export function Marker(description: DescriptionArgs): ReactiveMarker {
+export function Marker(description: Description): ReactiveMarker {
   return ReactiveMarker.create(MutableInternalsImpl.create(description));
 }
-
-Marker.described = (type: DescriptionType, args: DescriptionArgs) => {
-  return ReactiveMarker.create(MutableInternalsImpl.described(type, args));
-};
 
 export type Marker = ReactiveMarker;

--- a/packages/core/src/reactive-core/marker.ts
+++ b/packages/core/src/reactive-core/marker.ts
@@ -1,9 +1,4 @@
-import type {
-  Description,
-  DescriptionArgs,
-  DescriptionType,
-  Stack,
-} from "@starbeam/debug";
+import type { Description, Stack } from "@starbeam/debug";
 import {
   type MutableInternals,
   type ReactiveProtocol,

--- a/packages/core/src/reactive-core/render.ts
+++ b/packages/core/src/reactive-core/render.ts
@@ -1,4 +1,4 @@
-import type { Description, DescriptionArgs } from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
 import { Stack } from "@starbeam/debug";
 import { UNINITIALIZED } from "@starbeam/peer";
 import type { FinalizedFrame, ReactiveInternals } from "@starbeam/timeline";

--- a/packages/core/src/reactive.ts
+++ b/packages/core/src/reactive.ts
@@ -1,5 +1,5 @@
 import { isObject } from "@starbeam/core-utils";
-import type { Description } from "@starbeam/debug";
+import type { Description, Stack } from "@starbeam/debug";
 import {
   type MutableInternals,
   type ReactiveInternals,
@@ -8,7 +8,16 @@ import {
 } from "@starbeam/timeline";
 
 export interface Reactive<T> extends ReactiveProtocol {
+  /**
+   * The `current` property is treated as a user-facing entry point, and its consumption is reported
+   * from the direct caller of `current`.
+   */
   readonly current: T;
+  /**
+   * The `read` method is an internal entry point, and callers to `read` are expected to propagate the
+   * user-facing call stack.
+   */
+  read(caller: Stack): T;
 }
 
 export const Reactive = {

--- a/packages/core/src/storage/composite.ts
+++ b/packages/core/src/storage/composite.ts
@@ -1,11 +1,11 @@
 import { isArray } from "@starbeam/core-utils";
-import type { Description, DescriptionArgs } from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
 import {
-  InternalChildren,
-  REACTIVE,
   type ReactiveInternals,
   type ReactiveProtocol,
   type Timestamp,
+  InternalChildren,
+  REACTIVE,
 } from "@starbeam/timeline";
 
 export class CompositeInternalsImpl implements ReactiveProtocol {

--- a/packages/core/src/storage/composite.ts
+++ b/packages/core/src/storage/composite.ts
@@ -1,21 +1,17 @@
 import { isArray } from "@starbeam/core-utils";
+import type { Description, DescriptionArgs } from "@starbeam/debug";
 import {
-  type DescriptionArgs,
-  FormulaDescription,
-  TimestampValidatorDescription,
-} from "@starbeam/debug";
-import {
+  InternalChildren,
+  REACTIVE,
   type ReactiveInternals,
   type ReactiveProtocol,
   type Timestamp,
-  InternalChildren,
-  REACTIVE,
 } from "@starbeam/timeline";
 
 export class CompositeInternalsImpl implements ReactiveProtocol {
   static create(
     children: InternalChildren,
-    description: DescriptionArgs
+    description: Description
   ): CompositeInternalsImpl {
     return new CompositeInternalsImpl(children, description);
   }
@@ -23,17 +19,11 @@ export class CompositeInternalsImpl implements ReactiveProtocol {
   readonly type = "composite";
 
   #children: InternalChildren;
-  readonly #description: FormulaDescription;
+  readonly #description: Description;
 
-  private constructor(
-    children: InternalChildren,
-    description: DescriptionArgs
-  ) {
+  private constructor(children: InternalChildren, description: Description) {
     this.#children = children;
-    this.#description = FormulaDescription.from({
-      ...description,
-      validator: TimestampValidatorDescription.from(this),
-    });
+    this.#description = description;
   }
 
   get debug() {
@@ -46,7 +36,7 @@ export class CompositeInternalsImpl implements ReactiveProtocol {
     return this;
   }
 
-  get description(): FormulaDescription {
+  get description(): Description {
     return this.#description;
   }
 
@@ -65,7 +55,7 @@ export class CompositeInternalsImpl implements ReactiveProtocol {
 
 export function CompositeInternals(
   children: InternalChildren | readonly ReactiveProtocol[],
-  description: DescriptionArgs
+  description: Description
 ): CompositeInternalsImpl {
   if (isArray(children)) {
     return CompositeInternalsImpl.create(

--- a/packages/core/src/storage/mutable.ts
+++ b/packages/core/src/storage/mutable.ts
@@ -1,17 +1,10 @@
-import {
-  type DescriptionArgs,
-  type DescriptionType,
-  CellDescription,
-  Description,
-  inspector,
-  TimestampValidatorDescription,
-} from "@starbeam/debug";
+import { Description, inspector, Stack } from "@starbeam/debug";
 import type { Timestamp } from "@starbeam/timeline";
 import {
-  type ReactiveProtocol,
   InternalChildren,
   REACTIVE,
   TIMELINE,
+  type ReactiveProtocol,
 } from "@starbeam/timeline";
 
 export class MutableInternalsImpl implements ReactiveProtocol {
@@ -29,20 +22,12 @@ export class MutableInternalsImpl implements ReactiveProtocol {
     );
   }
 
-  static create(description: DescriptionArgs): MutableInternalsImpl {
-    return new MutableInternalsImpl(
-      false,
-      TIMELINE.now,
-      CellDescription,
-      description
-    );
+  static create(description: Description): MutableInternalsImpl {
+    return new MutableInternalsImpl(false, TIMELINE.now, description);
   }
 
-  static described(
-    type: DescriptionType,
-    description: DescriptionArgs
-  ): MutableInternalsImpl {
-    return new MutableInternalsImpl(false, TIMELINE.now, type, description);
+  static described(description: Description): MutableInternalsImpl {
+    return new MutableInternalsImpl(false, TIMELINE.now, description);
   }
 
   readonly type = "mutable";
@@ -54,17 +39,11 @@ export class MutableInternalsImpl implements ReactiveProtocol {
   private constructor(
     frozen: boolean,
     lastUpdate: Timestamp,
-    type: DescriptionType,
-    description: DescriptionArgs
+    description: Description
   ) {
     this.#frozen = frozen;
     this.#lastUpdate = lastUpdate;
-
-    this.#description = Description.from(
-      type,
-      description,
-      TimestampValidatorDescription.from(this)
-    );
+    this.#description = description;
   }
 
   get [REACTIVE]() {
@@ -87,9 +66,9 @@ export class MutableInternalsImpl implements ReactiveProtocol {
     return this.#frozen;
   }
 
-  consume(): void {
+  consume(caller: Stack): void {
     if (!this.#frozen) {
-      TIMELINE.didConsume(this);
+      TIMELINE.didConsume(this, caller);
     }
   }
 

--- a/packages/core/src/storage/mutable.ts
+++ b/packages/core/src/storage/mutable.ts
@@ -1,10 +1,11 @@
-import { Description, inspector, Stack } from "@starbeam/debug";
+import type { Description, Stack } from "@starbeam/debug";
+import { inspector } from "@starbeam/debug";
 import type { Timestamp } from "@starbeam/timeline";
 import {
+  type ReactiveProtocol,
   InternalChildren,
   REACTIVE,
   TIMELINE,
-  type ReactiveProtocol,
 } from "@starbeam/timeline";
 
 export class MutableInternalsImpl implements ReactiveProtocol {

--- a/packages/core/src/storage/static.ts
+++ b/packages/core/src/storage/static.ts
@@ -1,7 +1,4 @@
-import {
-  type CreateStaticDescription,
-  StaticDescription,
-} from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
 import type * as timeline from "@starbeam/timeline";
 import {
   type ReactiveInternals,
@@ -11,16 +8,14 @@ import {
 } from "@starbeam/timeline";
 
 export class StaticInternals implements timeline.StaticInternals {
-  static create(
-    description: StaticDescription | CreateStaticDescription
-  ): StaticInternals {
-    return new StaticInternals(StaticDescription.from(description));
+  static create(description: Description): StaticInternals {
+    return new StaticInternals(description);
   }
 
   readonly type = "static";
-  readonly #description: StaticDescription;
+  readonly #description: Description;
 
-  private constructor(description: StaticDescription) {
+  private constructor(description: Description) {
     this.#description = description;
   }
 
@@ -34,7 +29,7 @@ export class StaticInternals implements timeline.StaticInternals {
     return InternalChildren.None();
   }
 
-  get description(): StaticDescription {
+  get description(): Description {
     return this.#description;
   }
 

--- a/packages/debug/index.ts
+++ b/packages/debug/index.ts
@@ -1,9 +1,9 @@
 export {
-  Description,
   type DescriptionArgs,
   type DescriptionDetails,
   type DescriptionType,
   type ValueType,
+  Description,
 } from "./src/description/reactive-value.js";
 export { TimestampValidatorDescription } from "./src/description/validator.js";
 export {
@@ -18,6 +18,14 @@ export {
   inspector,
 } from "./src/inspect/inspect-support.js";
 export { type Logger, LOGGER, LogLevel } from "./src/logger.js";
+export {
+  Block,
+  Fragment,
+  Message,
+  Style,
+  Styled,
+  Styles,
+} from "./src/message.js";
 export { describeModule } from "./src/module.js";
 export { Stack, StackFrame } from "./src/stack.js";
 export { Tree } from "./src/tree.js";
@@ -29,11 +37,3 @@ export {
   QualifiedName,
   Wrapper,
 } from "./src/wrapper.js";
-export {
-  Block,
-  Fragment,
-  Style,
-  Styled,
-  Styles,
-  Message,
-} from "./src/message.js";

--- a/packages/debug/index.ts
+++ b/packages/debug/index.ts
@@ -1,16 +1,9 @@
 export {
-  type CreateDescription,
-  type CreateStaticDescription,
-  type DescriptionType,
-  type ImplementationDetails,
-  type UserFacingDescription,
-  CellDescription,
   Description,
-  DescriptionArgs,
-  FormulaDescription,
-  ImplementationDescription,
-  MarkerDescription,
-  StaticDescription,
+  type DescriptionArgs,
+  type DescriptionDetails,
+  type DescriptionType,
+  type ValueType,
 } from "./src/description/reactive-value.js";
 export { TimestampValidatorDescription } from "./src/description/validator.js";
 export {
@@ -36,3 +29,11 @@ export {
   QualifiedName,
   Wrapper,
 } from "./src/wrapper.js";
+export {
+  Block,
+  Fragment,
+  Style,
+  Styled,
+  Styles,
+  Message,
+} from "./src/message.js";

--- a/packages/debug/src/message.ts
+++ b/packages/debug/src/message.ts
@@ -1,0 +1,168 @@
+export class Style {
+  static create(property: string, value: string): Style {
+    return new Style(property, value);
+  }
+
+  #property: string;
+  #value: string;
+
+  constructor(property: string, value: string) {
+    this.#property = property;
+    this.#value = value;
+  }
+
+  toCSS() {
+    return `${this.#property}: ${this.#value};`;
+  }
+}
+
+export class Styles {
+  #styles: Style[] = [];
+
+  add(property: string, value: string) {
+    this.#styles.push(Style.create(property, value));
+  }
+
+  toCSS() {
+    return this.#styles.map((style) => style.toCSS()).join(" ");
+  }
+}
+
+export class Fragment {
+  #content: string;
+  #styles: Styles = new Styles();
+
+  constructor(content: string) {
+    this.#content = content;
+  }
+
+  css(style: `${string}:${string}`) {
+    const [property, value] = style.split(":");
+    this.#styles.add(property.trim(), value.trim());
+    return this;
+  }
+
+  append(buffer: Buffer) {
+    buffer.add(this.#content, this.#styles.toCSS());
+  }
+}
+
+export function Styled(content: string) {
+  return new Fragment(content);
+}
+
+export type IntoFragment =
+  | string
+  | [content: string, ...styles: `${string}:${string}`[]];
+
+export type IntoBlock = IntoFragment[] | "";
+
+export class Block {
+  #fragments: Fragment[] = [];
+
+  add(fragment: Fragment | string) {
+    if (typeof fragment === "string") {
+      this.#fragments.push(new Fragment(fragment));
+    } else {
+      this.#fragments.push(fragment);
+    }
+  }
+
+  appendTo(buffer: Buffer) {
+    for (const fragment of this.#fragments) {
+      fragment.append(buffer);
+    }
+  }
+}
+
+export class Blocks {
+  #blocks: Block[] = [];
+
+  add(block: Block | string) {
+    if (typeof block === "string") {
+      const b = new Block();
+      b.add(block);
+      this.#blocks.push(new Block());
+    } else {
+      this.#blocks.push(block);
+    }
+  }
+
+  appendTo(buffer: Buffer) {
+    for (const block of this.#blocks) {
+      block.appendTo(buffer);
+      buffer.break();
+    }
+  }
+}
+
+export function Message(into: IntoBlock[], options?: { plain: boolean }) {
+  const blocks = new Blocks();
+
+  for (const intoBlock of into) {
+    const block = new Block();
+    for (const fragment of intoBlock) {
+      if (typeof fragment === "string") {
+        block.add(fragment);
+      } else {
+        const [content, ...styles] = fragment;
+
+        const f = Styled(content);
+
+        for (const style of styles) {
+          f.css(style);
+        }
+
+        block.add(f);
+      }
+    }
+    blocks.add(block);
+  }
+
+  const buffer = new Buffer(options?.plain ?? false);
+
+  blocks.appendTo(buffer);
+
+  return buffer.message();
+}
+
+class Buffer {
+  static styled() {
+    return new Buffer(false);
+  }
+
+  static plain() {
+    return new Buffer(true);
+  }
+
+  #message: string[] = [];
+  #current: string = "";
+  #styles: string[] = [];
+  #plain: boolean;
+
+  constructor(plain: boolean) {
+    this.#plain = plain;
+  }
+
+  add(content: string, style?: string) {
+    if (style && !this.#plain) {
+      this.#current += `%c${content}`;
+      this.#styles.push(style);
+    } else {
+      this.#current += content;
+    }
+  }
+
+  message(): unknown[] {
+    if (this.#current) {
+      this.break();
+    }
+
+    return [this.#message.join("\n"), ...this.#styles];
+  }
+
+  break() {
+    this.#message.push(this.#current);
+    this.#current = "";
+  }
+}

--- a/packages/debug/src/message.ts
+++ b/packages/debug/src/message.ts
@@ -136,7 +136,7 @@ class Buffer {
   }
 
   #message: string[] = [];
-  #current: string = "";
+  #current = "";
   #styles: string[] = [];
   #plain: boolean;
 

--- a/packages/debug/src/stack.ts
+++ b/packages/debug/src/stack.ts
@@ -2,9 +2,9 @@ import { hasType, isObject, verified } from "@starbeam/verify";
 import StackTracey from "stacktracey";
 
 import {
-  Description,
   type DescriptionArgs,
   type DescriptionDetails,
+  Description,
 } from "./description/reactive-value.js";
 import { describeModule } from "./module.js";
 

--- a/packages/js/index.ts
+++ b/packages/js/index.ts
@@ -1,5 +1,5 @@
 import { Cell } from "@starbeam/core";
-import type { DescriptionArgs } from "@starbeam/debug";
+import type { Description, DescriptionArgs } from "@starbeam/debug";
 import { Stack } from "@starbeam/debug";
 
 import TrackedArray from "./src/array.js";
@@ -46,38 +46,93 @@ export const reactive = (
   });
 };
 
-reactive.Map = <K, V>(description?: string | DescriptionArgs): Map<K, V> => {
-  return ReactiveMap.reactive(Object.is, Stack.description(description));
+reactive.Map = <K, V>(description?: string | Description): Map<K, V> => {
+  return ReactiveMap.reactive(
+    Object.is,
+    Stack.description({
+      type: "collection:key-value",
+      api: {
+        package: "@starbeam/js",
+        name: "reactive.Map",
+      },
+      fromUser: description,
+    })
+  );
 };
 
 reactive.WeakMap = <K extends object, V>(
-  description?: string | DescriptionArgs
+  description?: string | Description
 ): WeakMap<K, V> => {
-  return TrackedWeakMap.reactive<K, V>(Stack.description(description));
+  return TrackedWeakMap.reactive<K, V>(
+    Stack.description({
+      type: "collection:key-value",
+      api: {
+        package: "@starbeam/js",
+        name: "reactive.WeakMap",
+      },
+      fromUser: description,
+    })
+  );
 };
 
-reactive.Set = <T>(description?: string | DescriptionArgs): Set<T> => {
-  return ReactiveSet.reactive(Object.is, Stack.description(description));
+reactive.Set = <T>(description?: string | Description): Set<T> => {
+  return ReactiveSet.reactive(
+    Object.is,
+    Stack.description({
+      type: "collection:value",
+      api: {
+        package: "@starbeam/js",
+        name: "reactive.Set",
+      },
+      fromUser: description,
+    })
+  );
 };
 
 reactive.WeakSet = <T extends object>(
-  description?: string | DescriptionArgs
+  description?: string | Description
 ): WeakSet<T> => {
-  return TrackedWeakSet.reactive(Stack.description(description));
+  return TrackedWeakSet.reactive(
+    Stack.description({
+      type: "collection:value",
+      api: {
+        package: "@starbeam/js",
+        name: "reactive.WeakSet",
+      },
+      fromUser: description,
+    })
+  );
 };
 
 reactive.object = <T extends object>(
   values: T,
-  description?: string | DescriptionArgs
+  description?: string | Description
 ): T => {
-  return TrackedObject.reactive(Stack.description(description), values);
+  return TrackedObject.reactive(
+    Stack.description({
+      type: "collection:key-value",
+      api: {
+        package: "@starbeam/js",
+        name: "reactive.object",
+      },
+      fromUser: description,
+    }),
+    values
+  );
 };
 
-reactive.array = <T>(
-  values: T[],
-  description?: string | DescriptionArgs
-): T[] => {
-  return new TrackedArray(Stack.description(description), values) as T[];
+reactive.array = <T>(values: T[], description?: string | Description): T[] => {
+  return new TrackedArray(
+    Stack.description({
+      type: "collection:value",
+      api: {
+        package: "@starbeam/js",
+        name: "reactive.array",
+      },
+      fromUser: description,
+    }),
+    values
+  ) as T[];
 };
 
 export default reactive;

--- a/packages/js/index.ts
+++ b/packages/js/index.ts
@@ -1,5 +1,5 @@
 import { Cell } from "@starbeam/core";
-import type { Description, DescriptionArgs } from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
 import { Stack } from "@starbeam/debug";
 
 import TrackedArray from "./src/array.js";

--- a/packages/js/src/array.ts
+++ b/packages/js/src/array.ts
@@ -6,7 +6,7 @@
 // and it will blow up in JS in exactly the same way, so it is safe to assume
 // that properties within the getter have the correct type in TS.
 
-import type { DescriptionArgs } from "@starbeam/debug";
+import { Stack, type Description, type DescriptionArgs } from "@starbeam/debug";
 
 import { Collection } from "./collection.js";
 
@@ -101,7 +101,7 @@ class Shadow<T> {
 
     if (!fn) {
       fn = (...args: unknown[]) => {
-        this.#collection.iterateKeys();
+        this.#collection.iterateKeys(Stack.fromCaller());
         // eslint-disable-next-line
         return (this.#target as any)[prop](...args);
       };
@@ -136,18 +136,19 @@ class Shadow<T> {
     return fn;
   }
 
-  at(index: number) {
+  at(index: number, caller: Stack) {
     this.#collection.get(
       index,
       index in this.#target ? "hit" : "miss",
-      member(index)
+      member(index),
+      caller
     );
-    this.#collection.iterateKeys();
+    this.#collection.iterateKeys(caller);
 
     return this.#target[index];
   }
 
-  updateAt(index: number, value: T) {
+  updateAt(index: number, value: T, caller: Stack) {
     const current = this.#target[index];
 
     if (Object.is(current, value)) {
@@ -155,7 +156,7 @@ class Shadow<T> {
     }
 
     this.#collection.splice();
-    this.#collection.set(index, "key:changes", member(index));
+    this.#collection.set(index, "key:changes", member(index), caller);
 
     this.#target[index] = value;
   }
@@ -196,7 +197,7 @@ class Shadow<T> {
 }
 
 export default class TrackedArray<T = unknown> {
-  constructor(description: DescriptionArgs, arr: T[] = []) {
+  constructor(description: Description, arr: T[] = []) {
     Object.freeze(arr);
 
     const target = [...arr];
@@ -205,7 +206,7 @@ export default class TrackedArray<T = unknown> {
     const proxy: T[] = new Proxy(target, {
       get(target, prop /*, _receiver */) {
         if (prop === "length") {
-          collection.iterateKeys();
+          collection.iterateKeys(Stack.fromCaller());
           return target.length;
         }
 
@@ -214,7 +215,7 @@ export default class TrackedArray<T = unknown> {
         if (index === null) {
           return shadow.get(prop);
         } else {
-          return shadow.at(index);
+          return shadow.at(index, Stack.fromCaller());
         }
       },
 
@@ -232,7 +233,7 @@ export default class TrackedArray<T = unknown> {
         if (index === null) {
           shadow.set(prop, value);
         } else if (index in target) {
-          shadow.updateAt(index, value as T);
+          shadow.updateAt(index, value as T, Stack.fromCaller());
         } else {
           shadow.set(prop, value);
         }

--- a/packages/js/src/array.ts
+++ b/packages/js/src/array.ts
@@ -6,7 +6,7 @@
 // and it will blow up in JS in exactly the same way, so it is safe to assume
 // that properties within the getter have the correct type in TS.
 
-import { Stack, type Description, type DescriptionArgs } from "@starbeam/debug";
+import { type Description, Stack } from "@starbeam/debug";
 
 import { Collection } from "./collection.js";
 

--- a/packages/js/src/collection.ts
+++ b/packages/js/src/collection.ts
@@ -1,5 +1,5 @@
 import { Cell, Marker, Reactive } from "@starbeam/core";
-import type { Description, DescriptionArgs, Stack } from "@starbeam/debug";
+import type { Description, Stack } from "@starbeam/debug";
 import { expected, isPresent, verified } from "@starbeam/verify";
 
 class ItemState {

--- a/packages/js/src/collection.ts
+++ b/packages/js/src/collection.ts
@@ -1,5 +1,5 @@
 import { Cell, Marker, Reactive } from "@starbeam/core";
-import type { Description, DescriptionArgs } from "@starbeam/debug";
+import type { Description, DescriptionArgs, Stack } from "@starbeam/debug";
 import { expected, isPresent, verified } from "@starbeam/verify";
 
 class ItemState {
@@ -10,9 +10,9 @@ class ItemState {
   ): ItemState {
     return new ItemState(
       Cell(initialized, {
-        ...description.key(member).args,
-        transform: (d: Description) =>
-          d.implementation({ reason: "initialization tracking" }),
+        ...description
+          .key(member)
+          .implementation({ reason: "initialization tracking" }),
       }),
       Marker(description.key(member))
     );
@@ -34,13 +34,13 @@ class ItemState {
     this.#value = value;
   }
 
-  check(): void {
-    this.#present.current;
+  check(caller: Stack): void {
+    this.#present.read(caller);
   }
 
-  read(): void {
-    this.#present.current;
-    this.#value.consume();
+  read(caller: Stack): void {
+    this.#present.read(caller);
+    this.#value.consume(caller);
   }
 
   initialize(): void {
@@ -58,12 +58,16 @@ class ItemState {
 }
 
 class Item {
-  static uninitialized(description: Description, member: string): Item {
+  static uninitialized(
+    description: Description,
+    member: string,
+    caller: Stack
+  ): Item {
     const item = new Item(ItemState.uninitialized(description, member));
 
     // check the item so that subsequent writes to the item will invalidate the
     // read that caused this item to be created
-    item.#value.check();
+    item.#value.check(caller);
 
     return item;
   }
@@ -81,8 +85,8 @@ class Item {
     this.#value = value;
   }
 
-  check() {
-    this.#value.check();
+  check(caller: Stack) {
+    this.#value.check(caller);
   }
 
   set() {
@@ -93,8 +97,8 @@ class Item {
     this.#value.delete();
   }
 
-  read(): void {
-    return this.#value.read();
+  read(caller: Stack): void {
+    return this.#value.read(caller);
   }
 }
 
@@ -111,40 +115,38 @@ export class Collection<K> {
     );
   }
 
-  static create<K>(
-    description: DescriptionArgs,
-    object: object
-  ): Collection<K> {
-    const collection = new Collection<K>(undefined, new Map(), {
-      ...description,
-      transform: (d) => d.key("entries"),
-    });
+  static create<K>(description: Description, object: object): Collection<K> {
+    const collection = new Collection<K>(
+      undefined,
+      new Map(),
+      description.key("entries")
+    );
     Collection.#objects.set(object, collection);
     return collection;
   }
 
   #iteration: Marker | undefined;
   #items: Map<K, Item>;
-  #description: DescriptionArgs;
+  #description: Description;
 
   constructor(
     iteration: undefined,
     items: Map<K, Item>,
-    description: DescriptionArgs
+    description: Description
   ) {
     this.#description = description;
     this.#iteration = iteration;
     this.#items = items;
   }
 
-  iterateKeys(): void {
+  iterateKeys(caller: Stack): void {
     if (this.#iteration === undefined) {
       this.#iteration = Marker(this.#description);
     }
 
     // remember that we iterated this collection so that consumers of the
     // iteration detect changes to the collection itself.
-    this.#iteration.consume();
+    this.#iteration.consume(caller);
   }
 
   splice() {
@@ -168,18 +170,23 @@ export class Collection<K> {
     this.#iteration.update();
   }
 
-  check(key: K, disposition: "hit" | "miss", description: string) {
+  check(
+    key: K,
+    disposition: "hit" | "miss",
+    description: string,
+    caller: Stack
+  ) {
     let item = this.#items.get(key);
 
     // If we're checking this key for the first time, we need to initialize the
     // item so that this consumer will be invalidated by subsequent writes.
     if (item === undefined) {
-      item = this.#initialize(key, disposition, description);
+      item = this.#initialize(key, disposition, description, caller);
     }
 
     // otherwise, read the presence of the key so that this consumer will be
     // invalidated by deletes.
-    item.check();
+    item.check(caller);
   }
 
   /**
@@ -187,17 +194,22 @@ export class Collection<K> {
    *
    * If the key is not present, that means that this is the first read from the key.
    */
-  get(key: K, disposition: "hit" | "miss", description: string) {
+  get(key: K, disposition: "hit" | "miss", description: string, caller: Stack) {
     let item = this.#items.get(key);
 
     if (item === undefined) {
-      item = this.#initialize(key, disposition, description);
+      item = this.#initialize(key, disposition, description, caller);
     }
 
-    return item.read();
+    return item.read(caller);
   }
 
-  set(key: K, disposition: "key:stable" | "key:changes", description: string) {
+  set(
+    key: K,
+    disposition: "key:stable" | "key:changes",
+    description: string,
+    caller: Stack
+  ) {
     if (disposition === "key:changes") {
       this.splice();
     }
@@ -205,7 +217,7 @@ export class Collection<K> {
     let item = this.#items.get(key);
 
     if (item === undefined) {
-      item = this.#initialize(key, "hit", description);
+      item = this.#initialize(key, "hit", description, caller);
       return;
     }
 
@@ -229,7 +241,12 @@ export class Collection<K> {
     this.splice();
   }
 
-  #initialize(key: K, disposition: "hit" | "miss", member: string): Item {
+  #initialize(
+    key: K,
+    disposition: "hit" | "miss",
+    member: string,
+    caller: Stack
+  ): Item {
     if (this.#iteration === undefined) {
       this.#iteration = Marker(this.#description);
     }
@@ -238,7 +255,7 @@ export class Collection<K> {
     const iteration = Reactive.internals(this.#iteration).description;
 
     if (disposition === "miss") {
-      item = Item.uninitialized(iteration, member);
+      item = Item.uninitialized(iteration, member, caller);
     } else {
       item = Item.initialized(iteration, member);
     }

--- a/packages/js/src/iterable.ts
+++ b/packages/js/src/iterable.ts
@@ -1,5 +1,5 @@
 import { type Equality, Cell, Marker, Reactive } from "@starbeam/core";
-import { Stack, type Description, type DescriptionArgs } from "@starbeam/debug";
+import { type Description, Stack } from "@starbeam/debug";
 
 class Entry<V> {
   static initialized<V>(value: V, desc: Description, equality: Equality<V>) {

--- a/packages/js/src/iterable.ts
+++ b/packages/js/src/iterable.ts
@@ -1,23 +1,21 @@
 import { type Equality, Cell, Marker, Reactive } from "@starbeam/core";
-import type { Description, DescriptionArgs } from "@starbeam/debug";
+import { Stack, type Description, type DescriptionArgs } from "@starbeam/debug";
 
 class Entry<V> {
-  static initialized<V>(
-    value: V,
-    desc: DescriptionArgs,
-    equality: Equality<V>
-  ) {
+  static initialized<V>(value: V, desc: Description, equality: Equality<V>) {
     return new Entry(
-      Cell<undefined | Cell<V>>(Cell(value, desc), {
-        ...desc,
-        transform: (d) => d.implementation({ reason: "initialized entry" }),
+      Cell<undefined | Cell<V>>(Cell(value, { description: desc }), {
+        description: desc.implementation({ reason: "initialized entry" }),
       }),
       equality
     );
   }
 
-  static uninitialized<V>(desc: DescriptionArgs, equality: Equality<V>) {
-    return new Entry(Cell<undefined | Cell<V>>(undefined, desc), equality);
+  static uninitialized<V>(desc: Description, equality: Equality<V>) {
+    return new Entry(
+      Cell<undefined | Cell<V>>(undefined, { description: desc }),
+      equality
+    );
   }
 
   #value: Cell<undefined | Cell<V>>;
@@ -70,28 +68,22 @@ class Entry<V> {
 export class ReactiveMap<K, V> implements Map<K, V> {
   static reactive<K, V>(
     equality: Equality<V>,
-    description: DescriptionArgs
+    description: Description
   ): ReactiveMap<K, V> {
     return new ReactiveMap(description, equality);
   }
 
-  #description: DescriptionArgs;
+  #description: Description;
   #entries: Map<K, Entry<V>> = new Map();
   #equality: Equality<V>;
   #keys: Marker;
   #values: Marker;
 
-  private constructor(description: DescriptionArgs, equality: Equality<V>) {
+  private constructor(description: Description, equality: Equality<V>) {
     this.#description = description;
     this.#equality = equality;
-    this.#keys = Marker({
-      ...description,
-      transform: (d: Description) => d.key("keys"),
-    });
-    this.#values = Marker({
-      ...description,
-      transform: (d: Description) => d.key("values"),
-    });
+    this.#keys = Marker(description.key("keys"));
+    this.#values = Marker(description.key("values"));
   }
 
   clear(): void {
@@ -123,8 +115,8 @@ export class ReactiveMap<K, V> implements Map<K, V> {
     callbackfn: (value: V, key: K, map: Map<K, V>) => void,
     thisArg?: unknown
   ): void {
-    this.#keys.consume();
-    this.#values.consume();
+    this.#keys.consume(Stack.fromCaller());
+    this.#values.consume(Stack.fromCaller());
 
     for (const [key, entry] of this.#entries) {
       callbackfn.call(thisArg, entry.get() as V, key, this);
@@ -156,7 +148,7 @@ export class ReactiveMap<K, V> implements Map<K, V> {
   }
 
   get size(): number {
-    this.#keys.consume();
+    this.#keys.consume(Stack.fromCaller());
 
     let size = 0;
 
@@ -178,8 +170,8 @@ export class ReactiveMap<K, V> implements Map<K, V> {
   }
 
   *entries(): IterableIterator<[K, V]> {
-    this.#keys.consume();
-    this.#values.consume();
+    this.#keys.consume(Stack.fromCaller());
+    this.#values.consume(Stack.fromCaller());
 
     for (const [key, value] of this.#iterate()) {
       yield [key, value.get() as V];
@@ -187,7 +179,7 @@ export class ReactiveMap<K, V> implements Map<K, V> {
   }
 
   *keys(): IterableIterator<K> {
-    this.#keys.consume();
+    this.#keys.consume(Stack.fromCaller());
 
     for (const [key] of this.#iterate()) {
       yield key;
@@ -195,7 +187,8 @@ export class ReactiveMap<K, V> implements Map<K, V> {
   }
 
   *values(): IterableIterator<V> {
-    this.#values.consume();
+    // add an extra frame for the internal JS call to .next()
+    this.#values.consume(Stack.fromCaller(1));
 
     for (const [, value] of this.#iterate()) {
       yield value.get() as V;
@@ -213,7 +206,7 @@ export class ReactiveMap<K, V> implements Map<K, V> {
 
     if (entry === undefined) {
       entry = Entry.uninitialized(
-        { ...this.#description, transform: (d) => d.key("entry") },
+        this.#description.key("entry"),
         this.#equality
       );
       this.#entries.set(key, entry);
@@ -226,23 +219,20 @@ export class ReactiveMap<K, V> implements Map<K, V> {
 export class ReactiveSet<T> implements Set<T> {
   static reactive<T>(
     equality: Equality<T>,
-    description: DescriptionArgs
+    description: Description
   ): ReactiveSet<T> {
     return new ReactiveSet(description, equality);
   }
 
-  #description: DescriptionArgs;
+  #description: Description;
   #entries: Map<T, Entry<T>> = new Map();
   #equality: Equality<T>;
   #values: Marker;
 
-  private constructor(description: DescriptionArgs, equality: Equality<T>) {
+  private constructor(description: Description, equality: Equality<T>) {
     this.#description = description;
     this.#equality = equality;
-    this.#values = Marker({
-      ...description,
-      transform: (d: Description) => d.key("values"),
-    });
+    this.#values = Marker(description.key("values"));
   }
 
   add(value: T): this {
@@ -285,7 +275,7 @@ export class ReactiveSet<T> implements Set<T> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     thisArg?: any
   ): void {
-    this.#values.consume();
+    this.#values.consume(Stack.fromCaller());
 
     for (const [value] of this.#iterate()) {
       callbackfn.call(thisArg, value, value, this);
@@ -297,7 +287,7 @@ export class ReactiveSet<T> implements Set<T> {
   }
 
   get size(): number {
-    this.#values.consume();
+    this.#values.consume(Stack.fromCaller());
 
     let size = 0;
 
@@ -317,7 +307,7 @@ export class ReactiveSet<T> implements Set<T> {
   }
 
   *entries(): IterableIterator<[T, T]> {
-    this.#values.consume();
+    this.#values.consume(Stack.fromCaller());
 
     for (const [value, entry] of this.#iterate()) {
       yield [value, entry.get() as T];
@@ -325,7 +315,7 @@ export class ReactiveSet<T> implements Set<T> {
   }
 
   *keys(): IterableIterator<T> {
-    this.#values.consume();
+    this.#values.consume(Stack.fromCaller());
 
     for (const [value] of this.#iterate()) {
       yield value;

--- a/packages/js/src/map.ts
+++ b/packages/js/src/map.ts
@@ -1,5 +1,5 @@
 import { type Equality, Marker } from "@starbeam/core";
-import { Stack, type Description, type DescriptionArgs } from "@starbeam/debug";
+import { type Description, Stack } from "@starbeam/debug";
 
 import { Collection } from "./collection.js";
 

--- a/packages/js/src/object.ts
+++ b/packages/js/src/object.ts
@@ -1,4 +1,4 @@
-import { Stack, type Description } from "@starbeam/debug";
+import { type Description, Stack } from "@starbeam/debug";
 
 import { Collection } from "./collection.js";
 

--- a/packages/js/src/set.ts
+++ b/packages/js/src/set.ts
@@ -1,4 +1,4 @@
-import { Stack, type Description, type DescriptionArgs } from "@starbeam/debug";
+import { type Description, Stack } from "@starbeam/debug";
 
 import { Collection } from "./collection.js";
 

--- a/packages/timeline/src/timeline/frames.ts
+++ b/packages/timeline/src/timeline/frames.ts
@@ -1,12 +1,12 @@
 import type { Description } from "@starbeam/debug";
 
-import { InternalChildren, type IsUpdatedSince } from "./internals.js";
+import { type IsUpdatedSince, InternalChildren } from "./internals.js";
 import {
-  REACTIVE,
   type CompositeInternals,
   type MutableInternals,
   type ReactiveInternals,
   type ReactiveProtocol,
+  REACTIVE,
 } from "./reactive.js";
 import type { Timestamp } from "./timestamp.js";
 

--- a/packages/timeline/src/timeline/frames.ts
+++ b/packages/timeline/src/timeline/frames.ts
@@ -1,17 +1,12 @@
 import type { Description } from "@starbeam/debug";
-import {
-  type DescriptionArgs,
-  FormulaDescription,
-  TimestampValidatorDescription,
-} from "@starbeam/debug";
 
-import { type IsUpdatedSince, InternalChildren } from "./internals.js";
+import { InternalChildren, type IsUpdatedSince } from "./internals.js";
 import {
+  REACTIVE,
   type CompositeInternals,
   type MutableInternals,
   type ReactiveInternals,
   type ReactiveProtocol,
-  REACTIVE,
 } from "./reactive.js";
 import type { Timestamp } from "./timestamp.js";
 
@@ -34,7 +29,7 @@ export class AssertFrame {
 }
 
 export class ActiveFrame {
-  static create(description: DescriptionArgs): ActiveFrame {
+  static create(description: Description): ActiveFrame {
     return new ActiveFrame(new Set(), description);
   }
 
@@ -42,7 +37,7 @@ export class ActiveFrame {
 
   private constructor(
     children: Set<ReactiveProtocol>,
-    readonly description: DescriptionArgs
+    readonly description: Description
   ) {
     this.#children = children;
   }
@@ -90,7 +85,7 @@ export class FinalizedFrame<T = unknown>
     children: Set<ReactiveProtocol>;
     finalizedAt: Timestamp;
     value: T;
-    description: DescriptionArgs;
+    description: Description;
   }): FinalizedFrame<T> {
     return new FinalizedFrame(children, finalizedAt, value, description);
   }
@@ -104,7 +99,7 @@ export class FinalizedFrame<T = unknown>
     children: Set<ReactiveProtocol>,
     finalizedAt: Timestamp,
     value: T,
-    readonly description: DescriptionArgs
+    readonly description: Description
   ) {
     this.#children = children;
     this.#finalizedAt = finalizedAt;
@@ -127,10 +122,7 @@ export class FinalizedFrame<T = unknown>
 
     (
       this.#composite as ReactiveInternals & { description: Description }
-    ).description = FormulaDescription.from({
-      ...description,
-      validator: TimestampValidatorDescription.from(this.#composite),
-    });
+    ).description = description;
   }
 
   get [REACTIVE](): ReactiveInternals {

--- a/packages/timeline/src/timeline/reactive.ts
+++ b/packages/timeline/src/timeline/reactive.ts
@@ -1,4 +1,4 @@
-import type { Description } from "@starbeam/debug";
+import type { Description, Stack } from "@starbeam/debug";
 
 import type { InternalChildren } from "./internals.js";
 import type { Timestamp } from "./timestamp.js";
@@ -42,6 +42,7 @@ export interface ReactiveProtocol {
 
 export interface Reactive<T> extends ReactiveProtocol {
   readonly current: T;
+  read(stack: Stack): T;
 }
 
 export const Reactive = {

--- a/packages/timeline/src/timeline/renderables/renderable.ts
+++ b/packages/timeline/src/timeline/renderables/renderable.ts
@@ -161,12 +161,12 @@ export class Renderable<T = unknown> implements ReactiveProtocol {
       dependencies.map((dependency) => {
         return implementation
           ? dependency.description
-          : dependency.description.userFacing();
+          : dependency.description.userFacing;
       })
     );
 
     const nodes = [...descriptions].map((d) => {
-      const description = implementation ? d : d.userFacing();
+      const description = implementation ? d : d.userFacing;
       return description.describe({ source });
     });
 

--- a/packages/timeline/src/timeline/timeline.ts
+++ b/packages/timeline/src/timeline/timeline.ts
@@ -1,4 +1,4 @@
-import type { Description, DescriptionArgs } from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
 import { LOGGER, Stack } from "@starbeam/debug";
 import { expected, isEqual, verify } from "@starbeam/verify";
 
@@ -11,11 +11,11 @@ import {
 import { type FinalizedFrame, ActiveFrame, AssertFrame } from "./frames.js";
 import { NOW } from "./now.js";
 import { Queue } from "./queue.js";
+import type { Reactive } from "./reactive.js";
 import {
-  REACTIVE,
-  Reactive,
   type MutableInternals,
   type ReactiveProtocol,
+  REACTIVE,
 } from "./reactive.js";
 // eslint-disable-next-line import/no-cycle
 import { Renderable } from "./renderables/renderable.js";

--- a/packages/timeline/src/timeline/timeline.ts
+++ b/packages/timeline/src/timeline/timeline.ts
@@ -1,4 +1,4 @@
-import type { DescriptionArgs } from "@starbeam/debug";
+import type { Description, DescriptionArgs } from "@starbeam/debug";
 import { LOGGER, Stack } from "@starbeam/debug";
 import { expected, isEqual, verify } from "@starbeam/verify";
 
@@ -11,10 +11,11 @@ import {
 import { type FinalizedFrame, ActiveFrame, AssertFrame } from "./frames.js";
 import { NOW } from "./now.js";
 import { Queue } from "./queue.js";
-import type {
-  MutableInternals,
+import {
+  REACTIVE,
   Reactive,
-  ReactiveProtocol,
+  type MutableInternals,
+  type ReactiveProtocol,
 } from "./reactive.js";
 // eslint-disable-next-line import/no-cycle
 import { Renderable } from "./renderables/renderable.js";
@@ -89,20 +90,26 @@ export class Timeline {
   }
 
   static StartedFormula = class StartedFormula {
-    static create(description: DescriptionArgs): StartedFormula {
+    static create(description: Description, caller: Stack): StartedFormula {
       const prevFrame = TIMELINE.#frame;
 
       const currentFrame = (TIMELINE.#frame = ActiveFrame.create(description));
 
-      return new StartedFormula(prevFrame, currentFrame);
+      return new StartedFormula(prevFrame, currentFrame, caller);
     }
 
     #prev: ActiveFrame | null;
     #current: ActiveFrame;
+    #caller: Stack;
 
-    private constructor(prev: ActiveFrame | null, current: ActiveFrame) {
+    private constructor(
+      prev: ActiveFrame | null,
+      current: ActiveFrame,
+      caller: Stack
+    ) {
       this.#prev = prev;
       this.#current = current;
+      this.#caller = caller;
     }
 
     done<T>(value: T): FormulaResult<T>;
@@ -119,7 +126,7 @@ export class Timeline {
 
       const newFrame = this.#current.finalize(value, NOW.now);
       TIMELINE.#frame = this.#prev;
-      TIMELINE.didConsume(newFrame.frame);
+      TIMELINE.didConsume(newFrame.frame, this.#caller);
       return newFrame;
     }
 
@@ -129,10 +136,10 @@ export class Timeline {
   };
 
   #phase: Phase;
+  #callerStack: Stack | null = null;
   #frame: ActiveFrame | null = null;
   #assertFrame: AssertFrame | null = null;
   #debugTimeline: DebugTimeline | null = null;
-  #writeAssertions: Set<() => { problem: string } | void> = new Set();
 
   readonly #renderables: Renderables;
   readonly #onUpdate: WeakMap<MutableInternals, Set<() => void>>;
@@ -158,7 +165,7 @@ export class Timeline {
   render<T>(
     input: Reactive<T>,
     render: () => void,
-    description?: string | DescriptionArgs
+    description?: string | Description
   ): Renderable<T> {
     const ready = () => {
       if (this.#renderables.isRemoved(renderable as Renderable<unknown>)) {
@@ -172,7 +179,18 @@ export class Timeline {
       input,
       { ready },
       this.#renderables,
-      Stack.description(description)
+      Stack.description({
+        type: "renderer",
+        api: {
+          package: "@starbeam/timeline",
+          name: "TIMELINE",
+          method: {
+            type: "static",
+            name: "render",
+          },
+        },
+        fromUser: description,
+      })
     );
     this.#renderables.insert(renderable as Renderable<unknown>);
 
@@ -192,19 +210,38 @@ export class Timeline {
     change: <T>(
       input: Reactive<T>,
       ready: (renderable: Renderable<T>) => void,
-      description?: string | DescriptionArgs
+      description?: string | Description
     ): Renderable<T> => {
       const renderable = Renderable.create(
         input,
         { ready },
         this.#renderables,
-        Stack.description(description)
+        Stack.description({
+          type: "renderer",
+          api: {
+            package: "@starbeam/timeline",
+            name: "TIMELINE",
+            method: {
+              type: "static",
+              name: "on.change",
+            },
+          },
+          fromUser: description,
+        })
       );
       this.#renderables.insert(renderable as Renderable<unknown>);
 
       return renderable;
     },
   } as const;
+
+  /**
+   * Dynamic assertions that are used in development mode to detect reads that occur outside of a
+   * tracking frame, but which are used to produce rendered outputs.
+   */
+  #readAssertions = new Set<
+    (reactive: ReactiveProtocol, caller: Stack) => void
+  >();
 
   // assert = {
   //   readonly: (assertion: () => void): (() => void) => {},
@@ -284,6 +321,20 @@ export class Timeline {
     return NOW.now;
   }
 
+  entryPoint<T>(callback: () => T): T {
+    // the outermost entry point wins.
+    if (isDebug() && !this.#callerStack) {
+      try {
+        this.#callerStack = Stack.fromCaller(1);
+        return callback();
+      } finally {
+        this.#callerStack = null;
+      }
+    } else {
+      return callback();
+    }
+  }
+
   mutation<T>(description: string, callback: () => T): T {
     if (isDebug()) {
       return this.#debug.mutation(description, callback);
@@ -347,13 +398,39 @@ export class Timeline {
   }
 
   // Indicate that a particular cell was used inside of the current computation.
-  didConsume(reactive: ReactiveProtocol) {
+  didConsume(reactive: ReactiveProtocol, caller: Stack) {
     if (this.#frame) {
       this.#frame.add(reactive);
-    } else if (isDebug()) {
+      return;
+    }
+
+    if (isDebug()) {
       // we don't add a consumption to the debug timeline if we're in a frame, because the frame
       // itself gets consumed
       this.#debug.consume(reactive);
+
+      // if we're consuming a cell, but we're not in the context of a tracking frame, give read
+      // barriers a chance to assert.
+      if (reactive[REACTIVE].type === "mutable") {
+        this.#untrackedRead(reactive, this.#callerStack ?? caller);
+      }
+    }
+  }
+
+  /**
+   * In debug mode, register a barrier for untracked reads. This allows you to throw an error if an
+   * untracked read occurred in a context (such as a render function) that a renderer knows will
+   * produce rendered content.
+   */
+  untrackedReadBarrier(
+    assertion: (reactive: ReactiveProtocol, caller: Stack) => void
+  ) {
+    this.#readAssertions.add(assertion);
+  }
+
+  #untrackedRead(reactive: ReactiveProtocol, caller: Stack) {
+    for (const read of this.#readAssertions) {
+      read(reactive, caller);
     }
   }
 
@@ -379,9 +456,10 @@ export class Timeline {
    */
   evaluateFormula<T>(
     callback: () => T,
-    description: DescriptionArgs
+    description: Description,
+    caller: Stack
   ): { readonly frame: FinalizedFrame<T>; readonly value: T } {
-    const formula = Timeline.StartedFormula.create(description);
+    const formula = Timeline.StartedFormula.create(description, caller);
 
     try {
       const result = callback();

--- a/packages/x-devtool/index.tsx
+++ b/packages/x-devtool/index.tsx
@@ -103,7 +103,7 @@ function Dependency({ description }: { description: Description }) {
 
 function unique(dependencies: MutableInternals[]): Description[] {
   const descriptions = new Set(
-    dependencies.map((d) => d.description.userFacing())
+    dependencies.map((d) => d.description.userFacing)
   );
 
   return [...descriptions];

--- a/packages/x-store/src/flat.ts
+++ b/packages/x-store/src/flat.ts
@@ -1,3 +1,4 @@
+import { TIMELINE } from "@starbeam/core";
 import type {
   AggregateRow,
   AggregatorFor,
@@ -32,7 +33,7 @@ export abstract class FlatRows<U extends UserTypes>
   }
 
   [Symbol.iterator](): IterableIterator<TableTypesFor<U>["Row"]> {
-    return this.rows[Symbol.iterator]();
+    return TIMELINE.entryPoint(() => this.rows[Symbol.iterator]());
   }
 }
 
@@ -228,15 +229,17 @@ export class Query<U extends UserTypes> extends FlatRows<U> {
   }
 
   get rows(): TableTypesFor<U>["Row"][] {
-    const table = this.#rows;
-    const rows = [...table.rows];
-    const filtered = rows.filter((row) => this.#filter.matches(row));
+    return TIMELINE.entryPoint(() => {
+      const table = this.#rows;
+      const rows = [...table.rows];
+      const filtered = rows.filter((row) => this.#filter.matches(row));
 
-    if (this.#sort) {
-      return filtered.sort(this.#sort);
-    } else {
-      return filtered;
-    }
+      if (this.#sort) {
+        return filtered.sort(this.#sort);
+      } else {
+        return filtered;
+      }
+    });
   }
 }
 

--- a/packages/x-store/src/flat.ts
+++ b/packages/x-store/src/flat.ts
@@ -1,4 +1,5 @@
 import { TIMELINE } from "@starbeam/core";
+
 import type {
   AggregateRow,
   AggregatorFor,

--- a/packages/x-store/src/table.ts
+++ b/packages/x-store/src/table.ts
@@ -1,4 +1,5 @@
-import { type DescriptionArgs, Stack } from "@starbeam/debug";
+import { TIMELINE } from "@starbeam/core";
+import { type DescriptionArgs, Stack, Description } from "@starbeam/debug";
 import { reactive } from "@starbeam/js";
 
 import { FlatRows } from "./flat.js";
@@ -26,9 +27,14 @@ export class Table<U extends UserTypes> extends FlatRows<U> {
       name?: string;
     }
   ): Table<TableTypes> {
-    const description = Stack.description(
-      definition.name ?? definition.model?.name ?? "table"
-    );
+    const description = Stack.description({
+      type: "formula",
+      api: {
+        package: "internal",
+        name: "Table",
+      },
+      fromUser: definition.name ?? definition.model?.name ?? "table",
+    });
 
     return new Table<TableTypes>(
       {
@@ -43,11 +49,11 @@ export class Table<U extends UserTypes> extends FlatRows<U> {
   #id = 0;
   readonly #definition: TableDefinition<TableTypesFor<U>>;
   readonly #rows: Map<string, TableTypesFor<U>["Row"]>;
-  readonly #description: DescriptionArgs;
+  readonly #description: Description;
 
   private constructor(
     definition: TableDefinition<TableTypesFor<U>>,
-    description: DescriptionArgs
+    description: Description
   ) {
     super();
     this.#rows = reactive.Map(description);
@@ -60,7 +66,7 @@ export class Table<U extends UserTypes> extends FlatRows<U> {
   }
 
   get rows(): TableTypesFor<U>["Row"][] {
-    return [...this.#rows.values()];
+    return TIMELINE.entryPoint(() => [...this.#rows.values()]);
   }
 
   append(

--- a/packages/x-store/src/table.ts
+++ b/packages/x-store/src/table.ts
@@ -1,5 +1,6 @@
 import { TIMELINE } from "@starbeam/core";
-import { type DescriptionArgs, Stack, Description } from "@starbeam/debug";
+import type { Description } from "@starbeam/debug";
+import { Stack } from "@starbeam/debug";
 import { reactive } from "@starbeam/js";
 
 import { FlatRows } from "./flat.js";


### PR DESCRIPTION
This commit adds infrastructure ("read barrier") that makes it possible
to emit errors if any cell is consumed in a rendering context, but it
is not inside a tracking frame.

It also threads through stack information for both the creation of
reactive variables and for consumption of reactive variables. Making
this a dev-time-only cost is extremely urgent and must be done before
0.6.

This commit also implements the read barrier assertion in the React
renderer. The long and short of it is that any reads that happen inside
of a React render function but outside of a useSetup or useReactive
will trigger the error.

Finally, this commit adds TIMELINE.entryPoint, which allows third-party
code to mask abstractions from developer tools and debug messages.

This allows libraries to help make sure that these messages actually
point at user code and not internals. The `@starbeamx/store` package
now makes use of this infrastructure.