### PR TITLE
Swap babel-eslint for @babel/eslint-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "vite": "*",
     "vitest": "*",
     "@vitest/ui": "*",
+    "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.19.1",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.19.1",
@@ -59,7 +60,6 @@
     "rollup-plugin-ts": "^3.0.2",
     "tslib": "^2.4.0",
     "eslint-config-airbnb": "^19.0.4",
-    "babel-eslint": "^10.1.0",
     "jsdom": "^20.0.0",
     "happy-dom": "^6.0.4"
   },
@@ -69,7 +69,7 @@
         "reason": "vscode eslint pulled in depcheck's .eslintrc.yml",
         "packages": [
           "eslint-config-airbnb",
-          "babel-eslint"
+          "@babel/eslint-parser"
         ]
       },
       {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ importers:
 
   .:
     specifiers:
+      '@babel/eslint-parser': ^7.19.1
       '@babel/plugin-proposal-decorators': ^7.19.1
       '@babel/plugin-syntax-dynamic-import': ^7.8.3
       '@babel/plugin-transform-runtime': ^7.19.1
@@ -25,7 +26,6 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.38.0
       '@typescript-eslint/parser': ^5.38.0
       '@vitest/ui': 0.23.4
-      babel-eslint: ^10.1.0
       eslint: ^8.23.1
       eslint-config-airbnb: ^19.0.4
       eslint-config-prettier: ^8.5.0
@@ -50,6 +50,7 @@ importers:
       vite: 3.1.3
       vitest: 0.23.4
     devDependencies:
+      '@babel/eslint-parser': 7.19.1_zdglor7vg7osicr5spasq6cc5a
       '@babel/plugin-proposal-decorators': 7.19.1_@babel+core@7.19.1
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.19.1
       '@babel/plugin-transform-runtime': 7.19.1_@babel+core@7.19.1
@@ -63,7 +64,6 @@ importers:
       '@typescript-eslint/eslint-plugin': 5.38.0_wsb62dxj2oqwgas4kadjymcmry
       '@typescript-eslint/parser': 5.38.0_irgkl5vooow2ydyo6aokmferha
       '@vitest/ui': 0.23.4
-      babel-eslint: 10.1.0_eslint@8.23.1
       eslint: 8.23.1
       eslint-config-airbnb: 19.0.4_4zstfqq5uopk5xuvotejlnl36y
       eslint-config-prettier: 8.5.0_eslint@8.23.1
@@ -702,6 +702,20 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@babel/eslint-parser/7.19.1_zdglor7vg7osicr5spasq6cc5a:
+    resolution: {integrity: sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
+    peerDependencies:
+      '@babel/core': '>=7.11.0'
+      eslint: ^7.5.0 || ^8.0.0
+    dependencies:
+      '@babel/core': 7.19.1
+      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
+      eslint: 8.23.1
+      eslint-visitor-keys: 2.1.0
+      semver: 6.3.0
     dev: true
 
   /@babel/generator/7.19.0:
@@ -2371,6 +2385,12 @@ packages:
     resolution: {integrity: sha512-EWUguj2kd7ldmrF9F+vI5hUOralPd+sdsUnYbRy33vZTuZkduC1shE9TtEMEjAQwyfyMb4ole5KtjF8MsnQOlA==}
     dev: true
 
+  /@nicolo-ribaudo/eslint-scope-5-internals/5.1.1-v1:
+    resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
+    dependencies:
+      eslint-scope: 5.1.1
+    dev: true
+
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -3118,24 +3138,6 @@ packages:
 
   /axobject-query/2.2.0:
     resolution: {integrity: sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==}
-    dev: true
-
-  /babel-eslint/10.1.0_eslint@8.23.1:
-    resolution: {integrity: sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==}
-    engines: {node: '>=6'}
-    deprecated: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.
-    peerDependencies:
-      eslint: '>= 4.12.1'
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.19.1
-      '@babel/traverse': 7.19.1
-      '@babel/types': 7.19.0
-      eslint: 8.23.1
-      eslint-visitor-keys: 1.3.0
-      resolve: 1.22.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /babel-plugin-dynamic-import-node/2.3.3:
@@ -4626,11 +4628,6 @@ packages:
     dependencies:
       eslint: 8.23.1
       eslint-visitor-keys: 2.1.0
-    dev: true
-
-  /eslint-visitor-keys/1.3.0:
-    resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
-    engines: {node: '>=4'}
     dev: true
 
   /eslint-visitor-keys/2.1.0:


### PR DESCRIPTION
babel-eslint is deprecated and replaced by @babel/eslint-parser

Tested via `pnpm run test:lint` and `pnpm run check:lint`

Fixes #51