### PR TITLE
Fixes use() bug reported by @LevelBossMike (closes #75)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,10 @@
     "editor.codeActionsOnSave": ["source.fixAll.eslint"]
   },
 
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+
   "[typescript][typescriptreact][javascript][javascriptreact]": {
     "editor.formatOnSave": false,
     "editor.codeActionsOnSave": [
@@ -77,8 +81,5 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.tsserver.experimental.enableProjectDiagnostics": true,
 
-  "vitest.enable": false,
-  "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  "vitest.enable": true
 }

--- a/packages/react/react/package.json
+++ b/packages/react/react/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@starbeam/core-utils": "workspace:^",
     "@starbeam/debug": "workspace:^",
+    "@starbeam/interfaces": "workspace:^",
     "@starbeam/js": "workspace:^",
     "@starbeam/modifier": "workspace:^",
     "@starbeam/shared": "workspace:^",

--- a/packages/react/react/src/use-reactive.ts
+++ b/packages/react/react/src/use-reactive.ts
@@ -39,6 +39,10 @@ export function useReactive<T>(
   }).current;
 }
 
+/**
+ * Returns a function that can be called to notify React that the current component should be
+ * re-rendered.
+ */
 export function useNotify(): () => void {
   const [, setNotify] = useState({});
   return () => {

--- a/packages/react/react/src/use-resource.ts
+++ b/packages/react/react/src/use-resource.ts
@@ -1,4 +1,4 @@
-import type { Description } from "@starbeam/debug";
+import { type Description, Desc } from "@starbeam/debug";
 import { LIFETIME, TIMELINE } from "@starbeam/timeline";
 import {
   type IntoResource,
@@ -7,6 +7,7 @@ import {
   Cell,
   Factory,
   Formula,
+  Wrap,
 } from "@starbeam/universal";
 import {
   unsafeTrackedElsewhere,
@@ -73,27 +74,49 @@ function createResource<T>(
 ): Reactive<T | undefined> {
   const notify = useNotify();
 
-  const deps: unknown[] = Array.isArray(options) ? options : dependencies ?? [];
-  const initialValue = Array.isArray(options) ? undefined : options?.initial;
+  function normalize(): {
+    deps: unknown[];
+    initialValue: T | undefined;
+    description: string | Description | undefined;
+  } {
+    if (Array.isArray(options)) {
+      return { deps: options, initialValue: undefined, description: undefined };
+    } else {
+      return {
+        deps: dependencies ?? [],
+        initialValue: options?.initial,
+        description: options?.description,
+      };
+    }
+  }
+
+  const { deps, initialValue, description } = normalize();
+  const desc = Desc("resource", description);
+
+  // const deps: unknown[] = Array.isArray(options) ? options : dependencies ?? [];
+  // const initialValue = Array.isArray(options) ? undefined : options?.initial;
   let prev: unknown[] = deps;
 
-  let stable = {};
-
+  // We pass `deps` and `factory` as the `useLifecycle` arguments. This means that `useLifecycle`
+  // callbacks will receive up-to-date values for `deps` and `factory` when they're called. This
+  // is especially important for `update`, which runs on every render: if the deps have changed in a
+  // particular render, we need to use an up-to-date `factory` to create the resource.
   return useLifecycle([deps, factory] as const, ({ on }) => {
-    on.cleanup(() => {
-      LIFETIME.finalize(stable);
-    });
+    // Create a new instance of `LastResource` for this mount. It will remain stable until the
+    // component is unmounted (even temporarily), at which point it will be finalized. This means
+    // that **re***-renders, which call the `update` callback, will share the same `LastResource`
+    // instance.
+    const resource = MountedResource.create<T>(initialValue as T, desc);
 
-    const lastResource = new LastResource<T>(initialValue as T);
+    // When React unmounts the component (even temporarily), we finalize the resource.
+    on.cleanup(() => {
+      LIFETIME.finalize(resource);
+    });
 
     // This function is called to instantiate the resource. It's called in two circumstances:
     //
     // 1. When the factory is first created, and
     // 2. When the dependencies change.
-    //
-    // The resource is never created during the initial render, because React can render the
-    // component and never run effects. So we defer the creation of the resource until React commits
-    // the component.
     //
     // React runs the render function twice in strict mode (without running effects or cleanup in
     // between). This means that any state that requires cleanup must be created in a React effect,
@@ -108,73 +131,98 @@ function createResource<T>(
     // In practice, this means that `use` returns the initial value (which defaults to `undefined`)
     // during the initial render, but always returns the current value of the resource after that.
     function create(factory: IntoResource<T>): void {
-      LIFETIME.finalize(stable);
-
-      // Create the resource. The resource is created using the `stable` lifetime, which we
-      // align with the component's lifecycle (below). This means that the resource will be
-      // finalized when the component is unmounted (even temporarily).
-      const created = lastResource.create((owner) =>
-        Factory.resource(factory, owner)
-      );
-
-      stable = created.owner;
+      // Create the resource. The resource is created with the `lastResource` as its owner. This
+      // means that the resource will be finalized when `lastResource` is finalized, which happens
+      // (above) when the component is unmounted.
+      resource.create((owner) => Factory.resource(factory, owner));
 
       // `value` is initialized below. It's a formula that returns the current value of the
       // resource (or its initial value). Whenever that value changes, we notify React.
-      const unsubscribe = TIMELINE.on.change(value, () => {
-        notify();
-      });
+      const unsubscribe = TIMELINE.on.change(resource, notify);
 
-      // When the component is unmounted, we unsubscribe from the resource's changes, so that
-      // further changes don't notify React. This is mainly for hygiene, but it also prevents
-      // unexpected leaks.
-      LIFETIME.on.cleanup(stable, () => {
-        unsubscribe();
-
-        lastResource.didCleanup();
-      });
+      // When the resource is finalized (because the component is unmounted, even temporarily), we
+      // unsubscribe from the resource's changes. This is largely for hygiene, but it also prevents
+      // us from (unnecessarily) notifying React after the component has been unmounted.
+      //
+      // If the component is remounted, we'll get a whole new `useLifecycle` instance, which will
+      // create a new `lastResource` and a new `value` formula. TL;DR From the perspective of this
+      // code, "mounting" and "remounting" are the same thing.
+      LIFETIME.on.cleanup(resource, unsubscribe);
 
       // Now that we've created the resource, we can notify React that the component has updated.
-      // This gives the component a chance to render with the resource's actual value.
+      // Since we haven't yet consumed the `value` formula, it doesn't yet have any dependencies.
+      // Notifying React will cause React to run the component's render function again, which will
+      // consume the `value` formula (and keep it up to date).
       notify();
     }
 
+    // When the component is first rendered, we wait until React commits the component to create the
+    // resource. This is because React can render the component and never run effects. So we defer
+    // the creation of the resource until React commits the component.
     on.layout(([_, factory]) => {
       create(factory);
     });
 
+    // When the component is re-rendered, we check to see if the dependencies have changed. If they
+    // have, we create a new resource. If they haven't, we do nothing.
+    //
+    // This is effectively equivalent to the resource constructor having a dependency on the deps
+    // array, but the deps array is a React stable value, not a Starbeam reactive value.
     on.update(([nextDeps, factory]) => {
-      if (!sameDeps(prev, nextDeps) || lastResource.isInactive()) {
+      if (differentDeps(prev, nextDeps) || resource.isInactive()) {
         prev = nextDeps;
-
-        LIFETIME.finalize(stable);
-        stable = {};
         create(factory);
       }
     });
 
-    const value = Formula(() => {
-      return lastResource.current;
-    });
-
-    return value;
+    return resource;
   });
 }
 
-class LastResource<T> {
+class MountedResource<T> {
+  static create<T>(
+    initial: T,
+    description: Description
+  ): MountedResource<T> & Reactive<T | undefined> {
+    const resource = new MountedResource(initial, description);
+    return Wrap(resource.formula, resource);
+  }
+
+  readonly formula: Formula<T | undefined>;
   readonly #initial: T;
   readonly #cell: Cell<Reactive<T | undefined> | undefined>;
   #value: Reactive<T | undefined> | undefined;
   #owner: object | undefined = undefined;
 
-  constructor(initial: T) {
+  private constructor(initial: T, description: Description) {
     this.#initial = initial;
-    this.#cell = Cell(undefined as Reactive<T | undefined> | undefined);
+    this.#cell = Cell(undefined as Reactive<T | undefined> | undefined, {
+      description: description.implementation("target"),
+    });
     this.#value = undefined;
+    this.formula = Formula(
+      () => this.#cell.current?.current ?? this.#initial,
+      description.implementation("formula")
+    );
+
+    LIFETIME.on.cleanup(this, () => {
+      this.#finalize();
+    });
   }
 
-  get current(): T {
-    return this.#cell.current?.current ?? this.#initial;
+  #finalize(): void {
+    if (this.#owner) {
+      LIFETIME.finalize(this.#owner);
+      this.#owner = undefined;
+    }
+  }
+
+  #reset(): object {
+    this.#finalize();
+
+    this.#owner = {};
+    LIFETIME.link(this, this.#owner);
+    return this.#owner;
   }
 
   isInactive(): boolean {
@@ -185,38 +233,31 @@ class LastResource<T> {
     reactive: Reactive<T | undefined>;
     owner: object;
   } {
-    if (this.#owner) {
-      LIFETIME.finalize(this.#owner);
-    }
+    const owner = this.#reset();
 
-    const owner = (this.#owner = {});
-    LIFETIME.link(this, owner);
     const reactive = factory(owner);
     this.#cell.set(reactive);
     this.#value = reactive;
 
-    LIFETIME.link(owner, reactive);
+    // If the `use`d resource is finalized, and the return value of the factory is a resource, we
+    // want to finalize that resource as well.
+    LIFETIME.link(this, reactive);
 
     return { reactive, owner };
   }
-
-  didCleanup(): void {
-    this.#cell.set(undefined);
-    this.#value = undefined;
-    this.#owner = undefined;
-  }
 }
 
-function sameDeps(
+function differentDeps(
   prev: unknown[] | undefined,
   next: unknown[] | undefined
 ): boolean {
   if (prev === undefined || next === undefined) {
-    return prev === next;
+    return prev !== next;
   }
 
-  return (
-    prev.length === next.length &&
-    prev.every((value, index) => Object.is(value, next[index]))
-  );
+  if (prev.length !== next.length) {
+    return true;
+  }
+
+  return prev.some((value, index) => !Object.is(value, next[index]));
 }

--- a/packages/react/react/src/use-resource.ts
+++ b/packages/react/react/src/use-resource.ts
@@ -1,13 +1,12 @@
 import type { Description } from "@starbeam/debug";
-import { callerStack } from "@starbeam/debug";
 import { LIFETIME, TIMELINE } from "@starbeam/timeline";
 import {
   type IntoResource,
   type Reactive,
   type ResourceBlueprint,
+  Cell,
   Factory,
   Formula,
-  Marker,
 } from "@starbeam/universal";
 import {
   unsafeTrackedElsewhere,
@@ -15,7 +14,6 @@ import {
 } from "@starbeam/use-strict-lifecycle";
 
 import { useNotify } from "./use-reactive.js";
-import { useComponent } from "./use-setup.js";
 
 export type UseFactory<T, D extends undefined> =
   | ResourceBlueprint<T, D>
@@ -73,7 +71,6 @@ function createResource<T>(
     | unknown[],
   dependencies?: unknown[]
 ): Reactive<T | undefined> {
-  const owner = useComponent();
   const notify = useNotify();
 
   const deps: unknown[] = Array.isArray(options) ? options : dependencies ?? [];
@@ -87,32 +84,58 @@ function createResource<T>(
       LIFETIME.finalize(stable);
     });
 
-    let lastResource: Reactive<T | undefined> | undefined = undefined;
-    const marker = Marker();
+    const lastResource = new LastResource<T>(initialValue as T);
 
+    // This function is called to instantiate the resource. It's called in two circumstances:
+    //
+    // 1. When the factory is first created, and
+    // 2. When the dependencies change.
+    //
+    // The resource is never created during the initial render, because React can render the
+    // component and never run effects. So we defer the creation of the resource until React commits
+    // the component.
+    //
+    // React runs the render function twice in strict mode (without running effects or cleanup in
+    // between). This means that any state that requires cleanup must be created in a React effect,
+    // or it will leak.
+    //
+    // The resource is initially created in an effect (which guarantees that React will run its
+    // cleanup function when the component is unmounted). When the resource's dependencies change,
+    // we need to reset the resource. In that situation, we know that the component's
+    // effects have already run, so we clean up the previous resource and create a new one in the
+    // call to `use`.
+    //
+    // In practice, this means that `use` returns the initial value (which defaults to `undefined`)
+    // during the initial render, but always returns the current value of the resource after that.
     function create(factory: IntoResource<T>): void {
       LIFETIME.finalize(stable);
-      stable = {};
 
-      const created: Reactive<T | undefined> = Factory.resource(factory, owner);
+      // Create the resource. The resource is created using the `stable` lifetime, which we
+      // align with the component's lifecycle (below). This means that the resource will be
+      // finalized when the component is unmounted (even temporarily).
+      const created = lastResource.create((owner) =>
+        Factory.resource(factory, owner)
+      );
 
-      lastResource = created;
-      LIFETIME.link(stable, lastResource);
-      marker.update(callerStack());
+      stable = created.owner;
 
+      // `value` is initialized below. It's a formula that returns the current value of the
+      // resource (or its initial value). Whenever that value changes, we notify React.
       const unsubscribe = TIMELINE.on.change(value, () => {
         notify();
       });
 
-      LIFETIME.link(stable, created);
-
+      // When the component is unmounted, we unsubscribe from the resource's changes, so that
+      // further changes don't notify React. This is mainly for hygiene, but it also prevents
+      // unexpected leaks.
       LIFETIME.on.cleanup(stable, () => {
         unsubscribe();
 
-        lastResource = undefined;
-        marker.update(callerStack());
+        lastResource.didCleanup();
       });
 
+      // Now that we've created the resource, we can notify React that the component has updated.
+      // This gives the component a chance to render with the resource's actual value.
       notify();
     }
 
@@ -121,7 +144,7 @@ function createResource<T>(
     });
 
     on.update(([nextDeps, factory]) => {
-      if (!sameDeps(prev, nextDeps) || lastResource === undefined) {
+      if (!sameDeps(prev, nextDeps) || lastResource.isInactive()) {
         prev = nextDeps;
 
         LIFETIME.finalize(stable);
@@ -131,13 +154,57 @@ function createResource<T>(
     });
 
     const value = Formula(() => {
-      marker.consume();
-
-      return lastResource?.current ?? initialValue;
+      return lastResource.current;
     });
 
     return value;
   });
+}
+
+class LastResource<T> {
+  readonly #initial: T;
+  readonly #cell: Cell<Reactive<T | undefined> | undefined>;
+  #value: Reactive<T | undefined> | undefined;
+  #owner: object | undefined = undefined;
+
+  constructor(initial: T) {
+    this.#initial = initial;
+    this.#cell = Cell(undefined as Reactive<T | undefined> | undefined);
+    this.#value = undefined;
+  }
+
+  get current(): T {
+    return this.#cell.current?.current ?? this.#initial;
+  }
+
+  isInactive(): boolean {
+    return this.#value === undefined;
+  }
+
+  create(factory: (owner: object) => Reactive<T | undefined>): {
+    reactive: Reactive<T | undefined>;
+    owner: object;
+  } {
+    if (this.#owner) {
+      LIFETIME.finalize(this.#owner);
+    }
+
+    const owner = (this.#owner = {});
+    LIFETIME.link(this, owner);
+    const reactive = factory(owner);
+    this.#cell.set(reactive);
+    this.#value = reactive;
+
+    LIFETIME.link(owner, reactive);
+
+    return { reactive, owner };
+  }
+
+  didCleanup(): void {
+    this.#cell.set(undefined);
+    this.#value = undefined;
+    this.#owner = undefined;
+  }
 }
 
 function sameDeps(

--- a/packages/react/react/src/use-setup.ts
+++ b/packages/react/react/src/use-setup.ts
@@ -11,6 +11,13 @@ import { useState } from "react";
 
 import { ReactiveElement } from "./element.js";
 
+/**
+ * Create a stable object that will automatically be cleaned up when the
+ * component is unmounted, **including** when the component is unmounted
+ * temporarily (i.e. when state is [reused] by React).
+ *
+ * [reused]: https://github.com/reactwg/react-18/discussions/19
+ */
 export function useComponent(): object {
   return useLifecycle(({ on }) => {
     const owner = Object.create(null) as object;
@@ -23,6 +30,21 @@ export function useComponent(): object {
   });
 }
 
+/**
+ * Run a callback when the component is mounted, and return the result.
+ *
+ * The callback will be run again if the component is unmounted and then remounted (i.e. when state
+ * is [reused] by React).
+ *
+ * When a component is unmounted (even temporarily), the object returned by `useSetup` will be
+ * finalized. You can therefore use the return value of `useSetup` as the owner of other resources.
+ *
+ * `useSetup` also supports `on.layout` and `on.idle` callbacks, which will be called when React
+ * schedules `useLayoutEffect` callbacks ("layout timing") or `useEffect` callbacks ("idle timing")
+ * respectively.
+ *
+ * [reused]: https://github.com/reactwg/react-18/discussions/19
+ */
 export function useSetup<T>(
   callback: (setup: ReactiveElement) => T,
   description?: string | Description

--- a/packages/react/react/src/use-setup.ts
+++ b/packages/react/react/src/use-setup.ts
@@ -1,15 +1,12 @@
 import { isObject } from "@starbeam/core-utils";
 import { type Description, descriptionFrom } from "@starbeam/debug";
-import { LIFETIME, Reactive, TIMELINE } from "@starbeam/timeline";
-import { type IntoReactiveObject, Factory } from "@starbeam/universal";
-import {
-  setupFunction,
-  unsafeTrackedElsewhere,
-  useLifecycle,
-} from "@starbeam/use-strict-lifecycle";
+import { LIFETIME } from "@starbeam/timeline";
+import { PolledFormula } from "@starbeam/universal";
+import { setupFunction, useLifecycle } from "@starbeam/use-strict-lifecycle";
 import { useState } from "react";
 
 import { ReactiveElement } from "./element.js";
+import { useReactive } from "./use-reactive.js";
 
 /**
  * Create a stable object that will automatically be cleaned up when the
@@ -69,7 +66,6 @@ export function useSetup<T>(
           }, desc);
 
       const nextInstance = setupFunction(() => callback(element));
-      // const nextInstance = callback(element);
 
       lifecycle.on.cleanup(() => {
         if (isObject(nextInstance)) {
@@ -93,7 +89,7 @@ export function useSetup<T>(
 }
 
 export function useReactiveSetup<T>(
-  callback: (setup: ReactiveElement) => IntoReactiveObject<T> | Reactive<T>,
+  callback: (setup: ReactiveElement) => () => T,
   description?: string | Description
 ): T {
   const desc = descriptionFrom({
@@ -102,57 +98,9 @@ export function useReactiveSetup<T>(
     fromUser: description,
   });
 
-  const [, setNotify] = useState({});
+  const instance = useSetup((setup) => {
+    return PolledFormula(callback(setup), desc);
+  }, desc);
 
-  const instance = useLifecycle((lifecycle) => {
-    const element = ReactiveElement.create(() => {
-      setNotify({});
-    }, desc);
-    const nextInstance = unsafeTrackedElsewhere(() => callback(element));
-
-    const setups = TIMELINE.on.change(element, () => {
-      setNotify({});
-    });
-
-    lifecycle.on.update(() => {
-      ReactiveElement.layout(element);
-      ReactiveElement.idle(element);
-    });
-
-    lifecycle.on.cleanup(() => {
-      if (isObject(nextInstance)) {
-        LIFETIME.finalize(nextInstance);
-      }
-      LIFETIME.finalize(element);
-    });
-
-    lifecycle.on.idle(() => {
-      ReactiveElement.idle(element);
-    });
-
-    const reactive = Factory.create(nextInstance);
-
-    lifecycle.on.layout(() => {
-      ReactiveElement.layout(element);
-
-      if (Reactive.is(reactive)) {
-        const unsubscribe = TIMELINE.on.change(reactive, () => {
-          setNotify({});
-        });
-
-        lifecycle.on.cleanup(() => {
-          unsubscribe();
-          LIFETIME.finalize(setups);
-        });
-      }
-    });
-
-    return reactive;
-  });
-
-  if (Reactive.is(instance)) {
-    return unsafeTrackedElsewhere(() => instance.read());
-  } else {
-    return instance;
-  }
+  return useReactive(() => instance.read());
 }

--- a/packages/react/react/tests/use-reactive.spec.ts
+++ b/packages/react/react/tests/use-reactive.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { useReactive, useReactiveSetup } from "@starbeam/react";
-import { Cell, Formula, PolledFormula } from "@starbeam/universal";
+import { Cell, Formula } from "@starbeam/universal";
 import { html, react, testReact } from "@starbeam-workspace/react-test-utils";
 import { useState } from "react";
 import { describe, expect } from "vitest";
@@ -180,7 +180,7 @@ describe("useReactive", () => {
   );
 
   testReact<void, { starbeam: number; react: number }>(
-    "everything in useSetup",
+    "useReactiveSetup",
     async (root) => {
       const result = await root
         .expectStable()
@@ -199,7 +199,7 @@ describe("useReactive", () => {
               cell.update((i) => i + INCREMENT);
             }
 
-            return PolledFormula(() => {
+            return () => {
               const [reactCount, setReactCount] = useState(INITIAL_COUNT);
 
               state.value({ starbeam: cell.current, react: reactCount });
@@ -225,7 +225,7 @@ describe("useReactive", () => {
                   )
                 )
               );
-            });
+            };
           });
         });
 

--- a/packages/react/react/tests/use-resource.spec.ts
+++ b/packages/react/react/tests/use-resource.spec.ts
@@ -212,7 +212,7 @@ describe("useResource", () => {
   );
 });
 
-describe.only("use", () => {
+describe("use", () => {
   testReact.strict<
     unknown,
     | { channel: ChannelInfo | undefined; increment: () => void }

--- a/packages/react/react/tests/use-setup.spec.ts
+++ b/packages/react/react/tests/use-setup.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { entryPoint } from "@starbeam/debug";
-import { useReactive, useReactiveSetup } from "@starbeam/react";
+import { useReactive, useSetup } from "@starbeam/react";
 import { Cell } from "@starbeam/universal";
 import { html, react, testReact } from "@starbeam-workspace/react-test-utils";
 import { describe, expect } from "vitest";
@@ -36,7 +36,7 @@ describe("useSetup", () => {
           }`
       )
       .render((state) => {
-        const reactiveState = useReactiveSetup((setup) => {
+        const reactiveState = useSetup((setup) => {
           const renderState = Cell(
             { state: "rendering" } as State,
             "outer cell"
@@ -59,13 +59,12 @@ describe("useSetup", () => {
         });
 
         return useReactive(() => {
-          state.value(reactiveState);
+          const current = reactiveState.current;
+          state.value(current);
 
           return react.fragment(
-            html.span(reactiveState.state),
-            reactiveState.state === "message"
-              ? html.span(reactiveState.lastMessage)
-              : null
+            html.span(current.state),
+            current.state === "message" ? html.span(current.lastMessage) : null
           );
         });
       });

--- a/packages/universal/debug/src/description/impl.ts
+++ b/packages/universal/debug/src/description/impl.ts
@@ -432,10 +432,20 @@ if (import.meta.env.DEV) {
     }
 
     #name(options: interfaces.DescriptionDescribeOptions): string {
-      if ((this.isAnonymous || options.source) ?? false) {
-        return `${this.fullName} @ ${this.#caller(options)}`;
+      const getName = (): string => {
+        if ((this.isAnonymous || options.source) ?? false) {
+          return `${this.fullName} @ ${this.#caller(options)}`;
+        } else {
+          return this.fullName;
+        }
+      };
+
+      const name = getName();
+
+      if (!this.isAnonymous && options.id) {
+        return `${name} (${this.#idName})`;
       } else {
-        return this.fullName;
+        return name;
       }
     }
 

--- a/packages/universal/interfaces/src/description.d.ts
+++ b/packages/universal/interfaces/src/description.d.ts
@@ -40,7 +40,8 @@ export interface DescriptionArgs {
 }
 
 export interface DescriptionDescribeOptions extends StackFrameDisplayOptions {
-  source?: boolean;
+  source?: boolean | undefined;
+  id?: boolean | undefined;
 }
 
 export interface Description extends DescriptionArgs {

--- a/packages/universal/timeline/src/timeline/protocol.ts
+++ b/packages/universal/timeline/src/timeline/protocol.ts
@@ -91,7 +91,7 @@ export const ReactiveProtocol = {
   log(
     this: void,
     reactive: ReactiveProtocol,
-    options: { implementation?: boolean; source?: boolean } = {}
+    options: { implementation?: boolean; source?: boolean; id?: boolean } = {}
   ): void {
     ReactiveInternals.log(reactive[REACTIVE], options);
   },
@@ -219,7 +219,8 @@ export const ReactiveInternals = {
     {
       implementation = false,
       source = false,
-    }: { implementation?: boolean; source?: boolean } = {}
+      id = false,
+    }: { implementation?: boolean; source?: boolean; id?: boolean } = {}
   ): string {
     const dependencies = [...ReactiveInternals.dependencies(internals)];
     const descriptions = new Set(
@@ -233,7 +234,7 @@ export const ReactiveInternals = {
     const nodes = [...descriptions]
       .map((d) => {
         const description = implementation ? d : d.userFacing;
-        return description.describe({ source });
+        return description.describe({ source, id });
       })
       .filter(isPresent);
 
@@ -243,12 +244,12 @@ export const ReactiveInternals = {
   log(
     this: void,
     internals: interfaces.ReactiveInternals,
-    options: { implementation?: boolean; source?: boolean } = {}
+    options: { implementation?: boolean; source?: boolean; id?: boolean } = {}
   ): void {
     const debug = ReactiveInternals.debug(internals, options);
 
     console.group(
-      ReactiveInternals.description(internals).describe(),
+      ReactiveInternals.description(internals).describe({ id: options.id }),
       `(updated at ${
         Timestamp.debug(ReactiveInternals.lastUpdated(internals)).at
       })`

--- a/packages/universal/universal/src/reactive-core/delegate.ts
+++ b/packages/universal/universal/src/reactive-core/delegate.ts
@@ -29,10 +29,11 @@ export function DelegateInternals(
   };
 }
 
-export function Wrap<
-  T extends Record<PropertyKey, unknown>,
-  U extends interfaces.ReactiveCore
->(reactive: U, value: T, desc?: Description | string): T & U {
+export function Wrap<T, U extends interfaces.ReactiveCore>(
+  reactive: U,
+  value: T,
+  desc?: Description | string
+): T & U {
   Object.defineProperty(value, REACTIVE, {
     configurable: true,
     writable: true,

--- a/packages/universal/universal/src/reactive-core/formula/formula.ts
+++ b/packages/universal/universal/src/reactive-core/formula/formula.ts
@@ -36,6 +36,7 @@ export function FormulaValidation<T>(
         updating: frame,
         evaluate: callback,
       });
+
       TIMELINE.update(frame);
 
       const newDeps = new Set(ReactiveProtocol.dependencies(frame));

--- a/packages/universal/universal/src/reactive-core/into.ts
+++ b/packages/universal/universal/src/reactive-core/into.ts
@@ -6,8 +6,8 @@ import { type Blueprint, type ReactiveFactory, Reactive } from "./reactive.js";
 import { ResourceBlueprint } from "./resource/resource.js";
 import { type ResourceFactory, Resource } from "./resource/resource.js";
 
-export type IntoResource<T> =
-  | ResourceBlueprint<T, undefined>
+export type IntoResource<T, Initial extends undefined = undefined> =
+  | ResourceBlueprint<T, Initial>
   | ReactiveBlueprint<T>
   | ResourceFactory<T>;
 

--- a/packages/universal/universal/src/reactive-core/resource/resource.ts
+++ b/packages/universal/universal/src/reactive-core/resource/resource.ts
@@ -38,6 +38,8 @@ export type ResourceFactory<T> =
  * quite a bit, and even getting cleaned up and reinitialized behind the scenes.
  */
 
+// TODO: Pass the `initial` value into the resource constructor, if an `initial` value exists.
+
 export function Resource<T, D extends undefined>(
   create: ResourceBlueprint<T, D>,
   description?: string | Description

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,6 +543,7 @@ importers:
       '@starbeam-dev/build-support': workspace:*
       '@starbeam/core-utils': workspace:^
       '@starbeam/debug': workspace:^
+      '@starbeam/interfaces': workspace:^
       '@starbeam/js': workspace:^
       '@starbeam/modifier': workspace:^
       '@starbeam/shared': workspace:^
@@ -556,6 +557,7 @@ importers:
     dependencies:
       '@starbeam/core-utils': link:../../universal/core-utils
       '@starbeam/debug': link:../../universal/debug
+      '@starbeam/interfaces': link:../../universal/interfaces
       '@starbeam/js': link:../../universal/js
       '@starbeam/modifier': link:../../universal/modifier
       '@starbeam/shared': link:../../universal/shared
@@ -880,7 +882,7 @@ importers:
       vite: 3.2.3
       vite-plugin-mpa: ^1.1.3
     devDependencies:
-      '@crxjs/vite-plugin': 2.0.0-beta.6
+      '@crxjs/vite-plugin': 2.0.0-beta.7
       chrome-types: 0.1.148
       dirfilename: 1.1.1
       preact: 10.11.2
@@ -2779,8 +2781,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@crxjs/vite-plugin/2.0.0-beta.6:
-    resolution: {integrity: sha512-4U7JE0BvawWYx5ORKHaeHsk1745K59EhQBFu2YrWa0g2qzaiExXzsEITKav0JomLhGny1Kglc7hyUxFWnOxa8g==}
+  /@crxjs/vite-plugin/2.0.0-beta.7:
+    resolution: {integrity: sha512-5BLtVwg65Rj+KxhODP1RJ83UCgaCZno6Yl9c1FBCkoPQ2vy+NcBgUvUuI2U/7mePIl7xP5X7Xs57Xjd9Gcg58w==}
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@webcomponents/custom-elements': 1.5.1


### PR DESCRIPTION
This PR:

- Fixes the reported bug, which failed to re-create the resource when the dependencies change.
- Fixes a related bug, where the callback passed to `use()` wasn't treated as part of the resource constructor, so Starbeam dependencies didn't invalidate it.
- Adds tests