### PR TITLE
Trim down tag protocol

### DIFF
--- a/packages/preact/preact/src/frame.ts
+++ b/packages/preact/preact/src/frame.ts
@@ -1,16 +1,16 @@
 import { getLast } from "@starbeam/core-utils";
-import type { Description } from "@starbeam/interfaces";
+import type { CoreFormulaTag, Description } from "@starbeam/interfaces";
 import type { InternalComponent } from "@starbeam/preact-utils";
 import type { FinalizedFormula, InitializingFormula } from "@starbeam/reactive";
 import { FormulaLifecycle } from "@starbeam/reactive";
 import { PUBLIC_TIMELINE, RUNTIME, type Unsubscribe } from "@starbeam/runtime";
-import { createFormulaTag, type FormulaTag } from "@starbeam/tags";
+import { createFormulaTag } from "@starbeam/tags";
 import { expected, isPresent, verify } from "@starbeam/verify";
 
 export class ComponentFrame {
   #active: InitializingFormula | null;
   #frame: FinalizedFormula | null;
-  #tag: FormulaTag;
+  #tag: CoreFormulaTag;
   #subscription: Unsubscribe | null;
 
   static #frames = new WeakMap<InternalComponent, ComponentFrame>();

--- a/packages/universal/debug/src/tag.ts
+++ b/packages/universal/debug/src/tag.ts
@@ -1,5 +1,5 @@
 import { isPresent } from "@starbeam/core-utils";
-import type { Description, Tag } from "@starbeam/interfaces";
+import type { CoreTag, Description } from "@starbeam/interfaces";
 import { RUNTIME } from "@starbeam/reactive";
 
 import { Tree } from "./tree.js";
@@ -7,7 +7,7 @@ import { Tree } from "./tree.js";
 RUNTIME;
 
 export const debugTag = (
-  tag: Tag,
+  tag: CoreTag,
   {
     implementation = false,
   }: { implementation?: boolean; source?: boolean; id?: boolean } = {}
@@ -30,7 +30,7 @@ export const debugTag = (
 };
 
 export const logTag = (
-  tag: Tag,
+  tag: CoreTag,
   options: { implementation?: boolean; source?: boolean; id?: boolean } = {}
 ): void => {
   const debug = debugTag(tag, options);

--- a/packages/universal/interfaces/index.ts
+++ b/packages/universal/interfaces/index.ts
@@ -1,21 +1,20 @@
+export type {
+  CoreCellTag,
+  CoreDelegateTag,
+  CoreFormulaTag,
+  CoreStaticTag,
+  CoreTag,
+  CoreTarget,
+} from "./src/core.js";
 export type * from "./src/debug/call-stack.js";
 export type * from "./src/debug/debug-runtime.js";
 export type * from "./src/debug/description.js";
 export type {
-  CellTag,
-  DelegateTag,
-  FormulaTag,
   Reactive,
-  ReactiveCell,
-  ReactiveFormula,
   ReactiveId,
   ReactiveValue,
-  StaticTag,
-  SubscriptionTarget,
-  Tag,
   Tagged,
   TaggedReactive,
-  TagMethods,
   TagSet,
 } from "./src/protocol.js";
 export type {

--- a/packages/universal/interfaces/src/core.ts
+++ b/packages/universal/interfaces/src/core.ts
@@ -1,0 +1,82 @@
+import type { Description } from "../index.js";
+import type { Timestamp } from "./timestamp.js";
+
+/**
+ * A tag validates a reactive value. The behavior of a tags is defined in relation to reads and
+ * writes of the reactive value they represent. Tags model **value composition** (and functional
+ * composition), not a more general algebra.
+ *
+ * In other words, it doesn't make sense to think about the composition of tags abstracted from the
+ * values they represent. Attempting to think about tags this way makes them seem more general than
+ * they are, and that generality breaks system invariants derived from value composition.
+ */
+export interface CoreTag {
+  readonly type: "cell" | "formula" | "delegate" | "static";
+  readonly description?: Description | undefined;
+  readonly lastUpdated: Timestamp;
+  readonly dependencies: () => readonly CoreCellTag[];
+  readonly targets: readonly CoreTarget[];
+}
+
+/**
+ * Cell is the fundamental mutable reactive value. All subscriptions in Starbeam are ultimately
+ * subscriptions to cells, and all mutations in Starbeam are ultimately mutations to cells.
+ */
+export interface CoreCellTag extends CoreTag {
+  readonly type: "cell";
+}
+
+/**
+ * Formula is a reactive that has *dynamic* children. This means that you can't cache the children
+ * (or subscribe directly to them), because they may change. This is different from delegates, which
+ * are guaranteed to have the same set of children forever.
+ *
+ * Composite reactives must notify the timeline when their children have changed.
+ *
+ * A subscription to a composite reactive is a subscription to its current children, as of the last
+ * time the timeline was notified of changes to the composite's children. Whenever the timeline is
+ * notified of a change to the composite's children, it removes subscriptions from any stale
+ * dependencies and adds subscriptions to any new dependencies.
+ */
+export interface CoreFormulaTag extends CoreTag {
+  readonly type: "formula";
+  readonly initialized: boolean;
+}
+
+/**
+ * Delegate is a reactive that represents one or more reactives, but that set of reactives cannot
+ * change. This allows you to cache the value of the `delegate` property, and it also allows you to
+ * subscribe directly to the delegate's targets.
+ *
+ * In practice, when you subscribe to a delegate, the timeline subscribes directly to the delegate's
+ * targets. This means that delegates don't need to know when their value changes, and don't need to
+ * notify the timeline when their targets change.
+ */
+export interface CoreDelegateTag extends CoreTag {
+  readonly type: "delegate";
+}
+
+/**
+ * Static is a reactive that is guaranteed not to change. This means that you can cache the value of
+ * the static reactive and don't need to include it in composite children. All validation semantics
+ * act as if static reactives were not present.
+ *
+ * If a formula or delegate has only static children, it is also static. Even though a formula's
+ * children can change, if the formula's *only* children are static, then the formula can never
+ * invalidate, and therefore it, itself, is treated as static.
+ *
+ * TODO: Do we need a separate fundamental type for pollable formulas, which can get new
+ * dependencies even if they never invalidate?
+ */
+export interface CoreStaticTag extends CoreTag {
+  readonly type: "static";
+}
+
+/**
+ * Cells and formulas can be subscribed to directly.
+ *
+ * A subscription to a formula is a dynamic subscription to its current dependencies.
+ * A subscription to a delegate is equivalent to subscribing to its (stable) targets.
+ * A subscription to a static is equivalent to subscribing to nothing.
+ */
+export type CoreTarget = CoreCellTag | CoreFormulaTag;

--- a/packages/universal/interfaces/src/debug/debug-runtime.ts
+++ b/packages/universal/interfaces/src/debug/debug-runtime.ts
@@ -1,4 +1,5 @@
-import type { Tag, Tagged } from "../protocol.js";
+import type { CoreCellTag } from "../core.js";
+import type { Tagged } from "../protocol.js";
 import type { CallerStackFn, CallStack } from "./call-stack.js";
 import type { DescFn, DescriptionDetails } from "./description.js";
 
@@ -15,7 +16,7 @@ export interface DebugRuntime {
     options?: { id: boolean | undefined } | undefined
   ) => string;
   readonly untrackedReadBarrier: (
-    barrier: (tag: Tag, stack: CallStack | undefined) => void | never
+    barrier: (tag: CoreCellTag, stack: CallStack | undefined) => void | never
   ) => void;
   readonly callerStack: CallerStackFn;
 

--- a/packages/universal/interfaces/src/debug/description.ts
+++ b/packages/universal/interfaces/src/debug/description.ts
@@ -1,9 +1,9 @@
-import type { ReactiveId, Tag } from "../protocol.js";
-import type { Expand } from "../utils.js";
+import type { CoreTag } from "../core.js";
+import type { ReactiveId } from "../protocol.js";
 import type { CallStack, StackFrame } from "./call-stack.js";
 
 export type ReactiveType =
-  | Expand<Tag["type"]>
+  | CoreTag["type"]
   | "resource"
   | "service"
   | "collection"

--- a/packages/universal/interfaces/src/protocol.ts
+++ b/packages/universal/interfaces/src/protocol.ts
@@ -1,124 +1,11 @@
 import type { TAG } from "@starbeam/shared";
 
+import type { CoreTag } from "./core.js";
 import type { CallStack } from "./debug/call-stack.js";
-import type { Description } from "./debug/description.js";
-import type { UpdateOptions } from "./runtime.js";
-import type { Timestamp } from "./timestamp.js";
 
 export type ReactiveId = number | string | ReactiveId[];
 
-export type TagSet = ReadonlySet<Tag>;
-
-export declare class TagMethods {
-  readonly lastUpdated: Timestamp;
-  readonly dependencies: () => readonly CellTag[];
-}
-
-/**
- * Cell is the fundamental mutable reactive value. All subscriptions in Starbeam are ultimately
- * subscriptions to cells, and all mutations in Starbeam are ultimately mutations to cells.
- */
-export interface CellTag extends TagMethods {
-  readonly type: "cell";
-  readonly description: Description | undefined;
-  readonly lastUpdated: Timestamp;
-  isFrozen: () => boolean;
-  freeze: () => void;
-  update: (options: UpdateOptions) => void;
-}
-
-/**
- * Formula is a reactive that has *dynamic* children. This means that you can't cache the children
- * (or subscribe directly to them), because they may change. This is different from delegates, which
- * are guaranteed to have the same set of children forever.
- *
- * Composite reactives must notify the timeline when their children have changed.
- *
- * A subscription to a composite reactive is a subscription to its current children, as of the last
- * time the timeline was notified of changes to the composite's children. Whenever the timeline is
- * notified of a change to the composite's children, it removes subscriptions from any stale
- * dependencies and adds subscriptions to any new dependencies.
- */
-export interface FormulaTag extends TagMethods {
-  readonly type: "formula";
-  readonly description: Description | undefined;
-
-  /**
-   * This flag starts out as false, when the formula hasn't been computed yet.
-   * Any subscriptions to an uninitialized formula will be deferred until the
-   * formula is initialized.
-   */
-  readonly initialized: boolean;
-
-  /**
-   * This method should be called by the formula's implementation after it is
-   * first computed, but before the timeline's `update` method is called.
-   */
-  markInitialized: () => void;
-
-  /**
-   * The current children of this formula. Note that "no children" does not
-   * necessarily mean that the formula is static, because a formula has no
-   * children before it was first initialized.
-   *
-   * Data structures built on `FormulaTag` should always read the formula before
-   * attempting to read the children if they plan to rely on the absence of
-   * children as a strong indicator of staticness.
-   */
-  children: () => ReadonlySet<Tag>;
-}
-
-/**
- * Delegate is a reactive that represents one or more reactives, but that set of reactives cannot
- * change. This allows you to cache the value of the `delegate` property, and it also allows you to
- * subscribe directly to the delegate's targets.
- *
- * In practice, when you subscribe to a delegate, the timeline subscribes directly to the delegate's
- * targets. This means that delegates don't need to know when their value changes, and don't need to
- * notify the timeline when their targets change.
- */
-export interface DelegateTag extends TagMethods {
-  readonly type: "delegate";
-  readonly description: Description | undefined;
-  readonly targets: readonly Tag[];
-}
-
-/**
- * Static is a reactive that is guaranteed not to change. This means that you can cache the value of
- * the static reactive and don't need to include it in composite children. All validation semantics
- * act as if static reactives were not present.
- *
- * If a formula or delegate has only static children, it is also static. Even though a formula's
- * children can change, if the formula's *only* children are static, then the formula can never
- * invalidate, and therefore it, itself, is treated as static.
- *
- * TODO: Do we need a separate fundamental type for pollable formulas, which can get new
- * dependencies even if they never invalidate?
- */
-export interface StaticTag extends TagMethods {
-  readonly type: "static";
-  readonly description: Description | undefined;
-}
-
-/**
- * A tag validates a reactive value. The behavior of a tags is defined in relation to reads and
- * writes of the reactive value they represent. Tags model **value composition** (and functional
- * composition), not a more general algebra.
- *
- * In other words, it doesn't make sense to think about the composition of tags abstracted from the
- * values they represent. Attempting to think about tags this way makes them seem more general than
- * they are, and that generality breaks system invariants derived from value composition.
- */
-export type Tag = CellTag | FormulaTag | DelegateTag | StaticTag;
-
-/**
- * Cells and formulas can be subscribed to directly.
- *
- * A subscription to a formula is a dynamic subscription to its current dependencies.
- * A subscription to a delegate is equivalent to subscribing to its (stable) targets.
- * A subscription to a static is equivalent to subscribing to nothing.
- */
-export type SubscriptionTarget = CellTag | FormulaTag;
+export type TagSet = ReadonlySet<CoreTag>;
 
 /**
  * A `Tagged` object is a reactive object that has a `Tag` (which is used to
@@ -135,11 +22,11 @@ export type SubscriptionTarget = CellTag | FormulaTag;
  * allows you to keep the tag stable while varying the children (which *are*
  * allowed to change, since that's the point of `FormulaTag`).
  */
-export interface Tagged<I extends Tag = Tag> {
+export interface Tagged<I extends CoreTag = CoreTag> {
   readonly [TAG]: I;
 }
 
-export interface ReactiveValue<T = unknown, I extends Tag = Tag>
+export interface ReactiveValue<T = unknown, I extends CoreTag = CoreTag>
   extends Tagged<I> {
   read: (stack?: CallStack) => T;
 }
@@ -148,23 +35,7 @@ export interface Reactive<T> extends ReactiveValue<T> {
   readonly current: T;
 }
 
-export interface TaggedReactive<I extends Tag, T = unknown>
+export interface TaggedReactive<I extends CoreTag, T = unknown>
   extends ReactiveValue<T, I> {
-  readonly current: T;
-}
-
-export interface ReactiveCell<T> extends ReactiveValue<T, CellTag> {
-  current: T;
-  /**
-   * Set the value of the cell. Returns true if the value was changed, false if
-   * the current value was equivalent to the new value.
-   */
-  set: (value: T, caller?: CallStack) => boolean;
-  update: (fn: (value: T) => T, caller?: CallStack) => void;
-  freeze: () => void;
-}
-
-export interface ReactiveFormula<T> extends ReactiveValue<T, FormulaTag> {
-  (): T;
   readonly current: T;
 }

--- a/packages/universal/interfaces/src/runtime.ts
+++ b/packages/universal/interfaces/src/runtime.ts
@@ -1,6 +1,6 @@
+import type { CoreCellTag, CoreFormulaTag, CoreTag } from "./core.js";
 import type { CallStack } from "./debug/call-stack.js";
 import type { DebugRuntime } from "./debug/debug-runtime.js";
-import type { CellTag, FormulaTag, Tag } from "./protocol.js";
 import type { Timestamp } from "./timestamp.js";
 import type { Unsubscribe } from "./utils.js";
 
@@ -10,19 +10,19 @@ export interface Runtime {
   readonly debug: DebugRuntime | undefined;
 }
 
-export type NotifyReady = (internals: CellTag) => void;
+export type NotifyReady = (internals: CoreCellTag) => void;
 
 export interface SubscriptionRuntime {
-  subscribe: (target: Tag, ready: NotifyReady) => Unsubscribe;
-  bump: (cell: CellTag, update: (revision: Timestamp) => void) => void;
-  update: (formula: FormulaTag) => void;
+  subscribe: (target: CoreTag, ready: NotifyReady) => Unsubscribe;
+  bump: (cell: CoreCellTag, update: (revision: Timestamp) => void) => void;
+  update: (formula: CoreFormulaTag) => void;
 }
 
-export type ActiveFrame = () => Set<Tag>;
+export type ActiveFrame = () => Set<CoreTag>;
 
 export interface AutotrackingRuntime {
   start: () => ActiveFrame;
-  consume: (tag: Tag) => void;
+  consume: (tag: CoreTag) => void;
 }
 
 export interface ActiveRuntimeFrame {
@@ -41,5 +41,5 @@ export interface TrackingStack {
 }
 
 export interface TrackingFrame {
-  done: () => Set<Tag>;
+  done: () => Set<CoreTag>;
 }

--- a/packages/universal/reactive/src/primitives/cell.ts
+++ b/packages/universal/reactive/src/primitives/cell.ts
@@ -1,16 +1,30 @@
-import type { Description, ReactiveCell } from "@starbeam/interfaces";
+import type {
+  CallStack,
+  CoreCellTag,
+  Description,
+  ReactiveValue,
+} from "@starbeam/interfaces";
 import { TAG } from "@starbeam/shared";
 import { createCellTag } from "@starbeam/tags";
 
 import { RUNTIME } from "../runtime.js";
 import { isDescriptionOption, type PrimitiveOptions } from "./utils.js";
 
-export type Cell<T = unknown> = ReactiveCell<T>;
+export interface Cell<T = unknown> extends ReactiveValue<T, CoreCellTag> {
+  current: T;
+  /**
+   * Set the value of the cell. Returns true if the value was changed, false if
+   * the current value was equivalent to the new value.
+   */
+  set: (value: T, caller?: CallStack) => boolean;
+  update: (fn: (value: T) => T, caller?: CallStack) => void;
+  freeze: () => void;
+}
 
 export function Cell<T>(
   value: T,
   options?: CellOptions<T> | string | Description | undefined
-): ReactiveCell<T> {
+): Cell<T> {
   const { description, equals = Object.is } = toCellOptions(options);
   const desc = RUNTIME.Desc?.("cell", description);
   const tag = createCellTag(desc);

--- a/packages/universal/reactive/src/primitives/delegate.ts
+++ b/packages/universal/reactive/src/primitives/delegate.ts
@@ -18,7 +18,7 @@ export function Wrap<T, U extends ReactiveValue>(
   readonly(
     value,
     TAG,
-    createDelegateTag(delegateDesc(reactive, desc), [getTag(reactive)])
+    createDelegateTag(delegateDesc(reactive, desc), getTag(reactive).targets)
   );
 
   defMethod(

--- a/packages/universal/reactive/src/primitives/formula-lifecycle.ts
+++ b/packages/universal/reactive/src/primitives/formula-lifecycle.ts
@@ -1,4 +1,4 @@
-import type { Tag } from "@starbeam/interfaces";
+import type { CoreTag } from "@starbeam/interfaces";
 import { lastUpdated, NOW } from "@starbeam/tags";
 
 import { RUNTIME } from "../runtime.js";
@@ -11,7 +11,7 @@ export function FormulaLifecycle(): InitializingFormula {
   };
 }
 
-function FinalizedFormula(children: Set<Tag>): FinalizedFormula {
+function FinalizedFormula(children: Set<CoreTag>): FinalizedFormula {
   let lastValidated = NOW.now;
 
   const isStale = () => lastUpdated(...children).gt(lastValidated);
@@ -43,6 +43,6 @@ export interface InitializingFormula {
 
 export interface FinalizedFormula {
   readonly isStale: () => boolean;
-  readonly children: () => Set<Tag>;
+  readonly children: () => Set<CoreTag>;
   readonly update: () => InitializingFormula;
 }

--- a/packages/universal/reactive/src/primitives/formula.ts
+++ b/packages/universal/reactive/src/primitives/formula.ts
@@ -1,4 +1,8 @@
-import type { ReactiveFormula, TagSet } from "@starbeam/interfaces";
+import type {
+  CoreFormulaTag,
+  CoreTag,
+  ReactiveValue,
+} from "@starbeam/interfaces";
 import { TAG } from "@starbeam/shared";
 import { createFormulaTag } from "@starbeam/tags";
 
@@ -10,7 +14,10 @@ import {
   WrapFn,
 } from "./utils.js";
 
-export type Formula<T> = ReactiveFormula<T>;
+export interface Formula<T = unknown> extends ReactiveValue<T, CoreFormulaTag> {
+  (): T;
+  readonly current: T;
+}
 
 export function Formula<T>(
   compute: () => T,
@@ -18,7 +25,7 @@ export function Formula<T>(
 ): FormulaFn<T> {
   const { description } = toOptions(options);
   const desc = RUNTIME.Desc?.("formula", description);
-  let children: TagSet = new Set();
+  let children = new Set<CoreTag>();
   const tag = createFormulaTag(desc, () => children);
 
   function read(_caller = RUNTIME.callerStack?.()): T {

--- a/packages/universal/reactive/src/primitives/marker.ts
+++ b/packages/universal/reactive/src/primitives/marker.ts
@@ -1,11 +1,11 @@
-import type { CallStack, CellTag, Tagged } from "@starbeam/interfaces";
+import type { CallStack, CoreCellTag, Tagged } from "@starbeam/interfaces";
 import { TAG } from "@starbeam/shared";
 import { createCellTag } from "@starbeam/tags";
 
 import { RUNTIME } from "../runtime.js";
 import { type SugaryPrimitiveOptions, toOptions } from "./utils.js";
 
-export interface Marker extends Tagged<CellTag> {
+export interface Marker extends Tagged<CoreCellTag> {
   read: (caller?: CallStack) => void;
   mark: (caller?: CallStack) => void;
   freeze: () => void;

--- a/packages/universal/reactive/src/primitives/static.ts
+++ b/packages/universal/reactive/src/primitives/static.ts
@@ -1,11 +1,11 @@
-import type { StaticTag, TaggedReactive } from "@starbeam/interfaces";
+import type { CoreStaticTag, TaggedReactive } from "@starbeam/interfaces";
 import { TAG } from "@starbeam/shared";
 import { createStaticTag } from "@starbeam/tags";
 
 import { RUNTIME } from "../runtime.js";
 import type { PrimitiveOptions } from "./utils.js";
 
-export type Static<T> = TaggedReactive<StaticTag, T>;
+export type Static<T> = TaggedReactive<CoreStaticTag, T>;
 
 export function Static<T>(
   value: T,

--- a/packages/universal/reactive/src/primitives/utils.ts
+++ b/packages/universal/reactive/src/primitives/utils.ts
@@ -1,7 +1,7 @@
 import type {
+  CoreFormulaTag,
+  CoreTag,
   Description,
-  FormulaTag,
-  Tag,
   TaggedReactive,
 } from "@starbeam/interfaces";
 import { TAG } from "@starbeam/shared";
@@ -34,7 +34,7 @@ export function toOptions(options: SugaryPrimitiveOptions): PrimitiveOptions {
   }
 }
 
-export interface FormulaFn<T> extends TaggedReactive<FormulaTag, T> {
+export interface FormulaFn<T> extends TaggedReactive<CoreFormulaTag, T> {
   (): T;
 }
 
@@ -42,12 +42,12 @@ export function isFormulaFn<T>(value: unknown): value is FormulaFn<T> {
   return !!(
     typeof value === "function" &&
     TAG in value &&
-    (value[TAG] as Tag).type === "formula"
+    (value[TAG] as CoreTag).type === "formula"
   );
 }
 
 export function WrapFn<T>(
-  formula: TaggedReactive<FormulaTag, T>
+  formula: TaggedReactive<CoreFormulaTag, T>
 ): FormulaFn<T> {
   // If the formula is *already* a function, we just need a new identity for it,
   // so we'll wrap it in a simple proxy.

--- a/packages/universal/reactive/src/runtime.ts
+++ b/packages/universal/reactive/src/runtime.ts
@@ -1,12 +1,12 @@
 import type {
   AutotrackingRuntime,
   CallerStackFn,
+  CoreTag,
   DebugRuntime,
   DescFn,
   DescriptionDetails,
   Runtime,
   SubscriptionRuntime,
-  Tag,
 } from "@starbeam/interfaces";
 import { isPresent, verified } from "@starbeam/verify";
 
@@ -63,7 +63,7 @@ class RuntimeImpl implements Runtime {
     }
   }
 
-  evaluate<T>(compute: () => T): { value: T; tags: Set<Tag> } {
+  evaluate<T>(compute: () => T): { value: T; tags: Set<CoreTag> } {
     const done = this.autotracking.start();
     const value = compute();
     const tags = done();

--- a/packages/universal/runtime/index.ts
+++ b/packages/universal/runtime/index.ts
@@ -16,6 +16,6 @@ export {
 } from "./src/timeline/tracker.js";
 export { diff } from "./src/timeline/utils.js";
 export { AUTOTRACKING_RUNTIME } from "./src/tracking-stack.js";
-export type { Tag, Tagged } from "@starbeam/interfaces";
+export type { Tagged } from "@starbeam/interfaces";
 export { TAG } from "@starbeam/shared";
 export { getTag, Timestamp } from "@starbeam/tags";

--- a/packages/universal/runtime/src/timeline/tracker.ts
+++ b/packages/universal/runtime/src/timeline/tracker.ts
@@ -1,14 +1,14 @@
 import type {
-  CellTag,
-  FormulaTag,
+  CoreCellTag,
+  CoreFormulaTag,
+  CoreTag,
   NotifyReady,
   SubscriptionRuntime,
-  Tag,
   Tagged,
   Unsubscribe,
 } from "@starbeam/interfaces";
 import { isTagged } from "@starbeam/reactive";
-import { getTag, getTargets, type Timestamp } from "@starbeam/tags";
+import { getTag, type Timestamp } from "@starbeam/tags";
 import { NOW } from "@starbeam/tags";
 
 import { Subscriptions } from "./subscriptions.js";
@@ -31,17 +31,17 @@ class Mutations implements SubscriptionRuntime {
   readonly #subscriptions = Subscriptions.create();
   readonly #lastPhase: Phase = Phase.read;
 
-  subscribe(target: Tag, ready: NotifyReady): Unsubscribe {
+  subscribe(target: CoreTag, ready: NotifyReady): Unsubscribe {
     return this.#subscriptions.register(target, ready);
   }
 
-  bump(cell: CellTag, update: (revision: Timestamp) => void): void {
+  bump(cell: CoreCellTag, update: (revision: Timestamp) => void): void {
     const revision = this.#updatePhase(Phase.write);
     update(revision);
     this.#subscriptions.notify(cell);
   }
 
-  update(formula: FormulaTag): void {
+  update(formula: CoreFormulaTag): void {
     this.#subscriptions.update(formula);
   }
 
@@ -58,10 +58,10 @@ export const SUBSCRIPTION_RUNTIME = new Mutations();
 
 export class PublicTimeline {
   readonly on = {
-    change: (tagged: Tagged | Tag, ready: NotifyReady): Unsubscribe => {
+    change: (tagged: Tagged | CoreTag, ready: NotifyReady): Unsubscribe => {
       const tag = isTagged(tagged) ? getTag(tagged) : tagged;
       const unsubscribes = new Set<Unsubscribe>();
-      for (const target of getTargets(tag)) {
+      for (const target of tag.targets) {
         unsubscribes.add(SUBSCRIPTION_RUNTIME.subscribe(target, ready));
       }
 

--- a/packages/universal/runtime/src/tracking-stack.ts
+++ b/packages/universal/runtime/src/tracking-stack.ts
@@ -1,4 +1,4 @@
-import type { AutotrackingRuntime, Tag } from "@starbeam/interfaces";
+import type { AutotrackingRuntime, CoreTag } from "@starbeam/interfaces";
 
 export class TrackingStack implements AutotrackingRuntime {
   static create(): TrackingStack {
@@ -7,7 +7,7 @@ export class TrackingStack implements AutotrackingRuntime {
 
   #current: TrackingFrameData | undefined;
 
-  start(): () => Set<Tag> {
+  start(): () => Set<CoreTag> {
     const frame: TrackingFrameData = { consumed: new Set() };
     const parent = this.#current;
     this.#current = frame;
@@ -19,7 +19,7 @@ export class TrackingStack implements AutotrackingRuntime {
     };
   }
 
-  consume(tag: Tag): void {
+  consume(tag: CoreTag): void {
     const current = this.#current;
 
     if (current) {
@@ -29,7 +29,7 @@ export class TrackingStack implements AutotrackingRuntime {
 }
 
 export interface TrackingFrameData {
-  readonly consumed: Set<Tag>;
+  readonly consumed: Set<CoreTag>;
 }
 
 export const AUTOTRACKING_RUNTIME = TrackingStack.create();

--- a/packages/universal/runtime/tests/subscribing.spec.ts
+++ b/packages/universal/runtime/tests/subscribing.spec.ts
@@ -128,9 +128,10 @@ describe("Tagged", () => {
 
     const delegate: ReactiveValue<number> = {
       read: () => sum.read(),
-      [TAG]: createDelegateTag(RUNTIME.Desc?.("delegate", "test delegate"), [
-        getTag(sum),
-      ]),
+      [TAG]: createDelegateTag(
+        RUNTIME.Desc?.("delegate", "test delegate"),
+        getTag(sum).targets
+      ),
     };
 
     let stale = false;

--- a/packages/universal/tags/index.ts
+++ b/packages/universal/tags/index.ts
@@ -3,7 +3,6 @@ export {
   createDelegateTag,
   createFormulaTag,
   createStaticTag,
-  getTargets,
 } from "./src/tag.js";
 export {
   getDependencies,
@@ -21,9 +20,3 @@ export {
   Timestamp,
   zero,
 } from "./src/timestamp.js";
-export type {
-  CellTag,
-  DelegateTag,
-  FormulaTag,
-  StaticTag,
-} from "@starbeam/interfaces";

--- a/packages/universal/tags/src/tagged.ts
+++ b/packages/universal/tags/src/tagged.ts
@@ -1,7 +1,7 @@
 import type {
-  CellTag,
+  CoreCellTag,
+  CoreTag,
   Description,
-  Tag,
   Tagged,
   Timestamp,
 } from "@starbeam/interfaces";
@@ -9,13 +9,13 @@ import { TAG } from "@starbeam/shared";
 
 import { zero } from "./timestamp.js";
 
-type HasTag<T extends Tag = Tag> = T | Tagged<T>;
+type HasTag<T extends CoreTag = CoreTag> = T | Tagged<T>;
 
-export function getTag<T extends Tag>(tagged: HasTag<T>): T {
+export function getTag<T extends CoreTag>(tagged: HasTag<T>): T {
   return TAG in tagged ? tagged[TAG] : tagged;
 }
 
-export function getTags<T extends HasTag<Tag>[]>(
+export function getTags<T extends HasTag[]>(
   tagged: T
 ): { [P in keyof T]: T[P] extends HasTag<infer U> ? U : never } {
   return tagged.map(getTag) as never;
@@ -27,7 +27,7 @@ export function getDescription(tagged: HasTag): Description | undefined {
 
 export function getDependencies(
   ...taggedList: readonly HasTag[]
-): readonly CellTag[] {
+): readonly CoreCellTag[] {
   return taggedList.flatMap((tagged) => getTag(tagged).dependencies());
 }
 

--- a/packages/universal/universal/src/reactive-core/variants.ts
+++ b/packages/universal/universal/src/reactive-core/variants.ts
@@ -1,9 +1,9 @@
 import { DisplayStruct } from "@starbeam/core-utils";
 import type {
   CallStack,
-  DelegateTag,
+  CoreDelegateTag,
+  CoreFormulaTag,
   Description,
-  FormulaTag,
 } from "@starbeam/interfaces";
 import { Cell, Marker, RUNTIME } from "@starbeam/reactive";
 import type { Tagged } from "@starbeam/runtime";
@@ -122,7 +122,7 @@ export class VariantGroup {
   }
 }
 
-export class Variant<T> implements Tagged<DelegateTag> {
+export class Variant<T> implements Tagged<CoreDelegateTag> {
   static selected<T>(
     type: string,
     typeMarker: Marker,
@@ -228,7 +228,7 @@ export class Variant<T> implements Tagged<DelegateTag> {
     value: T | UNINITIALIZED;
   };
   readonly #value: Cell<T | UNINITIALIZED>;
-  readonly [TAG]: DelegateTag;
+  readonly [TAG]: CoreDelegateTag;
 
   private constructor(
     type: string,
@@ -236,7 +236,7 @@ export class Variant<T> implements Tagged<DelegateTag> {
     localTypeMarker: Marker,
     value: Cell<T | UNINITIALIZED>,
     debug: { value: T | UNINITIALIZED },
-    reactive: DelegateTag
+    reactive: CoreDelegateTag
   ) {
     this.#type = type;
     this.#sharedTypeMarker = sharedTypeMarker;
@@ -341,7 +341,7 @@ export interface Variants<V extends VariantType, Narrow = V> extends Tagged {
       | undefined);
 }
 
-class VariantsImpl implements Tagged<FormulaTag> {
+class VariantsImpl implements Tagged<CoreFormulaTag> {
   static create(
     value: InternalVariant,
     description: Description | undefined
@@ -364,7 +364,7 @@ class VariantsImpl implements Tagged<FormulaTag> {
   readonly #typeMarker: Marker;
   readonly #groups: VariantGroups;
   readonly #description: Description | undefined;
-  readonly [TAG]: FormulaTag;
+  readonly [TAG]: CoreFormulaTag;
   #current: Variant<unknown>;
 
   private constructor(

--- a/packages/x/devtool/src/log/frame.tsx
+++ b/packages/x/devtool/src/log/frame.tsx
@@ -5,7 +5,7 @@
 /** @jsxRuntime automatic @jsxImportSource preact */
 
 import { logTag } from "@starbeam/debug";
-import type { CellTag, Timestamp } from "@starbeam/interfaces";
+import type { CoreCellTag, Timestamp } from "@starbeam/interfaces";
 import type { JSX } from "preact";
 
 import { DescribeLeaf } from "./describe.js";
@@ -58,7 +58,7 @@ function List({
   cells,
   change,
 }: {
-  cells: Set<CellTag>;
+  cells: Set<CoreCellTag>;
   change: "add" | "remove";
 }): JSX.Element | null {
   if (cells.size === EMPTY_SET) {

--- a/turbo.json
+++ b/turbo.json
@@ -7,6 +7,13 @@
     },
     "test:lint": {
       "outputs": []
+    },
+    "test:types": {
+      "outputs": []
+    },
+    "typecheck": {
+      "dependsOn": ["test:types"],
+      "outputs": []
     }
   }
 }

--- a/workspace/scripts/src/scripts.json
+++ b/workspace/scripts/src/scripts.json
@@ -8,7 +8,7 @@
     "cwd": "${package.root}"
   },
   "types": {
-    "command": "tsc -b",
+    "command": "turbo run typecheck --output-logs errors-only",
     "cwd": "${package.root}"
   }
 }


### PR DESCRIPTION
The previous iteration of the protocol included internal details that aren't needed for composition.

This change shrinks down the protocol to make it easier to move the stack aspects of the runtime into @starbeam/shared.