### PR TITLE
Updated internal documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,13 +30,10 @@
   // trying to format the code.
   "editor.formatOnSave": false,
 
-  "eslint.codeActionsOnSave.mode": "all",
+  "eslint.codeActionsOnSave.mode": "problems",
   "eslint.enable": true,
   "eslint.lintTask.enable": true,
   "eslint.lintTask.options": "--cache -c ./.eslintrc.json --max-warnings=0 \"**/*.ts\" \"**/*.tsx\" \"**/*.json\"",
-  "eslint.onIgnoredFiles": "warn",
-  "eslint.problems.shortenToSingleLine": true,
-  "eslint.quiet": false,
   "eslint.validate": [
     "javascript",
     "javascriptreact",
@@ -81,6 +78,7 @@
   "inline-bookmarks.view.exclude.gitIgnore": true,
 
   "inline-bookmarks.view.showVisibleFilesOnly": false,
+  "markdown.validate.enabled": true,
   "npm-outdated.decorations": "fancy",
   // rewrap provides a quick keyboard shortcut (alt-q) to reformat comments to
   // a specific column width. It also automatically rewraps comments when you

--- a/README.md
+++ b/README.md
@@ -8,17 +8,27 @@ Starbeam is a new kind of reactive library. It makes reactive programming simple
 
 </center>
 
+---
+
 [docs]: https://starbeamjs.com
 [discord]: https://discord.gg/HXq3PMmj8A
 
-It interoperates natively with React state management patterns, Svelte stores,
-the Vue composition API, and Ember's auto-tracking system.
+The core concepts of Starbeam are documented in the [docs] for users of Starbeam.
 
-## The Big Picture
+The package READMEs have additional implementor-focused documentation:
 
-- **Use normal JavaScript APIs and access patterns.** Build reactive data structures using reactive versions of JavaScript built-ins like objects, arrays, maps, and sets, and update them exactly as you would with normal JavaScript.
-- **No delays.** Updates to reactive values take effect immediately. Your reactive data and computations are always coherent, just like normal JavaScript.
-- **Works everywhere.** You don't need to learn a new framework to take advantage of Starbeam's cutting edge reactive system. You can render Starbeam data using renderers designed for your framework of choice, or even build your own renderer.
-- **TypeScript types are a first-class consideration.** Every part of Starbeam's API was designed from the ground up using TypeScript types with careful attention to the details. And if you're not a TypeScript user, you can still get the benefit in normal JavaScript code through inline suggestions, documentation and tab completion in your editor, no configuration needed.
+- [@starbeam/shared]: Primitive Starbeam fundamentals. This package enables multiple
+  copies of Starbeam to interoperate, including across major versions of Starbeam.
+- [@starbeam/tags]: The core of Starbeam's demand-driven validation system.
+- [@starbeam/reactive]: The implementation of Starbeam's fundamental reactive
+  values (cells and formulas).
+- [@starbeam/collections]: Starbeam's reactive collections: reactive
+  implementations of JavaScript's built-in collections (object, array,
+  `Map`, `Set`, `WeakMap`, and `WeakSet`).
 
-Get started with Starbeam and learn more at the [docs website](https://starbeamjs.com).
+More READMEs are coming.
+
+[@starbeam/shared]: ./packages/universal/shared/README.md
+[@starbeam/tags]: ./packages/universal/tags/README.md
+[@starbeam/reactive]: ./packages/universal/reactive/README.md
+[@starbeam/collections]: ./packages/universal/collections/README.md

--- a/packages/universal/collections/README.md
+++ b/packages/universal/collections/README.md
@@ -1,0 +1,120 @@
+# Starbeam Collections
+
+Starbeam collections are reactive implementations of JavaScript built-in
+collections.
+
+- [Object]
+- [Array]
+- [Map]
+- [Set]
+- [WeakMap]
+- [WeakSet]
+
+Starbeam collections behave identically to the JavaScript built-ins that they
+implement.
+
+> 📢 Starbeam Collections do not support prototype mutation. This is the only known
+> divergence from the JavaScript APIs.
+
+Internally, Starbeam collections model JavaScript read operations in one of
+three ways:
+
+- key accesses, which check whether a key is a member of the collection.
+- value accesses, which access and return a value from the collection.
+- key iterations, which iterate over a collection's keys.
+- value iterations, which iterate over a collection's values.
+
+## Example
+
+For example, in the `Map` API:
+
+- `has(key)` is a **key access**.
+- `get(key)` is an **value access**.
+- `keys()` is a **key iteration**.
+- `values()` is a **value iteration**.
+- `entries()` is a **key and value iteration**.
+- iterating the map via `Symbol.iterator` or `forEach` is a **key and value
+  iteration**.
+
+Consider this formula:
+
+```ts
+const recipes = reactive.Map(["pie", "http://example.com/pie-recipe"]);
+const hasTastyFood = Formula(() => food.has("pie") || food.has("cookie"));
+```
+
+This formula makes two _key accesses_: `"pie"` and `"cookie"`.
+
+If the URL for `pie` is updated:
+
+```ts
+recipes.set("pie", "http://example.com/better-pie-recipe");
+```
+
+This formula updates the _value_ of `"pie"`, but the _key_ has not changed. The
+`hasTastyFood` formula **will not invalidate**.
+
+Categorizing operations this way supports the intuition that `hasTastyFood` has
+not changed by providing enough granularity to capture the user's intent.
+
+## Iteration
+
+If a formula iterates over a reactive collection, the formula will invalidate
+when the collection changes.
+
+Replacing an existing value will invalidate a _value iteration_ but not a _key
+iteration_. Adding a new entry or deleting an existing entry will invalidate
+both.
+
+Let's create a couple of new formulas in our recipe example:
+
+```ts
+const recipeCount = Formula(() => recipes.size);
+const uniqueRecipeURLs = Formula(
+  () => new Set([...recipes.values()].map((r) => r.url))
+);
+```
+
+The `recipeCount` formula only changes when the _key iteration_ is invalidated.
+
+So let's say we update the pie recipe again:
+
+```ts
+recipes.set("pie", "http://example.com/even-better-pie-recipe");
+```
+
+Since changing the value of an existing entry doesn't invalidate the _key
+iteration_, the `recipeCount` formula **will not invalidate**.
+
+However, the `uniqueRecipeURLs` formula **will invalidate** when the
+collection changes.
+
+Intuitively, this behaves just as we'd expect: changing the value of a recipe
+doesn't change the size of the recipes collection. But it _might_ change the
+number of unique URLs.
+
+## 📢 Invalidation
+
+Starbeam collections have predictable, granular invalidation rules. They
+cannot, however, avoid invalidating a formula just because the formula
+ultimately produces the same answer.
+
+In this example, it's possible to invalidate `uniqueRecipeURLs` by changing
+the value of a recipe URL from a URL that has other existing entries to a URL
+that also has existing entries.
+
+In this situation, computing the formula will ultimately determine that
+nothing has changed. However, Starbeam invalidation rules are based upon the
+invalidation of storage cells, and **never** rely upon comparing the value of
+a previous computation with the value of a new computation.
+
+In practice, this means that renderers may want to compare the new value to
+the old value in order to determine whether to do the work of updating the
+rendererd output.
+
+[Object]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
+[Array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
+[Map]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
+[Set]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
+[WeakMap]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
+[WeakSet]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet

--- a/packages/universal/interfaces/src/tag.ts
+++ b/packages/universal/interfaces/src/tag.ts
@@ -1,5 +1,3 @@
-import type { UNINITIALIZED } from "@starbeam/shared";
-
 import type { Description } from "./debug/description.js";
 import type { Timestamp } from "./timestamp.js";
 
@@ -46,7 +44,7 @@ export interface CellTag {
 export interface FormulaTag {
   readonly type: "formula";
   readonly description?: Description | undefined;
-  readonly dependencies: UNINITIALIZED | (() => readonly CellTag[]);
+  readonly dependencies: undefined | (() => readonly CellTag[]);
 }
 
 /**

--- a/packages/universal/reactive/src/primitives/formula.ts
+++ b/packages/universal/reactive/src/primitives/formula.ts
@@ -1,8 +1,13 @@
-import type { FormulaTag, Tag, TaggedReactive } from "@starbeam/interfaces";
+import type {
+  FormulaTag,
+  Tag,
+  TaggedReactive,
+  TagSnapshot,
+} from "@starbeam/interfaces";
 import { TAG } from "@starbeam/shared";
 import { createFormulaTag } from "@starbeam/tags";
 
-import { evaluate, getDebug, getRuntime } from "../runtime.js";
+import { getDebug, getRuntime } from "../runtime.js";
 import type { FormulaFn, SugaryPrimitiveOptions } from "./utils.js";
 import { toOptions, WrapFn } from "./utils.js";
 
@@ -38,4 +43,11 @@ export function Formula<T>(
       return read(getDebug()?.callerStack());
     },
   });
+}
+
+function evaluate<T>(compute: () => T): { value: T; tags: TagSnapshot } {
+  const done = getRuntime().start();
+  const value = compute();
+  const tags = done();
+  return { value, tags };
 }

--- a/packages/universal/reactive/src/runtime.ts
+++ b/packages/universal/reactive/src/runtime.ts
@@ -1,4 +1,4 @@
-import type { DebugRuntime, Runtime, TagSnapshot } from "@starbeam/interfaces";
+import type { DebugRuntime, Runtime } from "@starbeam/interfaces";
 import { isPresent, verified } from "@starbeam/verify";
 
 export const CONTEXT = {
@@ -39,11 +39,4 @@ if (import.meta.env.DEV) {
     CONTEXT.debug = debug;
     DEBUG = debug;
   };
-}
-
-export function evaluate<T>(compute: () => T): { value: T; tags: TagSnapshot } {
-  const done = getRuntime().start();
-  const value = compute();
-  const tags = done();
-  return { value, tags };
 }

--- a/packages/universal/runtime/README.md
+++ b/packages/universal/runtime/README.md
@@ -1,10 +1,12 @@
 # Purpose
 
-`@starbeam/timeline` is part of Starbeam, a library for building and using reactive objects in any framework.
+**This document is outdated, but still contains relevant philosophical information.**
+
+`@starbeam/runtime` is part of Starbeam, a library for building and using reactive objects in any framework.
 
 ## Primitive
 
-`@starbeam/timeline` is stable, with the same [semver policy as Starbeam][starbeam semver policy].
+`@starbeam/runtime` is stable, with the same [semver policy as Starbeam][starbeam semver policy].
 
 That said, it is not intended to be used directly by application code. Rather, it is one of the core parts of the Starbeam composition story. You can use it to better understand how Starbeam works, or to build your own Starbeam libraries.
 
@@ -79,7 +81,7 @@ These steps allow you to implement _framework-agnostic_ [resources] that can cor
 
 ## Timeline
 
-The `Timeline` in `@starbeam/timeline` coordinates these phases.
+The `Timeline` in `@starbeam/runtime` coordinates these phases.
 
 It starts out in the _Actions_ phase, which allows free access to the _data universe_. As soon as a _data cell_ in the _data universe_ is mutated, the `Timeline` schedules a _Render_ phase using the configured scheduler. By default, this will schedule a _Render_ phase during a microtask checkpoint, which occurs asynchronously, but before the next paint.
 

--- a/packages/universal/runtime/src/timeline/subscriptions.ts
+++ b/packages/universal/runtime/src/timeline/subscriptions.ts
@@ -6,7 +6,6 @@ import type {
   NotifyReady,
   Tag,
 } from "@starbeam/interfaces";
-import { UNINITIALIZED } from "@starbeam/shared";
 import { getDependencies, getTag } from "@starbeam/tags";
 
 import type { Unsubscribe } from "../lifetime/object-lifetime.js";
@@ -87,8 +86,8 @@ export class Subscriptions {
 
 function isUninitialized(
   tag: Tag,
-): tag is FormulaTag & { dependencies: UNINITIALIZED } {
-  return tag.dependencies === UNINITIALIZED;
+): tag is FormulaTag & { dependencies: undefined } {
+  return tag.dependencies === undefined;
 }
 
 /**
@@ -100,8 +99,7 @@ function hasDependencies(
   tagged: Tag,
 ): tagged is Tag & { readonly dependencies: () => readonly CellTag[] } {
   const deps = getTag(tagged).dependencies;
-
-  return deps !== UNINITIALIZED && isPresentArray(deps());
+  return deps !== undefined && isPresentArray(deps());
 }
 
 interface Subscription {

--- a/packages/universal/shared/README.md
+++ b/packages/universal/shared/README.md
@@ -1,15 +1,90 @@
-This package provides an extremely stable API for getting:
+# `@starbeam/shared`
 
-- The current timestamp as a number
-- The value of the `UNINITIALIZED` symbol
+**Unless you are very interested in the stability strategy of Starbeam, you don't
+need to understand how this package works.**
 
-Apps shouldn't use the exports of this dependency directly. Instead, separating the most fundamental
-parts of Starbeam's composition into a separate package allows two versions of Starbeam to coexist
-in the same process and **to share reactivity between them**.
+---
 
-In other words, if you access a Cell from version 1 of Starbeam in the context of a formula
-created in version 2 of Starbeam, updating the cell will invalidate the formula.
+This package is designed to make it possible for multiple copies of Starbeam to
+interact with each other in a single process.
 
-This package uses `Symbol.for` to ensure that only a single copy of the fundamental symbols and
-constants exists in a single process. As a result, it is not necessary to install this package as a
-peer dependency.
+> For example, this means that:
+>
+> - if one copy of Starbeam creates a formula
+> - and the formula read the value of a cell from another copy of Starbeam
+> - then updating the cell will invalidate the formula
+
+## How it Works
+
+It accomplishes this by storing a handful of very stable Starbeam fundamentals
+in a single global symbol (`Symbol.for("starbeam.COORDINATION")`).
+
+The first access to any of `@starbeam/shared`'s exports (from any copy of
+Starbeam) instantiates the values in that symbol. Future accesses of the exports
+use that already instantiated value.
+
+> This package uses `Symbol.for` to ensure that only a single copy of the
+> fundamental symbols and constants exists in a single process. As a result, **it
+> is not necessary to install this package as a peer dependency**.
+
+## Starbeam Fundamentals
+
+<dl>
+  <dt><code>now()</code></dt>
+  <dd>Returns the current timestamp as a number.</dd>
+  <dt><code>bump()</code></dt>
+  <dd>Increment the current timestamp and return the new one.</dd>
+  <dt><code>start()</code></dt>
+  <dd>Start a new tracking frame. This function returns a function that, when called, finalizes the tracking frame. The finalization function returns a list of the cell tags that were consumed during the duration of the tracking frame.</dd>
+  <dt><code>consume(tag)</code></dt>
+  <dd>Consume a tag.</dd>
+  <dt><code>getId()</code></dt>
+  <dd>Returns a unique, deterministic identifier as a string or number. This is useful to create primitive identifiers that are guaranteed to be unique even if multiple copies of Starbeam exist in a single process.</dd>
+  <dt><code>TAG</code></dt>
+  <dd>The value of the `TAG` symbol. A reactive value's tag is stored in this property.</dd>
+  <dt><code>UNINITIALIZED</code></dt>
+  <dd>A special value representing an uninitialized value. This is sometimes necessary to differentiate between <code>undefined</code> as an actual user value and an internal uninitialized state.</dd>
+</dl>
+
+## Stability
+
+The goal of this package is to provide a place for the most primitive
+representation of Starbeam fundamentals. It is designed to be as stable as
+possible, so that the implementations of tags and reactive values from multiple
+different major versions of Starbeam can interoperate.
+
+We expect this package to remain at `1.x` for the foreseeable future.
+
+If we need to make breaking changes to this package, that will also make
+versions of Starbeam that depend on `1.x` incompatible with versions of Starbeam
+that depend on `2.x`. As a result, we intend to try as hard as possible to avoid
+strictly breaking changes.
+
+One consequence of this design goal is that the functions in this package take
+and return simple TypeScript types. For example, timestamps are represented as
+numbers and cell tags are just `unknown`.
+
+In practice, interoperability between Starbeam versions will also require
+stability in the fundamental protocol of cell tags. This basically means that
+the fundamental interface for tags is:
+
+```ts
+interface CellTag {
+  readonly lastUpdated: number;
+  readonly dependencies: () => CellTag[];
+}
+
+interface FormulaTag {
+  readonly dependencies: undefined | (() => CellTag[]);
+}
+
+type Tag = CellTag | FormulaTag;
+```
+
+Because TypeScript frequently makes breaking changes, adding these fundamental
+types to this package as part of its API is still a work in progress.
+
+However, the description of the fundamental tag types is intended to document
+the intended stability of the `Tag` types in Starbeam, which means that the
+implementation of tags in other parts of Starbeam will only change if
+`@starbeam/shared` has a major version bump.

--- a/packages/universal/shared/index.ts
+++ b/packages/universal/shared/index.ts
@@ -1,4 +1,4 @@
-export { COORDINATION, TAG, UNINITIALIZED } from "./src/constants.js";
+export { TAG, UNINITIALIZED } from "./src/constants.js";
 export { getID } from "./src/id.js";
 export {
   finalize,

--- a/packages/universal/shared/tests/constants.spec.ts
+++ b/packages/universal/shared/tests/constants.spec.ts
@@ -1,10 +1,9 @@
-import { COORDINATION, TAG, UNINITIALIZED } from "@starbeam/shared";
+import { TAG, UNINITIALIZED } from "@starbeam/shared";
 import { describe, expect, test } from "vitest";
 
 describe("symbols", () => {
   testSymbol(UNINITIALIZED, "UNINITIALIZED");
   testSymbol(TAG, "TAG");
-  testSymbol(COORDINATION, "COORDINATION");
 });
 
 function testSymbol(symbol: symbol, description: string): void {

--- a/packages/universal/tags/src/tag.ts
+++ b/packages/universal/tags/src/tag.ts
@@ -5,7 +5,6 @@ import type {
   FormulaTag,
   TagSnapshot,
 } from "@starbeam/interfaces";
-import { UNINITIALIZED } from "@starbeam/shared";
 
 import { getDependencies } from "./tagged.js";
 import type { Timestamp } from "./timestamp.js";
@@ -84,11 +83,15 @@ export function createFormulaTag(
   const tag = {
     type: "formula",
     description,
-    dependencies: UNINITIALIZED as UNINITIALIZED | typeof dependencies,
-  };
+    dependencies: undefined as undefined | typeof dependencies,
+  } satisfies Mutable<FormulaTag>;
 
   return {
     tag: tag as FormulaTag,
     markInitialized: () => (tag.dependencies = dependencies),
   };
 }
+
+type Mutable<T> = {
+  -readonly [P in keyof T]: T[P];
+};


### PR DESCRIPTION
This commit continues the process of documenting the core Starbeam concepts for contributor consumption, using the package READMEs to document the APIs of the individual packages.

This factoring is not designed for application developers, but it's a perfect place to outline the structure of the concepts from the perspective of someone trying to understand how the codebase is structured.