### PR TITLE
Initial Vue support

### DIFF
--- a/demos/preact-hello-world/package.json
+++ b/demos/preact-hello-world/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
-    "@vitest/ui": "^0.30.1",
+    "@vitest/ui": "*",
     "vite": "*",
     "vitest": "^0.30.1"
   }

--- a/demos/preact/package.json
+++ b/demos/preact/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
-    "@vitest/ui": "^0.30.1",
+    "@vitest/ui": "*",
     "vite": "*",
     "vitest": "^0.30.1"
   }

--- a/demos/react-lite-query/package.json
+++ b/demos/react-lite-query/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
-    "@vitest/ui": "^0.30.1",
+    "@vitest/ui": "*",
     "vite": "*",
     "vitest": "^0.30.1"
   }

--- a/demos/react-query/package.json
+++ b/demos/react-query/package.json
@@ -48,7 +48,7 @@
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
     "@types/styled-components": "^5.1.25",
-    "@vitest/ui": "^0.30.1",
+    "@vitest/ui": "*",
     "axios": "^1.3.5",
     "styled-components": "^5.3.9",
     "vite": "*",

--- a/demos/react-stock-ticker/package.json
+++ b/demos/react-stock-ticker/package.json
@@ -42,7 +42,7 @@
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
     "@types/react-portal": "^4.0.4",
-    "@vitest/ui": "^0.30.1",
+    "@vitest/ui": "*",
     "vite": "*",
     "vitest": "^0.30.1"
   }

--- a/demos/react-store/package.json
+++ b/demos/react-store/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
-    "@vitest/ui": "^0.30.1",
+    "@vitest/ui": "*",
     "vite": "*",
     "vitest": "^0.30.1"
   }

--- a/demos/react/package.json
+++ b/demos/react/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
-    "@vitest/ui": "^0.30.1",
+    "@vitest/ui": "*",
     "vite": "*",
     "vitest": "^0.30.1"
   }

--- a/packages/universal/debug/src/tag.ts
+++ b/packages/universal/debug/src/tag.ts
@@ -36,7 +36,7 @@ export const logTag = (
 
   console.group(
     describe(tag.description, { id: options.id }),
-    `(updated at ${lastUpdated(tag).at}`
+    `(updated at ${lastUpdated(tag).at})`
   );
   console.info(debug);
   console.groupEnd();

--- a/packages/universal/interfaces/index.ts
+++ b/packages/universal/interfaces/index.ts
@@ -8,6 +8,6 @@ export type {
   UpdateOptions,
 } from "./src/runtime.js";
 export type { CellTag, FormulaTag, Tag, TagSnapshot } from "./src/tag.js";
-export type { Reactive, Tagged, TaggedReactive } from "./src/tagged.js";
+export type { HasTag, Reactive, Tagged, TaggedReactive } from "./src/tagged.js";
 export type { CoreTimestamp } from "./src/timestamp.js";
 export type { Diff, Expand, Unsubscribe } from "./src/utils.js";

--- a/packages/universal/interfaces/src/runtime.ts
+++ b/packages/universal/interfaces/src/runtime.ts
@@ -1,5 +1,6 @@
 import type { CallStack } from "./debug/call-stack.js";
 import type { CellTag, FormulaTag, Tag, TagSnapshot } from "./tag.js";
+import type { HasTag } from "./tagged.js";
 import type { CoreTimestamp } from "./timestamp.js";
 import type { Unsubscribe } from "./utils.js";
 
@@ -62,7 +63,7 @@ export interface Runtime {
    * should efficiently update the output to reflect the new value of the
    * reactive state.
    */
-  readonly subscribe: (target: Tag, ready: NotifyReady) => Unsubscribe;
+  readonly subscribe: (target: HasTag, ready: NotifyReady) => Unsubscribe;
 
   /**
    * Start a new tracking frame. This should be called at the start of a

--- a/packages/universal/interfaces/src/tagged.ts
+++ b/packages/universal/interfaces/src/tagged.ts
@@ -3,6 +3,8 @@ import type { TAG } from "@starbeam/shared";
 import type { CallStack } from "../index.js";
 import type { Tag } from "./tag.js";
 
+export type HasTag<T extends Tag = Tag> = T | Tagged<T>;
+
 /**
  * A `Tagged` object is a reactive object that has a `Tag` (which is used to
  * validate it).

--- a/packages/universal/runtime/src/context/context.ts
+++ b/packages/universal/runtime/src/context/context.ts
@@ -36,7 +36,7 @@ export class AppContext {
 
   create<Ret>(
     key: object,
-    constructor: () => Ret,
+    constructor: (app: object) => Ret,
     {
       app,
     }: {
@@ -50,7 +50,7 @@ export class AppContext {
     let singletons = this.#singletons.get(app);
 
     if (singletons === undefined) {
-      singletons = new SingletonContext();
+      singletons = new SingletonContext(app);
       this.#singletons.set(app, singletons);
     }
 
@@ -59,17 +59,22 @@ export class AppContext {
 }
 
 class SingletonContext {
+  readonly #app: object;
   #instances = new WeakMap<object, object>();
 
-  create<Ret>(key: object | undefined, constructor: () => Ret): Ret {
+  constructor(app: object) {
+    this.#app = app;
+  }
+
+  create<Ret>(key: object | undefined, constructor: (app: object) => Ret): Ret {
     if (key === undefined) {
-      return constructor();
+      return constructor(this.#app);
     }
 
     let existing = this.#instances.get(key) as Ret | undefined;
 
     if (existing === undefined) {
-      existing = constructor();
+      existing = constructor(this.#app);
       this.#instances.set(key, existing as object);
     }
 

--- a/packages/universal/runtime/src/timeline/render.ts
+++ b/packages/universal/runtime/src/timeline/render.ts
@@ -1,6 +1,7 @@
 import type {
   CellTag,
   FormulaTag,
+  HasTag,
   NotifyReady,
   Tag,
   Tagged,
@@ -15,15 +16,15 @@ import { Subscriptions } from "./subscriptions.js";
 export class ReactiveError extends Error {}
 
 function SubscriptionRuntime(): {
-  subscribe: (target: Tag, ready: NotifyReady) => Unsubscribe;
+  subscribe: (target: HasTag, ready: NotifyReady) => Unsubscribe;
   mark: (cell: CellTag, update: (revision: Timestamp) => void) => void;
   update: (formula: FormulaTag) => void;
 } {
   const subscriptions = Subscriptions.create();
 
   return {
-    subscribe: (target: Tag, ready: NotifyReady): Unsubscribe => {
-      return subscriptions.register(target, ready);
+    subscribe: (target: HasTag, ready: NotifyReady): Unsubscribe => {
+      return subscriptions.register(getTag(target), ready);
     },
 
     mark: (cell: CellTag, update: (revision: Timestamp) => void): void => {

--- a/packages/universal/tags/src/tagged.ts
+++ b/packages/universal/tags/src/tagged.ts
@@ -3,7 +3,7 @@ import { TAG } from "@starbeam/shared";
 
 import { zero } from "./timestamp.js";
 
-type HasTag<T extends Tag = Tag> = T | Tagged<T>;
+export type HasTag<T extends Tag = Tag> = T | Tagged<T>;
 
 export function getTag<T extends Tag>(tagged: HasTag<T>): T {
   return TAG in tagged ? tagged[TAG] : tagged;

--- a/packages/vue/vue-testing-utils/.eslintrc.json
+++ b/packages/vue/vue-testing-utils/.eslintrc.json
@@ -2,8 +2,8 @@
   "root": false,
   "overrides": [
     {
-      "extends": ["plugin:@starbeam/commonjs"],
-      "files": ["index.d.ts", "src/**/*.d.ts"],
+      "extends": ["plugin:@starbeam/tight"],
+      "files": ["index.ts", "src/**/*.ts"],
       "parserOptions": {
         "project": "tsconfig.json"
       }

--- a/packages/vue/vue-testing-utils/.npmrc
+++ b/packages/vue/vue-testing-utils/.npmrc
@@ -1,0 +1,2 @@
+auto-install-peers=true
+strict-peer-dependencies=true

--- a/packages/vue/vue-testing-utils/index.ts
+++ b/packages/vue/vue-testing-utils/index.ts
@@ -1,0 +1,7 @@
+export type {
+  EventMap,
+  IfAny,
+  ReturnElement,
+  StarbeamRenderResult,
+} from "./src/testing.js";
+export { define, testing } from "./src/testing.js";

--- a/packages/vue/vue-testing-utils/package.json
+++ b/packages/vue/vue-testing-utils/package.json
@@ -1,12 +1,8 @@
 {
-  "name": "@starbeam/preact-utils",
-  "version": "0.8.9",
+  "private": true,
+  "name": "@starbeam-workspace/vue-testing-utils",
+  "version": "0.7.4",
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
-  "exports": {
-    "default": "./index.ts"
-  },
   "publishConfig": {
     "exports": {
       ".": {
@@ -18,20 +14,24 @@
     "main": "dist/index.cjs",
     "types": "dist/index.d.ts"
   },
-  "starbeam:type": "library:public",
+  "starbeam:type": "library:test-support",
   "scripts": {
     "test:lint": "eslint \"index.ts\" \"src/**/*.ts\"",
     "test:specs": "vitest --run",
     "test:types": "tsc -b"
   },
   "dependencies": {
-    "@starbeam/core-utils": "workspace:^"
+    "@starbeam/interfaces": "workspace:^",
+    "@starbeam/verify": "workspace:^",
+    "@starbeam-workspace/test-utils": "workspace:^",
+    "@testing-library/dom": "^9.2.0",
+    "@testing-library/vue": "^7.0.0"
   },
   "devDependencies": {
     "@starbeam-dev/build-support": "workspace:*",
     "rollup": "^3.20.6"
   },
   "peerDependencies": {
-    "preact": ">=10"
+    "vue": ">=3.0.0"
   }
 }

--- a/packages/vue/vue-testing-utils/rollup.config.mjs
+++ b/packages/vue/vue-testing-utils/rollup.config.mjs
@@ -1,0 +1,3 @@
+import { Package } from "@starbeam-dev/build-support";
+
+export default Package.config(import.meta);

--- a/packages/vue/vue-testing-utils/src/testing.ts
+++ b/packages/vue/vue-testing-utils/src/testing.ts
@@ -1,0 +1,311 @@
+import type { Expand } from "@starbeam/interfaces";
+import { expect, expect as vitestExpect } from "@starbeam-workspace/test-utils";
+import {
+  type BoundFunction,
+  fireEvent,
+  type queries,
+  type RenderResult,
+  type VueFireEventObject,
+} from "@testing-library/vue";
+import { render } from "@testing-library/vue";
+import {
+  defineComponent,
+  type Plugin,
+  type Prop,
+  type PropType,
+  type RenderFunction,
+  type VNode,
+} from "vue";
+
+type ExpectHTML<T extends PropTypes | void> = T extends void
+  ? (<U>(
+      callback: (value: U) => string,
+      initial: U
+    ) => {
+      render: (props: PropsFor<void>) => StarbeamRenderResult<void, U>;
+    }) &
+      ((callback: (props: PropsFor<T>) => string) => {
+        render: (props: PropsFor<T>) => StarbeamRenderResult<T, void>;
+      })
+  : (<U>(
+      callback: (props: PropsFor<T>, value: U) => string,
+      initial: U
+    ) => {
+      render: (props: PropsFor<T>) => StarbeamRenderResult<T, U>;
+    }) &
+      ((callback: (props: PropsFor<T>) => string) => {
+        render: (props: PropsFor<T>) => StarbeamRenderResult<T, void>;
+      });
+
+// interface RenderOptions {
+//   plugin?: Plugin;
+// }
+
+// type VueRenderOptions = Partial<Parameters<typeof render>[1]>;
+
+interface Define<T extends PropTypes | void> {
+  define: (
+    options: { setup: Setup<T> } | ((props: PropsFor<T>) => VNode | VNode[]),
+    plugin?: Plugin
+  ) => {
+    html: ExpectHTML<T>;
+  };
+}
+
+export const define: Define<void>["define"] = testing().define;
+
+export function testing(): Define<void>;
+export function testing<T extends PropTypes>(props: T): Define<T>;
+export function testing(props?: PropTypes): Define<PropTypes | void> {
+  const lastProps = { props: undefined as undefined | PropsFor<PropTypes> };
+  const hasProps = props !== undefined;
+
+  return {
+    define: (options, plugin) => {
+      const component = defineComponent({
+        props: props ?? [],
+        setup: (props): RenderFunction => {
+          const typedProps = props;
+          lastProps.props = typedProps;
+          if (typeof options === "function") {
+            return () => options(typedProps);
+          } else {
+            return options.setup(typedProps);
+          }
+        },
+      });
+
+      return {
+        html: ((
+          expectHTML: (props: unknown, value?: unknown) => string,
+          initial?: unknown
+        ) => {
+          function checkHTML(props: unknown, value?: unknown) {
+            if (hasProps) {
+              return (
+                expectHTML as (
+                  props: PropsFor<PropTypes>,
+                  value: unknown
+                ) => string
+              )(props as PropsFor<PropTypes>, value);
+            } else {
+              return (expectHTML as (value: unknown) => string)(value);
+            }
+          }
+
+          return {
+            render: (props: PropsFor<PropTypes>) => {
+              const global = plugin ? { global: { plugins: [plugin] } } : {};
+
+              const result = render(component, {
+                props,
+                ...global,
+              });
+              const starbeamResult = new StarbeamRenderResult(
+                result,
+                result.container,
+                {
+                  html: checkHTML,
+                },
+                lastProps as { props: PropsFor<PropTypes> }
+              );
+
+              vitestExpect(starbeamResult.innerHTML).toBe(
+                checkHTML(props, initial)
+              );
+              return starbeamResult;
+            },
+          };
+        }) as ExpectHTML<PropTypes>,
+      };
+    },
+  };
+}
+
+export class StarbeamRenderResult<Props extends PropTypes | void, U> {
+  readonly #result: RenderResult;
+  readonly #container: Element;
+  readonly #expectations: {
+    html: (props: PropsFor<Props>, value: U) => string;
+  };
+  readonly #lastProps: { props: PropsFor<Props> };
+
+  constructor(
+    result: RenderResult,
+    container: Element,
+    expectations: {
+      html: (props: PropsFor<Props>, value: U) => string;
+    },
+    lastProps: { props: PropsFor<Props> }
+  ) {
+    this.#result = result;
+    this.#container = container;
+    this.#expectations = expectations;
+    this.#lastProps = lastProps;
+  }
+
+  get innerHTML(): string {
+    return this.#container.innerHTML;
+  }
+
+  async rerender(props: PropsFor<Props>, value: U): Promise<void>;
+  async rerender(
+    this: StarbeamRenderResult<Props, void>,
+    props: PropsFor<Props>
+  ): Promise<void>;
+  async rerender(props: PropsFor<Props>, value?: U): Promise<void> {
+    console.log("rerendering");
+    await this.#result.rerender(props as object);
+    this.#lastProps.props = props;
+
+    expect(this.#container.innerHTML).toBe(
+      this.#expectations.html(props, value as U)
+    );
+  }
+
+  async update(callback: () => void | Promise<void>, value: U): Promise<void>;
+  async update(
+    this: StarbeamRenderResult<Props, void>,
+    callback: () => void | Promise<void>
+  ): Promise<void>;
+  async update(callback: () => void | Promise<void>, value?: U): Promise<void> {
+    await callback();
+
+    expect(this.#container.innerHTML).toBe(
+      this.#expectations.html(this.#lastProps.props, value as U)
+    );
+  }
+
+  unmount(): void {
+    this.#result.unmount();
+  }
+
+  find<H extends HTMLElement>(
+    ...args: Parameters<BoundFunction<queries.FindByRole<H>>>
+  ): ReturnElement<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    queries.FindByRole<H> extends (...args: any) => Promise<infer T> | infer T
+      ? T
+      : never
+  > {
+    return new ReturnElement(this.#result.findByRole(...args));
+  }
+}
+
+Error.stackTraceLimit = Infinity;
+
+export class ReturnElement<H extends HTMLElement> {
+  readonly #element: Promise<H>;
+
+  constructor(element: Promise<H>) {
+    this.#element = element;
+  }
+
+  get fire(): EventMap {
+    const keys = new Set(Reflect.ownKeys(fireEvent));
+    for (const key of Reflect.ownKeys(Function.prototype)) {
+      keys.delete(key);
+    }
+
+    const descs = Object.fromEntries(
+      [...keys].map((key) => {
+        return [
+          key,
+          {
+            configurable: true,
+            value: async (...args: unknown[]) => {
+              return fireEvent[key as keyof typeof fireEvent](
+                await this.#element,
+                ...(args as never[])
+              );
+            },
+          },
+        ];
+      })
+    ) as PropertyDescriptorMap;
+
+    return Object.defineProperties({}, descs) as EventMap;
+  }
+}
+
+export type EventMap = Expand<{
+  [P in keyof VueFireEventObject]: VueFireEventObject[P] extends <
+    N extends Document | Element | Window
+  >(
+    element: N,
+    ...args: infer Args
+  ) => infer Return
+    ? (...args: Args) => Return
+    : never;
+}>;
+
+type ZERO = 0;
+type ONE = 1;
+export declare type IfAny<T, Y, N> = ZERO extends ONE & T ? Y : N;
+
+declare type InferPropType<T> = [T] extends [null]
+  ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any
+  : [T] extends [
+      {
+        type: null | true;
+      }
+    ]
+  ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any
+  : [T] extends [
+      | ObjectConstructor
+      | {
+          type: ObjectConstructor;
+        }
+    ]
+  ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Record<string, any>
+  : [T] extends [
+      | BooleanConstructor
+      | {
+          type: BooleanConstructor;
+        }
+    ]
+  ? boolean
+  : [T] extends [
+      | NumberConstructor
+      | {
+          type: NumberConstructor;
+        }
+    ]
+  ? number
+  : [T] extends [
+      | DateConstructor
+      | {
+          type: DateConstructor;
+        }
+    ]
+  ? Date
+  : [T] extends [
+      | (infer U)[]
+      | {
+          type: (infer U)[];
+        }
+    ]
+  ? U extends DateConstructor
+    ? Date | InferPropType<U>
+    : InferPropType<U>
+  : [T] extends [Prop<infer V, infer D>]
+  ? unknown extends V
+    ? IfAny<V, V, D>
+    : V
+  : T;
+
+type PropTypes = Readonly<Record<string, PropType<unknown>>>;
+type PropsFor<Props extends PropTypes | void> = Expand<
+  Props extends void
+    ? void
+    : {
+        [P in keyof Props]: InferPropType<Props[P]>;
+      }
+>;
+
+type Setup<T extends PropTypes | void> =
+  | ((props: PropsFor<T>) => () => VNode)
+  | ((props: PropsFor<T>) => () => VNode[]);

--- a/packages/vue/vue-testing-utils/tests/.eslintrc.json
+++ b/packages/vue/vue-testing-utils/tests/.eslintrc.json
@@ -2,8 +2,8 @@
   "root": false,
   "overrides": [
     {
-      "extends": ["plugin:@starbeam/commonjs"],
-      "files": ["index.d.ts", "src/**/*.d.ts"],
+      "extends": ["plugin:@starbeam/loose"],
+      "files": ["**/*.ts"],
       "parserOptions": {
         "project": "tsconfig.json"
       }

--- a/packages/vue/vue-testing-utils/tests/.npmrc
+++ b/packages/vue/vue-testing-utils/tests/.npmrc
@@ -1,0 +1,2 @@
+auto-install-peers=true
+strict-peer-dependencies=true

--- a/packages/vue/vue-testing-utils/tests/package.json
+++ b/packages/vue/vue-testing-utils/tests/package.json
@@ -1,0 +1,29 @@
+{
+  "private": true,
+  "name": "@starbeam-tests/vue-testing-utils",
+  "version": "1.0.0",
+  "type": "module",
+  "starbeam:type": "tests",
+  "scripts": {
+    "test:lint": "eslint ",
+    "test:types": "tsc -b"
+  },
+  "dependencies": {
+    "@starbeam/debug": "workspace:^",
+    "@starbeam/interfaces": "workspace:^",
+    "@starbeam/preact": "workspace:^",
+    "@starbeam/runtime": "workspace:^",
+    "@starbeam/universal": "workspace:^",
+    "@starbeam/vue": "workspace:^",
+    "@starbeam-workspace/test-utils": "workspace:^",
+    "@starbeam-workspace/vue-testing-utils": "workspace:^",
+    "@testing-library/dom": "^9.2.0",
+    "@testing-library/vue": "^7.0.0",
+    "htm": "^3.1.1",
+    "jsdom": "^21.1.1",
+    "vue": ">=3.0.0"
+  },
+  "devDependencies": {
+    "preact-render-to-string": "^6.0.2"
+  }
+}

--- a/packages/vue/vue-testing-utils/tests/testing.spec.ts
+++ b/packages/vue/vue-testing-utils/tests/testing.spec.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { describe, test } from "@starbeam-workspace/test-utils";
+import { testing } from "@starbeam-workspace/vue-testing-utils/src/testing.js";
+import { h, ref } from "vue";
+
+describe("useReactive", () => {
+  test("baseline", () => {
+    testing({ name: String })
+      .define((props) => h("div", ["hello ", props.name]))
+      .html((props) => `<div>hello ${props.name}</div>`)
+      .render({ name: "world" });
+  });
+
+  test("rerendering", async () => {
+    const result = testing({ name: String })
+      .define((props) => h("div", ["hello ", props.name]))
+      .html((props) => `<div>hello ${props.name}</div>`)
+      .render({ name: "world" });
+
+    await result.update(async () => result.rerender({ name: "cruel world" }));
+  });
+
+  test("firing events", async () => {
+    const result = testing({ name: String })
+      .define({
+        setup: (props) => {
+          const counter = ref(0);
+
+          return () =>
+            h("div", [
+              props.name,
+              h("button", { onClick: () => counter.value++ }, "increment"),
+              h("p", String(counter.value)),
+            ]);
+        },
+      })
+      .html(
+        (_, { counter }) =>
+          `<div>Hello world<button>increment</button><p>${String(
+            counter
+          )}</p></div>`,
+        { counter: 0 }
+      )
+      .render({ name: "Hello world" });
+
+    await result.update(async () => result.find("button").fire.click(), {
+      counter: 1,
+    });
+  });
+});

--- a/packages/vue/vue-testing-utils/tests/tsconfig.json
+++ b/packages/vue/vue-testing-utils/tests/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.config/tsconfig/tsconfig.shared.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "../../../../dist/types",
+    "declarationMap": true,
+    "outDir": "../../../../dist/packages",
+    "types": ["../../../env"]
+  },
+  "exclude": ["dist/**/*"]
+}

--- a/packages/vue/vue-testing-utils/tsconfig.json
+++ b/packages/vue/vue-testing-utils/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../.config/tsconfig/tsconfig.shared.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "../../../dist/types",
+    "declarationMap": true,
+    "outDir": "../../../dist/packages",
+    "types": ["../../env"]
+  },
+  "exclude": ["dist/**/*"]
+}

--- a/packages/vue/vue/.eslintrc.json
+++ b/packages/vue/vue/.eslintrc.json
@@ -2,8 +2,8 @@
   "root": false,
   "overrides": [
     {
-      "extends": ["plugin:@starbeam/commonjs"],
-      "files": ["index.d.ts", "src/**/*.d.ts"],
+      "extends": ["plugin:@starbeam/tight"],
+      "files": ["index.ts", "src/**/*.ts"],
       "parserOptions": {
         "project": "tsconfig.json"
       }

--- a/packages/vue/vue/.npmrc
+++ b/packages/vue/vue/.npmrc
@@ -1,0 +1,2 @@
+auto-install-peers=true
+strict-peer-dependencies=true

--- a/packages/vue/vue/CHANGELOG.md
+++ b/packages/vue/vue/CHANGELOG.md
@@ -1,0 +1,117 @@
+# @starbeam/preact
+
+## 0.8.9
+
+### Patch Changes
+
+- e459bf2: Fix CJS builds
+- Updated dependencies [e459bf2]
+  - @starbeam/preact-utils@0.8.9
+  - @starbeam/core-utils@0.8.9
+  - @starbeam/debug@0.8.9
+  - @starbeam/timeline@0.8.9
+  - @starbeam/universal@0.8.9
+  - @starbeam/verify@0.8.9
+
+## 0.8.8
+
+### Patch Changes
+
+- 2a1f728: Improve @starbeam/react
+- Updated dependencies [2a1f728]
+  - @starbeam/preact-utils@0.8.8
+  - @starbeam/core-utils@0.8.8
+  - @starbeam/debug@0.8.8
+  - @starbeam/timeline@0.8.8
+  - @starbeam/universal@0.8.8
+  - @starbeam/verify@0.8.8
+
+## 0.8.7
+
+### Patch Changes
+
+- 14f961b: Fixes #75
+- Updated dependencies [14f961b]
+  - @starbeam/preact-utils@0.8.7
+  - @starbeam/core-utils@0.8.7
+  - @starbeam/debug@0.8.7
+  - @starbeam/timeline@0.8.7
+  - @starbeam/universal@0.8.7
+  - @starbeam/verify@0.8.7
+
+## 0.8.7
+
+### Patch Changes
+
+- ded6421: Add /setup to preact
+- Updated dependencies [ded6421]
+  - @starbeam/preact-utils@0.8.7
+  - @starbeam/core-utils@0.8.7
+  - @starbeam/debug@0.8.7
+  - @starbeam/timeline@0.8.7
+  - @starbeam/universal@0.8.7
+  - @starbeam/verify@0.8.7
+
+## 0.8.6
+
+### Patch Changes
+
+- 6502cc7: Remove errant import
+- Updated dependencies [6502cc7]
+  - @starbeam/preact-utils@0.8.6
+  - @starbeam/core-utils@0.8.6
+  - @starbeam/debug@0.8.6
+  - @starbeam/timeline@0.8.6
+  - @starbeam/universal@0.8.6
+  - @starbeam/verify@0.8.6
+
+## 0.8.5
+
+### Patch Changes
+
+- de755c6: Improve type inference
+- Updated dependencies [de755c6]
+  - @starbeam/universal@0.8.5
+  - @starbeam/preact-utils@0.8.5
+  - @starbeam/core-utils@0.8.5
+  - @starbeam/debug@0.8.5
+  - @starbeam/timeline@0.8.5
+  - @starbeam/verify@0.8.5
+
+## 0.8.4
+
+### Patch Changes
+
+- 3bf1221: Prepare for Starbeam 0.8.4
+- Updated dependencies [3bf1221]
+  - @starbeam/timeline@0.8.4
+  - @starbeam/universal@0.8.4
+  - @starbeam/preact-utils@0.8.4
+  - @starbeam/core-utils@0.8.4
+  - @starbeam/debug@0.8.4
+  - @starbeam/verify@0.8.4
+
+## 0.8.1
+
+### Patch Changes
+
+- Updated dependencies [a781c84]
+  - @starbeam/debug@0.8.1
+  - @starbeam/timeline@0.8.1
+  - @starbeam/universal@0.8.1
+
+## 0.8.0
+
+### Minor Changes
+
+- 1a553c5: Prepare for 0.8
+
+### Patch Changes
+
+- Updated dependencies [1a553c5]
+  - @starbeam/preact-utils@0.8.0
+  - @starbeam/debug@0.8.0
+  - @starbeam/core-utils@0.8.0
+  - @starbeam/timeline@0.8.0
+  - @starbeam/universal@0.8.0
+  - @starbeam/verify@0.8.0

--- a/packages/vue/vue/index.ts
+++ b/packages/vue/vue/index.ts
@@ -1,0 +1,2 @@
+export { create, service } from "./src/resource.js";
+export { Starbeam, useReactive } from "./src/setup.js";

--- a/packages/vue/vue/package.json
+++ b/packages/vue/vue/package.json
@@ -1,9 +1,9 @@
 {
-  "private": true,
-  "name": "@starbeam-demos/react-jsnation",
-  "version": "1.0.0",
+  "name": "@starbeam/vue",
+  "version": "0.8.9",
   "type": "module",
   "main": "index.ts",
+  "types": "index.ts",
   "exports": {
     "default": "./index.ts"
   },
@@ -19,39 +19,34 @@
     "types": "dist/index.d.ts"
   },
   "starbeam": {
-    "jsx": "react",
-    "source": "tsx",
-    "type": "demo:react",
-    "used": [
-      {
-        "packages": [
-          "purecss"
-        ],
-        "reason": "css"
-      }
-    ]
+    "entry": {
+      "index": "./index.ts",
+      "setup": "./src/setup.ts"
+    },
+    "type": "library:public"
   },
   "scripts": {
-    "test:lint": "eslint \"src/**/*.{tsx,ts}\"",
+    "test:lint": "eslint \"index.ts\" \"src/**/*.ts\"",
     "test:specs": "vitest --run",
     "test:types": "tsc -b"
   },
   "dependencies": {
-    "@starbeam/collections": "workspace:^",
+    "@starbeam/core-utils": "workspace:^",
     "@starbeam/debug": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
-    "@starbeam/react": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/resource": "workspace:^",
+    "@starbeam/runtime": "workspace:^",
+    "@starbeam/service": "workspace:^",
+    "@starbeam/tags": "workspace:^",
     "@starbeam/universal": "workspace:^",
-    "purecss": "3.0.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "@starbeam/verify": "workspace:^"
   },
   "devDependencies": {
-    "@types/react": "^18.0.37",
-    "@types/react-dom": "^18.0.11",
-    "@vitest/ui": "*",
-    "vite": "*"
+    "@starbeam-dev/build-support": "workspace:*",
+    "rollup": "^3.20.6"
+  },
+  "peerDependencies": {
+    "vue": "^3.2.47"
   }
 }

--- a/packages/vue/vue/rollup.config.mjs
+++ b/packages/vue/vue/rollup.config.mjs
@@ -1,0 +1,3 @@
+import { Package } from "@starbeam-dev/build-support";
+
+export default Package.config(import.meta);

--- a/packages/vue/vue/src/app.ts
+++ b/packages/vue/vue/src/app.ts
@@ -1,0 +1,41 @@
+import { RUNTIME } from "@starbeam/runtime";
+import { isPresent, verified } from "@starbeam/verify";
+import { type App, getCurrentInstance } from "vue";
+
+const APPS = new WeakMap<App, StarbeamApp>();
+
+export class StarbeamApp {
+  static initialized(app: App): StarbeamApp {
+    let starbeamApp = APPS.get(app);
+
+    if (!starbeamApp) {
+      starbeamApp = new StarbeamApp(app);
+      APPS.set(app, starbeamApp);
+      StarbeamApp.#setup(starbeamApp);
+    }
+
+    return starbeamApp;
+  }
+
+  static #setup(app: StarbeamApp): void {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const prevUnmount = app.#vue.unmount;
+
+    app.#vue.unmount = () => {
+      RUNTIME.finalize(app);
+      prevUnmount();
+    };
+  }
+
+  readonly #vue: App;
+
+  constructor(app: App) {
+    this.#vue = app;
+  }
+}
+
+export function useApp(
+  app = verified(getCurrentInstance(), isPresent).appContext.app
+): StarbeamApp {
+  return StarbeamApp.initialized(app);
+}

--- a/packages/vue/vue/src/resource.ts
+++ b/packages/vue/vue/src/resource.ts
@@ -1,0 +1,37 @@
+import type {
+  IntoResourceBlueprint,
+  ResourceBlueprint,
+} from "@starbeam/resource";
+import { use } from "@starbeam/resource";
+import { CONTEXT } from "@starbeam/runtime";
+import { type Ref, shallowRef } from "vue";
+
+import { useReactive } from "./setup.js";
+
+export function create<T>(resource: ResourceBlueprint<T, void>): Ref<T> {
+  const vueInstance = useReactive();
+
+  const reactive = use(resource, { lifetime: vueInstance });
+  const ref = shallowRef(reactive.current);
+  vueInstance.render(reactive, () => (ref.value = reactive.current));
+
+  return ref;
+}
+
+export function service<T>(blueprint: IntoResourceBlueprint<T>): Ref<T> {
+  const vueInstance = useReactive();
+  const app = vueInstance.app;
+
+  const reactive = CONTEXT.create(
+    blueprint,
+    () => use(blueprint, { lifetime: app }),
+    {
+      app,
+    }
+  );
+
+  const ref = shallowRef(reactive.current);
+  vueInstance.render(reactive, () => (ref.value = reactive.current));
+
+  return ref;
+}

--- a/packages/vue/vue/src/setup.ts
+++ b/packages/vue/vue/src/setup.ts
@@ -1,0 +1,14 @@
+import { type App, type Plugin } from "vue";
+
+import { useApp } from "./app.js";
+import { VueInstance } from "./vue-instance.js";
+
+export function useReactive(): VueInstance {
+  return VueInstance.current();
+}
+
+export const Starbeam = {
+  install: (app: App) => {
+    useApp(app);
+  },
+} satisfies Plugin;

--- a/packages/vue/vue/src/vue-instance.ts
+++ b/packages/vue/vue/src/vue-instance.ts
@@ -1,0 +1,122 @@
+import type { FormulaTag, HasTag, Reactive, Tag } from "@starbeam/interfaces";
+import {
+  DEBUG,
+  type FinalizedFormula,
+  FormulaLifecycle,
+  type InitializingFormula,
+} from "@starbeam/reactive";
+import { RUNTIME } from "@starbeam/runtime";
+import { getTag, initializeFormulaTag } from "@starbeam/tags";
+import { isPresent, verified } from "@starbeam/verify";
+import {
+  type ComponentInternalInstance,
+  getCurrentInstance,
+  onBeforeMount,
+  onBeforeUpdate,
+  onMounted,
+  onUnmounted,
+  onUpdated,
+} from "vue";
+
+import { type StarbeamApp, useApp } from "./app.js";
+
+const INSTANCES = new WeakMap<ComponentInternalInstance, VueInstance>();
+
+export class VueInstance {
+  static current(): VueInstance {
+    return VueInstance.for(verified(getCurrentInstance(), isPresent));
+  }
+
+  static for(instance: ComponentInternalInstance): VueInstance {
+    let vueInstance = INSTANCES.get(instance);
+
+    if (!vueInstance) {
+      const tags = new Set<FormulaTag>();
+      const newInstance = (vueInstance = new VueInstance(instance, tags));
+      INSTANCES.set(instance, vueInstance);
+      VueInstance.#setup(newInstance);
+    }
+
+    return vueInstance;
+  }
+
+  static #setup(instance: VueInstance): void {
+    let tag: FormulaTag | undefined;
+
+    onUnmounted(() => void RUNTIME.finalize(instance));
+    let initializing: InitializingFormula | undefined;
+    onBeforeMount(() => {
+      initializing = FormulaLifecycle();
+    });
+
+    let finalized: FinalizedFormula | undefined;
+
+    onMounted(() => {
+      for (const tag of instance.#renderedTags) {
+        RUNTIME.consume(tag);
+      }
+
+      const frame = (finalized = verified(initializing, isPresent).done());
+      tag = initializeFormulaTag(DEBUG?.Desc("formula", "rendered"), () =>
+        frame.children()
+      );
+      RUNTIME.subscribe(
+        tag,
+        () => void instance.#publicInstance.$forceUpdate()
+      );
+
+      initializing = undefined;
+    });
+
+    onBeforeUpdate(() => {
+      for (const task of instance.#queued) {
+        task();
+      }
+      instance.#queued.clear();
+
+      initializing = verified(finalized, isPresent).update();
+    });
+
+    onUpdated(() => {
+      finalized = verified(initializing, isPresent).done();
+      RUNTIME.update(verified(tag, isPresent));
+    });
+  }
+
+  readonly #instance: ComponentInternalInstance;
+  readonly #queued = new Set<UpdateTask>();
+
+  /**
+   * A set of tags that were created during this instance's setup, and which
+   * have associated render tasks. We need these tags to become dependencies of the
+   * component so that they trigger a re-render (and run the render tasks).
+   */
+  readonly #renderedTags: Set<Tag>;
+
+  constructor(instance: ComponentInternalInstance, tags: Set<FormulaTag>) {
+    this.#instance = instance;
+    this.#renderedTags = tags;
+  }
+
+  get app(): StarbeamApp {
+    return useApp(this.#instance.appContext.app);
+  }
+
+  get #publicInstance() {
+    return verified(this.#instance.proxy, isPresent);
+  }
+
+  render<T>(reactive: Reactive<T>, task: UpdateTask): void {
+    this.#render(reactive, () => {
+      this.#publicInstance.$forceUpdate();
+      this.#queued.add(task);
+    });
+  }
+
+  #render(tagged: HasTag, callback: () => void): void {
+    RUNTIME.onFinalize(this, RUNTIME.subscribe(tagged, callback));
+    this.#renderedTags.add(getTag(tagged));
+  }
+}
+
+type UpdateTask = () => void;

--- a/packages/vue/vue/tests/.eslintrc.json
+++ b/packages/vue/vue/tests/.eslintrc.json
@@ -2,8 +2,8 @@
   "root": false,
   "overrides": [
     {
-      "extends": ["plugin:@starbeam/commonjs"],
-      "files": ["index.d.ts", "src/**/*.d.ts"],
+      "extends": ["plugin:@starbeam/loose"],
+      "files": ["**/*.ts"],
       "parserOptions": {
         "project": "tsconfig.json"
       }

--- a/packages/vue/vue/tests/.npmrc
+++ b/packages/vue/vue/tests/.npmrc
@@ -1,0 +1,2 @@
+auto-install-peers=true
+strict-peer-dependencies=true

--- a/packages/vue/vue/tests/create.spec.ts
+++ b/packages/vue/vue/tests/create.spec.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { Cell, Resource } from "@starbeam/universal";
+import { create, useReactive } from "@starbeam/vue";
+import { describe, test } from "@starbeam-workspace/test-utils";
+import { define, testing } from "@starbeam-workspace/vue-testing-utils";
+import { defineComponent, h, type Ref } from "vue";
+
+describe("create", () => {
+  test("baseline", () => {
+    function App({ name }: { name: string }) {
+      return h("div", ["hello ", name]);
+    }
+
+    testing({ name: String })
+      .define(App)
+      .html((props) => `<div>hello ${props.name}</div>`)
+      .render({ name: "world" });
+  });
+
+  test("reactive values render", async () => {
+    const Counter = defineComponent({
+      props: ["counter"],
+      setup: (props: { counter: Ref<Counter> }) => {
+        useReactive();
+        return () => h("p", ["count: ", props.counter.value.count]);
+      },
+    });
+
+    function App() {
+      const counter = create(ReactiveObject);
+
+      return () => [
+        h(Counter, { counter }),
+        h(
+          "button",
+          { onClick: () => void counter.value.increment() },
+          "increment"
+        ),
+      ];
+    }
+
+    const result = define({
+      setup: App,
+    })
+      .html(({ count }) => `<p>count: ${count}</p><button>increment</button>`, {
+        count: 0,
+      })
+      .render();
+
+    await result.update(async () => result.find("button").fire.click(), {
+      count: 1,
+    });
+  });
+});
+
+const INITIAL_COUNT = 0;
+const INCREMENT = 1;
+
+interface Counter {
+  readonly count: number;
+  readonly increment: () => void;
+}
+
+const ReactiveObject = Resource((): Counter => {
+  const cell = Cell(INITIAL_COUNT);
+
+  const increment = () => {
+    return cell.set(cell.current + INCREMENT);
+  };
+
+  return {
+    get count() {
+      return cell.current;
+    },
+
+    increment,
+  };
+});
+
+// function ReactiveObject(): { cell: Cell<number>; increment: () => void } {
+//   const cell = Cell(INITIAL_COUNT, {
+//     description: `ReactiveObject #${++nextId}`,
+//   });
+
+//   function increment(): void {
+//     cell.set(cell.current + INCREMENT);
+//   }
+
+//   return { cell, increment };
+// }

--- a/packages/vue/vue/tests/package.json
+++ b/packages/vue/vue/tests/package.json
@@ -1,0 +1,26 @@
+{
+  "private": true,
+  "name": "@starbeam-tests/vue",
+  "version": "1.0.0",
+  "type": "module",
+  "starbeam:type": "tests",
+  "scripts": {
+    "test:lint": "eslint ",
+    "test:types": "tsc -b"
+  },
+  "dependencies": {
+    "@starbeam/debug": "workspace:^",
+    "@starbeam/resource": "workspace:^",
+    "@starbeam/runtime": "workspace:^",
+    "@starbeam/service": "workspace:^",
+    "@starbeam/universal": "workspace:^",
+    "@starbeam/vue": "workspace:^",
+    "@starbeam-workspace/test-utils": "workspace:^",
+    "@starbeam-workspace/vue-testing-utils": "workspace:^",
+    "@testing-library/dom": "^9.2.0",
+    "@testing-library/vue": "^7.0.0",
+    "@vue/test-utils": "^2.3.2",
+    "jsdom": "^21.1.1",
+    "vue": ">=3.0.0"
+  }
+}

--- a/packages/vue/vue/tests/resources.spec.ts
+++ b/packages/vue/vue/tests/resources.spec.ts
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+
+import { create } from "@starbeam/vue";
+import {
+  describe,
+  expect,
+  resources,
+  test,
+  TestResource,
+} from "@starbeam-workspace/test-utils";
+import { define } from "@starbeam-workspace/vue-testing-utils";
+import { h } from "vue";
+
+describe("resources", () => {
+  test("resources are cleaned up correctly", () => {
+    const result = define({
+      setup: () => {
+        const test = create(TestResource);
+        return () => h("p", ["hello ", test.value.id]);
+      },
+    })
+      .html(({ id }) => `<p>hello ${id}</p>`, { id: resources.nextId })
+      .render();
+
+    result.unmount();
+
+    expect(resources.last.isActive).toBe(false);
+  });
+});

--- a/packages/vue/vue/tests/services.spec.ts
+++ b/packages/vue/vue/tests/services.spec.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { service, Starbeam } from "@starbeam/vue";
+import {
+  describe,
+  expect,
+  resources,
+  test,
+  TestResource,
+} from "@starbeam-workspace/test-utils";
+import { define, testing } from "@starbeam-workspace/vue-testing-utils";
+import { defineComponent, h, type VNode } from "vue";
+
+describe("services", () => {
+  test("services are like resources", () => {
+    function App() {
+      const test = service(TestResource);
+      return () => h("p", [test.value.id]);
+    }
+
+    const result = define({ setup: App }, Starbeam)
+      .html(({ id }) => `<p>${id}</p>`, {
+        id: resources.nextId,
+      })
+      .render();
+
+    result.unmount();
+
+    expect(resources.last.isActive).toBe(false);
+  });
+
+  const Inner = defineComponent({
+    setup: () => {
+      const test = service(TestResource);
+      return () => h("p", ["inner: ", test.value.id]);
+    },
+  });
+
+  test("a service is only instantiated once", async () => {
+    function App(props: { id: number }): () => VNode[] {
+      const test = service(TestResource);
+      return () => [
+        h("p", [`id prop: ${props.id}`]),
+        h("p", [`outer: ${test.value.id}`]),
+        h(Inner),
+      ];
+    }
+
+    const result = testing({ id: Number })
+      .define({ setup: App }, Starbeam)
+      .html(
+        ({ id }, { testId }) => {
+          return `<p>id prop: ${id}</p><p>outer: ${testId}</p><p>inner: ${testId}</p>`;
+        },
+        {
+          testId: 1,
+        }
+      )
+      .render({ id: 1 });
+
+    await result.rerender({ id: 2 }, { testId: 1 });
+
+    result.unmount();
+
+    expect(resources.last.isActive).toBe(false);
+  });
+});

--- a/packages/vue/vue/tests/support/testing.ts
+++ b/packages/vue/vue/tests/support/testing.ts
@@ -1,0 +1,323 @@
+import { type ByRoleMatcher, getByRole, getByText } from "@testing-library/dom";
+import * as testing from "@testing-library/preact";
+import {
+  type Attributes,
+  type ComponentChildren,
+  type ComponentClass,
+  type ComponentType,
+  createElement,
+  Fragment,
+  type FunctionComponent,
+  h,
+  type VNode,
+} from "preact";
+import { act } from "preact/test-utils";
+import { renderToString } from "preact-render-to-string";
+import { expect } from "vitest";
+
+type TestComponentType<P> =
+  | ComponentClass<P>
+  | (FunctionComponent<P> extends (...args: infer A) => infer R
+      ? (...args: A) => R | VNode[]
+      : never);
+
+interface RenderExpectations<T> {
+  html?: (value: T) => ComponentChildren;
+}
+
+export function RenderTest(
+  component: TestComponentType<void>,
+  props?: Attributes,
+  options?: { into?: HTMLElement }
+): Render<void, void>;
+export function RenderTest<P>(
+  component: TestComponentType<P>,
+  props: Attributes & P,
+  options?: { into?: HTMLElement }
+): Render<P, void>;
+export function RenderTest<P>(
+  component: TestComponentType<P>,
+  props: Attributes & P,
+  { into = document.createElement("div") }: { into?: HTMLElement } = {}
+): Render<P, void> {
+  return new Render(component, props, into, Expect.from(into));
+}
+
+class Expect<T> {
+  static from<T>(container: HTMLElement): Expect<T> {
+    return new Expect(container, undefined);
+  }
+
+  readonly #container: HTMLElement;
+  readonly #expectations: RenderExpectations<T> | undefined;
+
+  constructor(
+    container: HTMLElement,
+    expectations: RenderExpectations<T> | undefined
+  ) {
+    this.#container = container;
+    this.#expectations = expectations;
+  }
+
+  check(value: T): void {
+    if (this.#expectations && this.#expectations.html) {
+      const expected = this.#expectations.html(value);
+      const string = renderToString(
+        h(Fragment, {}, expected) as VNode<unknown>
+      );
+
+      expect(this.#container.innerHTML).toBe(string);
+    }
+  }
+}
+
+class Render<P, T> {
+  readonly #component: TestComponentType<P>;
+  #props: Attributes & P;
+  readonly #into: HTMLElement;
+  readonly #expect: Expect<T>;
+
+  constructor(
+    component: TestComponentType<P>,
+    props: Attributes & P,
+    into: HTMLElement,
+    expectation: Expect<T>
+  ) {
+    this.#component = component;
+    this.#props = props;
+    this.#into = into;
+    this.#expect = expectation;
+  }
+
+  render(value?: T): RenderResult<P, T> {
+    const result = testing.render(
+      createElement(this.#component as ComponentType<P>, this.#props),
+      {
+        container: this.#into as Element,
+      }
+    );
+
+    if (value) {
+      this.#expect.check(value);
+    }
+
+    return RenderResult.create<P, T>({
+      component: this.#component,
+      container: this.#into,
+      expectation: this.#expect,
+      props: this.#props,
+      result,
+    });
+  }
+
+  html(this: Render<P, void>, check: () => ComponentChildren): Render<P, void>;
+  html<U>(
+    this: Render<P, void>,
+    check: (value: U) => ComponentChildren
+  ): Render<P, U>;
+  html<U extends T>(
+    this: Render<P, void>,
+    check: (value: U) => ComponentChildren
+  ): Render<P, U>;
+  html<U>(check: (value: U) => ComponentChildren): Render<P, U> {
+    return new Render(
+      this.#component,
+      this.#props,
+      this.#into,
+      new Expect(this.#into, {
+        ...this.#expect,
+        html: check,
+      })
+    );
+  }
+}
+
+class RenderResult<P, T> {
+  static create<P, T>({
+    component,
+    container,
+    expectation,
+    next,
+    props,
+    result,
+  }: {
+    component: TestComponentType<P>;
+    container: HTMLElement;
+    expectation: Expect<T>;
+    props: Attributes & P;
+    result: testing.RenderResult;
+    next?: { value: T };
+  }): RenderResult<P, T> {
+    return new RenderResult(
+      component,
+      container,
+      expectation,
+      next,
+      props,
+      result
+    );
+  }
+
+  readonly #component: TestComponentType<P>;
+  readonly #container: HTMLElement;
+  readonly #expect: Expect<T>;
+  readonly #next: { value: T } | undefined;
+  #props: Attributes & P;
+  #result: testing.RenderResult;
+
+  constructor(
+    component: TestComponentType<P>,
+    container: HTMLElement,
+    expectation: Expect<T>,
+    next: { value: T } | undefined,
+    props: Attributes & P,
+    result: testing.RenderResult
+  ) {
+    this.#component = component;
+    this.#container = container;
+    this.#expect = expectation;
+    this.#next = next;
+    this.#props = props;
+    this.#result = result;
+  }
+
+  get element(): TestElement<HTMLElement, T> {
+    return TestElement.create(this.#container, this.#expect, this.#next);
+  }
+
+  get innerHTML(): string {
+    return this.element.innerHTML;
+  }
+
+  get fire(): Fire {
+    return this.element.fire;
+  }
+
+  render(props?: P): this {
+    if (props) {
+      this.#props = props;
+    }
+    this.#result.rerender(
+      createElement(this.#component as ComponentType<P>, this.#props)
+    );
+    return this;
+  }
+
+  find(
+    role: ByRoleMatcher,
+    options?: testing.ByRoleOptions
+  ): TestElement<HTMLElement, T> {
+    return this.element.find(role, options);
+  }
+
+  unmount(): void {
+    this.#result.unmount();
+  }
+
+  next(value: T): RenderResult<P, T> {
+    return RenderResult.create({
+      component: this.#component,
+      container: this.#container,
+      expectation: this.#expect,
+      props: this.#props,
+      result: this.#result,
+      next: { value },
+    });
+  }
+}
+
+type Fire = {
+  [P in keyof testing.FireObject]: testing.FireObject[P] extends (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    element: any,
+    ...args: infer Args
+  ) => infer Return
+    ? (...args: Args) => Promise<Return>
+    : never;
+};
+
+export class TestElement<E extends Element, T> {
+  static create<E extends Element, T>(
+    element: E,
+    expectation: Expect<T>,
+    next: { value: T } | undefined
+  ): TestElement<E, T> {
+    return new TestElement(element, expectation, next);
+  }
+
+  readonly #element: E;
+  readonly #expect: Expect<T>;
+  readonly #next: { value: T } | undefined;
+
+  readonly fire: Fire;
+
+  constructor(
+    element: E,
+    expectation: Expect<T>,
+    next: { value: T } | undefined
+  ) {
+    this.#element = element;
+    this.#expect = expectation;
+    this.#next = next;
+
+    const fire = new Proxy(testing.fireEvent, {
+      get: (target, prop) => {
+        const value = Reflect.get(target, prop) as unknown;
+        if (typeof value === "function") {
+          return async (...args: unknown[]) => {
+            let result: unknown = false;
+
+            await act(() => {
+              result = value(this.#element, ...args);
+            });
+
+            if (this.#next) {
+              this.#expect.check(this.#next.value);
+            }
+
+            return result;
+          };
+        }
+        return value;
+      },
+    });
+
+    this.fire = fire as unknown as Fire;
+  }
+
+  get innerHTML(): string {
+    return this.#element.innerHTML;
+  }
+
+  get textContent(): string {
+    return this.#element.textContent ?? "";
+  }
+
+  find(
+    this: TestElement<HTMLElement, T>,
+    role: ByRoleMatcher,
+    options?: testing.ByRoleOptions
+  ): TestElement<HTMLElement, T> {
+    return TestElement.create(
+      getByRole(this.#element, role, options),
+      this.#expect,
+      this.#next
+    );
+  }
+
+  findByText(
+    this: TestElement<HTMLElement, T>,
+    id: testing.Matcher,
+    options?: testing.SelectorMatcherOptions
+  ): TestElement<HTMLElement, T> {
+    return TestElement.create(
+      getByText(this.#element, id, options),
+      this.#expect,
+      this.#next
+    );
+  }
+
+  raw<U>(callback: (element: E) => U): U {
+    return callback(this.#element);
+  }
+}

--- a/packages/vue/vue/tests/tsconfig.json
+++ b/packages/vue/vue/tests/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../../.config/tsconfig/tsconfig.shared.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "../../../../dist/types",
+    "declarationMap": true,
+    "outDir": "../../../../dist/packages",
+    "types": ["../../../env"]
+  },
+  "exclude": ["dist/**/*"],
+  "references": [
+    {
+      "path": "../../vue-testing-utils/tsconfig.json"
+    }
+  ]
+}

--- a/packages/vue/vue/tsconfig.json
+++ b/packages/vue/vue/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../.config/tsconfig/tsconfig.shared.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "../../../dist/types",
+    "declarationMap": true,
+    "outDir": "../../../dist/packages",
+    "types": ["../../env"]
+  },
+  "exclude": ["dist/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,7 +201,7 @@ importers:
         specifier: ^0.2.3
         version: 0.2.3(esbuild@0.17.17)
       '@vitest/ui':
-        specifier: ^0.30.1
+        specifier: '*'
         version: 0.30.1
       vite:
         specifier: 4.2.2
@@ -235,7 +235,7 @@ importers:
         specifier: ^0.2.3
         version: 0.2.3(esbuild@0.17.17)
       '@vitest/ui':
-        specifier: ^0.30.1
+        specifier: '*'
         version: 0.30.1
       vite:
         specifier: 4.2.2
@@ -272,7 +272,7 @@ importers:
         specifier: ^18.0.11
         version: 18.0.11
       '@vitest/ui':
-        specifier: ^0.30.1
+        specifier: '*'
         version: 0.30.1
       vite:
         specifier: 4.2.2
@@ -321,7 +321,7 @@ importers:
         specifier: ^18.0.11
         version: 18.0.11
       '@vitest/ui':
-        specifier: ^0.30.1
+        specifier: '*'
         version: 0.30.1
       vite:
         specifier: 4.2.2
@@ -401,7 +401,7 @@ importers:
         specifier: ^18.0.11
         version: 18.0.11
       '@vitest/ui':
-        specifier: ^0.30.1
+        specifier: '*'
         version: 0.30.1
       vite:
         specifier: 4.2.2
@@ -447,7 +447,7 @@ importers:
         specifier: ^5.1.25
         version: 5.1.25
       '@vitest/ui':
-        specifier: ^0.30.1
+        specifier: '*'
         version: 0.30.1
       axios:
         specifier: ^1.3.5
@@ -496,7 +496,7 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4
       '@vitest/ui':
-        specifier: ^0.30.1
+        specifier: '*'
         version: 0.30.1
       vite:
         specifier: 4.2.2
@@ -539,7 +539,7 @@ importers:
         specifier: ^18.0.11
         version: 18.0.11
       '@vitest/ui':
-        specifier: ^0.30.1
+        specifier: '*'
         version: 0.30.1
       vite:
         specifier: 4.2.2
@@ -672,7 +672,7 @@ importers:
         version: 10.13.2
     devDependencies:
       '@starbeam-dev/build-support':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../../../workspace/build
       rollup:
         specifier: ^3.20.6
@@ -1419,6 +1419,165 @@ importers:
       '@starbeam/verify':
         specifier: workspace:^
         version: link:..
+
+  packages/vue/vue:
+    dependencies:
+      '@starbeam/core-utils':
+        specifier: workspace:^
+        version: link:../../universal/core-utils
+      '@starbeam/debug':
+        specifier: workspace:^
+        version: link:../../universal/debug
+      '@starbeam/interfaces':
+        specifier: workspace:^
+        version: link:../../universal/interfaces
+      '@starbeam/reactive':
+        specifier: workspace:^
+        version: link:../../universal/reactive
+      '@starbeam/resource':
+        specifier: workspace:^
+        version: link:../../universal/resource
+      '@starbeam/runtime':
+        specifier: workspace:^
+        version: link:../../universal/runtime
+      '@starbeam/service':
+        specifier: workspace:^
+        version: link:../../universal/service
+      '@starbeam/tags':
+        specifier: workspace:^
+        version: link:../../universal/tags
+      '@starbeam/universal':
+        specifier: workspace:^
+        version: link:../../universal/universal
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../../universal/verify
+      vue:
+        specifier: ^3.2.47
+        version: 3.2.47
+    devDependencies:
+      '@starbeam-dev/build-support':
+        specifier: workspace:*
+        version: link:../../../workspace/build
+      rollup:
+        specifier: ^3.20.6
+        version: 3.20.6
+
+  packages/vue/vue-testing-utils:
+    dependencies:
+      '@starbeam-workspace/test-utils':
+        specifier: workspace:^
+        version: link:../../../workspace/test-utils
+      '@starbeam/interfaces':
+        specifier: workspace:^
+        version: link:../../universal/interfaces
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../../universal/verify
+      '@testing-library/dom':
+        specifier: ^9.2.0
+        version: 9.2.0
+      '@testing-library/vue':
+        specifier: ^7.0.0
+        version: 7.0.0(@vue/compiler-sfc@3.2.47)(vue@3.2.47)
+      vue:
+        specifier: '>=3.0.0'
+        version: 3.2.47
+    devDependencies:
+      '@starbeam-dev/build-support':
+        specifier: workspace:*
+        version: link:../../../workspace/build
+      rollup:
+        specifier: ^3.20.6
+        version: 3.20.6
+
+  packages/vue/vue-testing-utils/tests:
+    dependencies:
+      '@starbeam-workspace/test-utils':
+        specifier: workspace:^
+        version: link:../../../../workspace/test-utils
+      '@starbeam-workspace/vue-testing-utils':
+        specifier: workspace:^
+        version: link:..
+      '@starbeam/debug':
+        specifier: workspace:^
+        version: link:../../../universal/debug
+      '@starbeam/interfaces':
+        specifier: workspace:^
+        version: link:../../../universal/interfaces
+      '@starbeam/preact':
+        specifier: workspace:^
+        version: link:../../../preact/preact
+      '@starbeam/runtime':
+        specifier: workspace:^
+        version: link:../../../universal/runtime
+      '@starbeam/universal':
+        specifier: workspace:^
+        version: link:../../../universal/universal
+      '@starbeam/vue':
+        specifier: workspace:^
+        version: link:../../vue
+      '@testing-library/dom':
+        specifier: ^9.2.0
+        version: 9.2.0
+      '@testing-library/vue':
+        specifier: ^7.0.0
+        version: 7.0.0(@vue/compiler-sfc@3.2.47)(vue@3.2.47)
+      htm:
+        specifier: ^3.1.1
+        version: 3.1.1
+      jsdom:
+        specifier: ^21.1.1
+        version: 21.1.1
+      vue:
+        specifier: '>=3.0.0'
+        version: 3.2.47
+    devDependencies:
+      preact-render-to-string:
+        specifier: ^6.0.2
+        version: 6.0.2(preact@10.13.2)
+
+  packages/vue/vue/tests:
+    dependencies:
+      '@starbeam-workspace/test-utils':
+        specifier: workspace:^
+        version: link:../../../../workspace/test-utils
+      '@starbeam-workspace/vue-testing-utils':
+        specifier: workspace:^
+        version: link:../../vue-testing-utils
+      '@starbeam/debug':
+        specifier: workspace:^
+        version: link:../../../universal/debug
+      '@starbeam/resource':
+        specifier: workspace:^
+        version: link:../../../universal/resource
+      '@starbeam/runtime':
+        specifier: workspace:^
+        version: link:../../../universal/runtime
+      '@starbeam/service':
+        specifier: workspace:^
+        version: link:../../../universal/service
+      '@starbeam/universal':
+        specifier: workspace:^
+        version: link:../../../universal/universal
+      '@starbeam/vue':
+        specifier: workspace:^
+        version: link:..
+      '@testing-library/dom':
+        specifier: ^9.2.0
+        version: 9.2.0
+      '@testing-library/vue':
+        specifier: ^7.0.0
+        version: 7.0.0(@vue/compiler-sfc@3.2.47)(vue@3.2.47)
+      '@vue/test-utils':
+        specifier: ^2.3.2
+        version: 2.3.2(vue@3.2.47)
+      jsdom:
+        specifier: ^21.1.1
+        version: 21.1.1
+      vue:
+        specifier: '>=3.0.0'
+        version: 3.2.47
 
   packages/x/devtool:
     dependencies:
@@ -3963,6 +4122,20 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
+  /@testing-library/vue@7.0.0(@vue/compiler-sfc@3.2.47)(vue@3.2.47):
+    resolution: {integrity: sha512-JU/q93HGo2qdm1dCgWymkeQlfpC0/0/DBZ2nAHgEAsVZxX11xVIxT7gbXdI7HACQpUbsUWt1zABGU075Fzt9XQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@vue/compiler-sfc': '>= 3'
+      vue: '>= 3'
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@testing-library/dom': 9.2.0
+      '@vue/compiler-sfc': 3.2.47
+      '@vue/test-utils': 2.3.2(vue@3.2.47)
+      vue: 3.2.47
+    dev: false
+
   /@tootallnate/once@2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -4309,7 +4482,7 @@ packages:
   /@vue/compiler-sfc@3.2.47:
     resolution: {integrity: sha512-rog05W+2IFfxjMcFw10tM9+f7i/+FFpZJJ5XHX72NP9eC2uRD+42M3pYcQqDXVYoj74kHMSEdQ/WmCjt8JFksQ==}
     dependencies:
-      '@babel/parser': 7.16.4
+      '@babel/parser': 7.21.4
       '@vue/compiler-core': 3.2.47
       '@vue/compiler-dom': 3.2.47
       '@vue/compiler-ssr': 3.2.47
@@ -4338,8 +4511,51 @@ packages:
       magic-string: 0.25.9
     dev: false
 
+  /@vue/reactivity@3.2.47:
+    resolution: {integrity: sha512-7khqQ/75oyyg+N/e+iwV6lpy1f5wq759NdlS1fpAhFXa8VeAIKGgk2E/C4VF59lx5b+Ezs5fpp/5WsRYXQiKxQ==}
+    dependencies:
+      '@vue/shared': 3.2.47
+    dev: false
+
+  /@vue/runtime-core@3.2.47:
+    resolution: {integrity: sha512-RZxbLQIRB/K0ev0K9FXhNbBzT32H9iRtYbaXb0ZIz2usLms/D55dJR2t6cIEUn6vyhS3ALNvNthI+Q95C+NOpA==}
+    dependencies:
+      '@vue/reactivity': 3.2.47
+      '@vue/shared': 3.2.47
+    dev: false
+
+  /@vue/runtime-dom@3.2.47:
+    resolution: {integrity: sha512-ArXrFTjS6TsDei4qwNvgrdmHtD930KgSKGhS5M+j8QxXrDJYLqYw4RRcDy1bz1m1wMmb6j+zGLifdVHtkXA7gA==}
+    dependencies:
+      '@vue/runtime-core': 3.2.47
+      '@vue/shared': 3.2.47
+      csstype: 2.6.21
+    dev: false
+
+  /@vue/server-renderer@3.2.47(vue@3.2.47):
+    resolution: {integrity: sha512-dN9gc1i8EvmP9RCzvneONXsKfBRgqFeFZLurmHOveL7oH6HiFXJw5OGu294n1nHc/HMgTy6LulU/tv5/A7f/LA==}
+    peerDependencies:
+      vue: 3.2.47
+    dependencies:
+      '@vue/compiler-ssr': 3.2.47
+      '@vue/shared': 3.2.47
+      vue: 3.2.47
+    dev: false
+
   /@vue/shared@3.2.47:
     resolution: {integrity: sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==}
+    dev: false
+
+  /@vue/test-utils@2.3.2(vue@3.2.47):
+    resolution: {integrity: sha512-hJnVaYhbrIm0yBS0+e1Y0Sj85cMyAi+PAbK4JHqMRUZ6S622Goa+G7QzkRSyvCteG8wop7tipuEbHoZo26wsSA==}
+    peerDependencies:
+      vue: ^3.0.1
+    dependencies:
+      js-beautify: 1.14.6
+      vue: 3.2.47
+    optionalDependencies:
+      '@vue/compiler-dom': 3.2.47
+      '@vue/server-renderer': 3.2.47(vue@3.2.47)
     dev: false
 
   /@webcomponents/custom-elements@1.6.0:
@@ -4353,6 +4569,10 @@ packages:
 
   /abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+
+  /abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+    dev: false
 
   /acorn-globals@7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
@@ -4906,6 +5126,10 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
+  /commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+    dev: false
+
   /commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
@@ -4946,6 +5170,13 @@ packages:
       md5-hex: 3.0.1
       semver: 7.5.0
       well-known-symbols: 2.0.0
+
+  /config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
+    dev: false
 
   /confusing-browser-globals@1.0.11:
     resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
@@ -5144,6 +5375,10 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       rrweb-cssom: 0.6.0
+
+  /csstype@2.6.21:
+    resolution: {integrity: sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==}
+    dev: false
 
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
@@ -5428,6 +5663,16 @@ packages:
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  /editorconfig@0.15.3:
+    resolution: {integrity: sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==}
+    hasBin: true
+    dependencies:
+      commander: 2.20.3
+      lru-cache: 4.1.5
+      semver: 5.7.1
+      sigmund: 1.0.1
+    dev: false
 
   /electron-to-chromium@1.4.368:
     resolution: {integrity: sha512-e2aeCAixCj9M7nJxdB/wDjO6mbYX+lJJxSJCXDzlr5YPGYVofuJwGN9nKg2o6wWInjX6XmxRinn3AeJMK81ltw==}
@@ -6457,6 +6702,10 @@ packages:
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  /ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+    dev: false
+
   /inspect-custom-symbol@1.1.1:
     resolution: {integrity: sha512-GOucsp9EcdlLdhPUyOTvQDnbFJtp2WBWZV1Jqe+mVnkJQBL3w96+fB84C+JL+EKXOspMdB0eMDQPDp5w9fkfZA==}
     dev: false
@@ -6681,6 +6930,17 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  /js-beautify@1.14.6:
+    resolution: {integrity: sha512-GfofQY5zDp+cuHc+gsEXKPpNw2KbPddreEo35O6jT6i0RVK6LhsoYBhq5TvK4/n74wnA0QbK8gGd+jUZwTMKJw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 0.15.3
+      glob: 8.1.0
+      nopt: 6.0.0
+    dev: false
 
   /js-sdsl@4.4.0:
     resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
@@ -6950,7 +7210,6 @@ packages:
     dependencies:
       pseudomap: 1.0.2
       yallist: 2.1.2
-    dev: true
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -7142,6 +7401,14 @@ packages:
 
   /node-releases@2.0.10:
     resolution: {integrity: sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==}
+
+  /nopt@6.0.0:
+    resolution: {integrity: sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      abbrev: 1.1.1
+    dev: false
 
   /normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -7881,12 +8148,15 @@ packages:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  /proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+    dev: false
+
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   /pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
-    dev: true
 
   /psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
@@ -8290,7 +8560,6 @@ packages:
   /semver@5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
     hasBin: true
-    dev: true
 
   /semver@6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
@@ -8364,6 +8633,10 @@ packages:
 
   /siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  /sigmund@1.0.1:
+    resolution: {integrity: sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==}
+    dev: false
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -9160,6 +9433,16 @@ packages:
     resolution: {integrity: sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA==}
     dev: false
 
+  /vue@3.2.47:
+    resolution: {integrity: sha512-60188y/9Dc9WVrAZeUVSDxRQOZ+z+y5nO2ts9jWXSTkMvayiWxCWOWtBQoYjLeccfXkiiPZWAHcV+WTPhkqJHQ==}
+    dependencies:
+      '@vue/compiler-dom': 3.2.47
+      '@vue/compiler-sfc': 3.2.47
+      '@vue/runtime-dom': 3.2.47
+      '@vue/server-renderer': 3.2.47(vue@3.2.47)
+      '@vue/shared': 3.2.47
+    dev: false
+
   /w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
     engines: {node: '>=14'}
@@ -9329,7 +9612,6 @@ packages:
 
   /yallist@2.1.2:
     resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
-    dev: true
 
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}

--- a/workspace/eslint/package.json
+++ b/workspace/eslint/package.json
@@ -23,6 +23,7 @@
     "type": "library:build-support"
   },
   "scripts": {
+    "test:lint": "eslint \"src/**/*.{js,d.ts}\"",
     "test:types": "tsc -b"
   },
   "dependencies": {


### PR DESCRIPTION
This is an initial implementation of a Vue renderer.

It supports reactivity, resources and services.

In the current implementation, the `create` function is used in a Vue component setup context (`<script setup>` or the `setup` method) to create a reactive instance. It takes a `ResourceBlueprint`. The `service` function works the same way, but creates a single instance of the resource per app instance and cleans up the resource when it's done.

Both `create` and `service` return a `Ref<T>` that is automatically synchronized with the `Reactive<T>` instance returned by instantiating the blueprint. Any changes to the `Reactive<T>` update the `Ref<T>` and notify Vue to re-render the component.

It's possible to access Starbeam state in a render function (or template) without having used `create` explicitly. For example, you could manually create a cell and access its `current` property in the render function. In this situation, you can call `useReactive()` (with no parameters) in the setup context and everything will just work.

A follow-up PR will add back the debug read barrier that allowed us to warn React users that they were accessing Starbeam state without `useReactive`, and the same infrastructure will be used for Vue.

The biggest follow-up work needed after this PR (other than verifying that it actually works in Vue by getting real-world usage) is to consolidate the naming and APIs across the React, Preact and Vue renderers to avoid gratuitous differences in the concepts and APIs.