### PR TITLE
Allow manual running of the ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches: [master]
   merge_group:
   pull_request:
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
This is most helpful when we have long-running feature branches and haven't merged to ci in a while -- we need to be able to quickly see if we have a problem on our branch vs on main