### PR TITLE
Fix merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on:
   push:
     branches: [master]
+  merge_group:
   pull_request:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
trying things out -- 

https://github.com/orgs/community/discussions/39933
and 

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group

_by default_ having required checks blocks the merge queue, because we need to tell the CI workflow to run in the merge queue