### PR TITLE
Publish with --access=public, per the updates from embroider

### DIFF
--- a/workspace/unstable-release/publish.js
+++ b/workspace/unstable-release/publish.js
@@ -10,7 +10,7 @@ async function publish() {
   for (let workspace of publicWorkspaces) {
     console.info(`Publishing ${workspace}`);
     try {
-      await execaCommand("npm publish --tag=unstable --verbose", {
+      await execaCommand("npm publish --tag=unstable --verbose --access=public", {
         cwd: dirname(workspace),
       });
     } catch (err) {


### PR DESCRIPTION
missed this change:

https://github.com/embroider-build/embroider/blob/main/test-packages/unstable-release/publish.js