### PR TITLE
Change the ci.yml lint script to use turbo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: NullVoxPopuli/action-setup-pnpm@v2
-      - run: pnpm ci:lint
+      - run: pnpm test:workspace:lint --continue 
 
   release:
     name: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       # even if dependencies of packages have failed
       # (which means we'll have a lot of extra errors
       #  if something core doesn't pass type checking)
-      - run: pnpm test:workspace:types --continue 
+      - run: ./node_modules/.bin/turbo run test:types --continue 
 
   lint:
     name: "Lint"
@@ -73,7 +73,7 @@ jobs:
       - uses: wyvox/action@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: pnpm test:workspace:lint --continue 
+      - run: ./node_modules/.bin/turbo run test:lint --continue 
 
   # Release automation is not active at this time
   # ------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+env:
+  TURBO_API: http://127.0.0.1:9080
+  TURBO_TOKEN: this-is-not-a-secret
+  TURBO_TEAM: the-starbeam-folks
+
 jobs:
   install_dependencies:
     name: "Setup"
@@ -60,15 +65,18 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: ["install_dependencies"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: NullVoxPopuli/action-setup-pnpm@v2
+      - uses: wyvox/action@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm test:workspace:lint --continue 
 
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs: ["install_dependencies", "lint", "typecheck", "test", "build"]
+  # Release automation is not active at this time
+  # ------------------
+  # release:
+  #   name: Release
+  #   runs-on: ubuntu-latest
+  #   needs: ["install_dependencies", "lint", "typecheck", "test", "build"]
 
-    steps:
-      - uses: actions/checkout@v2
-      - uses: NullVoxPopuli/action-setup-pnpm@v2
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: NullVoxPopuli/action-setup-pnpm@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,14 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: ["install_dependencies"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: NullVoxPopuli/action-setup-pnpm@v2
-      - run: pnpm ci:types
+      - uses: wyvox/action@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      # --continue will keep running test:types 
+      # even if dependencies of packages have failed
+      # (which means we'll have a lot of extra errors
+      #  if something core doesn't pass type checking)
+      - run: pnpm test:workspace:types --continue 
 
   lint:
     name: "Lint"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,41 @@ These are aliased via `pnpm dev` at the monorepo root and is an alias for the sc
 
 Common monorepo tasks can be added to `<repo-root>/workspace/scripts/*` and then invoke with `pnpm dev <command name>`
 
+### Using turborepo
+
+If you're ever unsure about the cache status of each package, 
+you can inspect what turbo thinks is going to happen with
+```bash
+pnpm turbo run list of tasks --dry-run=json \
+| jq 'reduce .tasks[] as {$package,$task,$cache} ({};
+        .[$package][$task] |= $cache
+      )
+      ' 
+```
+
+For example
+```bash
+pnpm turbo run test:lint test:types --dry-run=json \
+| jq 'reduce .tasks[] as {$package,$task,$cache} ({};
+        .[$package][$task] |= $cache
+      )
+      '
+```
+
+
+To use this information with other scripts, pipe it to `jq -c`
+
+To see what _inputs_ turbo is expecting for a package, use:
+```bash
+pnpm turbo run test:lint --dry-run=json \
+| jq 'reduce .tasks[] as {$package,$task,$inputs} ({};
+      .[$package][$task] |= $inputs
+     )' \
+| jq '."@starbeam/universal"'
+```
+
+This can be useful when debugging either unexpected cache misses, or unexpected cache hits.
+
 ## The `starbeam` key in `package.json`
 
 The tooling in this repository is driven by a number of keys in `package.json` under the `starbeam`

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "check:unused": "esno ./workspace/scripts/index.ts unused",
     "ci:prod": "vitest --run --mode production",
     "ci:specs": "vitest --run",
-    "ci:types": "esno ./workspace/scripts/index.ts ci --type types -v",
     "demo": "esno ./workspace/scripts/index.ts demo",
     "dev": "esno ./workspace/scripts/index.ts",
     "lint:fix": "pnpm dev lint --fix",
@@ -96,7 +95,7 @@
     "test:workspace:lint": "turbo run lint --output-logs errors-only --log-prefix none",
     "test:workspace:prod": "PROD=1 DEV= vitest --run",
     "test:workspace:specs": "vitest --run",
-    "test:workspace:types": "tsc -b"
+    "test:workspace:types": "turbo run test:types --output-logs errors-only --log-prefix none"
   },
   "dependencies": {
     "@starbeam/core-utils": "workspace:^"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
   "scripts": {
     "build": "esno ./workspace/scripts/index.ts build",
     "check:unused": "esno ./workspace/scripts/index.ts unused",
-    "ci:lint": "esno ./workspace/scripts/index.ts ci --type lint -v",
     "ci:prod": "vitest --run --mode production",
     "ci:specs": "vitest --run",
     "ci:types": "esno ./workspace/scripts/index.ts ci --type types -v",
@@ -116,8 +115,8 @@
     "@changesets/config": "^2.3.1",
     "@edge-runtime/vm": "^3.1.3",
     "@nrr/pnpm-duplicate-cli": "^0.0.1",
-    "@starbeam-dev/build-support": "workspace:*",
     "@starbeam/eslint-plugin": "workspace:^",
+    "@starbeam-dev/build-support": "workspace:*",
     "@types/eslint": "^8.44.2",
     "@types/node": "20.6.2",
     "@typescript-eslint/eslint-plugin": "^6.7.2",

--- a/package.json
+++ b/package.json
@@ -85,17 +85,19 @@
   "scripts": {
     "build": "esno ./workspace/scripts/index.ts build",
     "check:unused": "esno ./workspace/scripts/index.ts unused",
+    "ci:lint": "esno ./workspace/scripts/index.ts ci --type lint -v",
     "ci:prod": "vitest --run --mode production",
     "ci:specs": "vitest --run",
+    "ci:types": "esno ./workspace/scripts/index.ts ci --type types -v",
     "demo": "esno ./workspace/scripts/index.ts demo",
     "dev": "esno ./workspace/scripts/index.ts",
     "lint:fix": "pnpm dev lint --fix",
     "prepack": "pnpm run build",
     "release": "esno ./workspace/scripts/index.ts release",
-    "test:workspace:lint": "turbo run test:lint --output-logs errors-only --log-prefix none",
+    "test:workspace:lint": "turbo run lint --output-logs errors-only --log-prefix none",
     "test:workspace:prod": "PROD=1 DEV= vitest --run",
     "test:workspace:specs": "vitest --run",
-    "test:workspace:types": "turbo run test:types --output-logs errors-only --log-prefix none"
+    "test:workspace:types": "tsc -b"
   },
   "dependencies": {
     "@starbeam/core-utils": "workspace:^"
@@ -114,8 +116,8 @@
     "@changesets/config": "^2.3.1",
     "@edge-runtime/vm": "^3.1.3",
     "@nrr/pnpm-duplicate-cli": "^0.0.1",
-    "@starbeam/eslint-plugin": "workspace:^",
     "@starbeam-dev/build-support": "workspace:*",
+    "@starbeam/eslint-plugin": "workspace:^",
     "@types/eslint": "^8.44.2",
     "@types/node": "20.6.2",
     "@typescript-eslint/eslint-plugin": "^6.7.2",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "lint:fix": "pnpm dev lint --fix",
     "prepack": "pnpm run build",
     "release": "esno ./workspace/scripts/index.ts release",
-    "test:workspace:lint": "turbo run lint --output-logs errors-only --log-prefix none",
+    "test:workspace:lint": "turbo run test:lint --output-logs errors-only --log-prefix none",
     "test:workspace:prod": "PROD=1 DEV= vitest --run",
     "test:workspace:specs": "vitest --run",
     "test:workspace:types": "turbo run test:types --output-logs errors-only --log-prefix none"

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,21 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  // Additive to package.json and turbo.json
+  //
+  // https://turbo.build/repo/docs/core-concepts/caching/file-inputs#specifying-additional-inputs
+  "globalDependencies": [
+    ".github/workflows/ci.yml",
+    ".npmrc",
+    ".eslintrc.json",
+    ".eslintrc.repo.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "patches",
+    "vitest.config.ts",
+    "vitest.workspace.ts",
+    "tsconfig.json",
+    "tsconfig.root.json"
+  ],
   "pipeline": {
     "lint": {
       "dependsOn": ["test:lint"],


### PR DESCRIPTION
the previous script, ci:lint, takes over 6 minutes to run on C.I., and doesn't run at all on my laptop :sweat_smile: 

The goal of this change is to:
- worst case have lint checking still be faster than 6m.
- best case have lint checking be near-noop (prior to this change, lint _always_ takes 6m, it seems)
- be kinder to the environment
- lean in to human impatience :D 


-------

Using turbo, logs are now grouped together under `<details>`-esque groups:

![image](https://github.com/starbeamjs/starbeam/assets/199018/455956c3-1369-4cb4-8e7b-60cc315153cd)


------


## Lint: Baselines (main branch results)
- 6m9s : https://github.com/starbeamjs/starbeam/actions/runs/6292201602
  - 5m40s of actual linting 
- 5m50s : https://github.com/starbeamjs/starbeam/actions/runs/6291893932
  - 5m34s of actual linting 
- 7m7s : https://github.com/starbeamjs/starbeam/actions/runs/6286683339
  - 6m39s of actual linting 

## Lint: This PR

- worst case: ~1m35s faster -- also way more consistent
  - 4m45s : https://github.com/starbeamjs/starbeam/actions/runs/6292841126/job/17082637983?pr=131
    - 4m19s of actual linting

- best case, way faster and < 4s locally (FULL TURBO)
  - 29s : https://github.com/starbeamjs/starbeam/actions/runs/6292665751/job/17082304245?pr=131
    - most of this 29s is installing node_modules
    - 6s of actual "linting"

- average case: around 1m

The average case would then lint only the packages that have changed, which keeps CI as fast as it can be.
This is why focusing on package-relative commands is so beneficial -- it allows caching per package, which enables to not do more work than we need to.


----------------------------------

## Typecheck: Baselines  (main branch results)

- 4m49s : https://github.com/starbeamjs/starbeam/actions/runs/6292201602
  - 4m28s of actual typechecking 
- 5m38s : https://github.com/starbeamjs/starbeam/actions/runs/6291893932
  - 5m8s of actual typechecking 
- 4m44s : https://github.com/starbeamjs/starbeam/actions/runs/6286683339
  - 4m22s of actual typechecking 

## Typecheck: This PR

- worst case,
  - 3m57s : https://github.com/starbeamjs/starbeam/actions/runs/6292841126/job/17082638043?pr=131
    - 3m33s of actual type checking
- average case -- maybe around 1-2m


--------------------------

A note on average / best cases -- more work needs to happen in https://github.com/starbeamjs/starbeam/pull/132
Because the turbo config is being dirtied more often than it should be. 
Likewise, we need to be sure still dirty when real things change.
So I've added some debugging tips to CONTRIBUTING.md