### PR TITLE
Turbo/lint

### DIFF
--- a/@types/shell-split/package.json
+++ b/@types/shell-split/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@starbeam/eslint-plugin": "workspace:^",
-    "@types/node": "18.16.1"
+    "@types/node": "18.16.1",
+    "eslint": "^8.49.0"
   }
 }

--- a/demos/react-jsnation/tests/package.json
+++ b/demos/react-jsnation/tests/package.json
@@ -24,6 +24,7 @@
     "@starbeam/eslint-plugin": "workspace:^",
     "@testing-library/react": "^14.0.0",
     "@types/react": "^18.2.22",
+    "eslint": "^8.49.0",
     "jsdom": "^22.1.0"
   }
 }

--- a/demos/react-stock-ticker/package.json
+++ b/demos/react-stock-ticker/package.json
@@ -43,6 +43,7 @@
     "@types/react-dom": "^18.2.7",
     "@types/react-portal": "^4.0.4",
     "@vitest/ui": "^0.34.4",
+    "eslint": "^8.49.0",
     "vite": "4.3.9",
     "vitest": "^0.34.4"
   }

--- a/packages/preact/preact-utils/package.json
+++ b/packages/preact/preact-utils/package.json
@@ -28,8 +28,9 @@
     "@starbeam/core-utils": "workspace:^"
   },
   "devDependencies": {
-    "@starbeam/eslint-plugin": "workspace:^",
     "@starbeam-dev/build-support": "workspace:^",
+    "@starbeam/eslint-plugin": "workspace:^",
+    "eslint": "^8.49.0",
     "rollup": "^3.29.2"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       '@types/node':
         specifier: 20.6.2
         version: 20.6.2
+      eslint:
+        specifier: ^8.49.0
+        version: 8.49.0
 
   demos/preact:
     dependencies:
@@ -449,6 +452,9 @@ importers:
       '@types/react':
         specifier: ^18.2.22
         version: 18.2.22
+      eslint:
+        specifier: ^8.49.0
+        version: 8.49.0
       jsdom:
         specifier: ^22.1.0
         version: 22.1.0
@@ -593,6 +599,9 @@ importers:
       '@vitest/ui':
         specifier: ^0.34.4
         version: 0.34.4(vitest@0.34.4)
+      eslint:
+        specifier: ^8.49.0
+        version: 8.49.0
       vite:
         specifier: 4.4.9
         version: 4.4.9(@types/node@20.6.2)
@@ -793,6 +802,9 @@ importers:
       '@starbeam/eslint-plugin':
         specifier: workspace:^
         version: link:../../../workspace/eslint
+      eslint:
+        specifier: ^8.49.0
+        version: 8.49.0
       rollup:
         specifier: ^3.29.2
         version: 3.29.2

--- a/turbo.json
+++ b/turbo.json
@@ -27,7 +27,7 @@
       // because we have nested workspaces.
       // We want to omit the tests workspace
       // for example.
-      "inputs": ["src/**", "*.{ts,js,mjs,json,mts,cjs,cts"]
+      "inputs": ["src/**", "*.{ts,js,mjs,json,mts,cjs,cts}"]
     },
     "test:types": {
       "outputs": [],
@@ -35,7 +35,7 @@
       // because we have nested workspaces.
       // We want to omit the tests workspace
       // for example.
-      "inputs": ["src/**", "*.{ts,js,mjs,json,mts,cjs,cts"]
+      "inputs": ["src/**", "*.{ts,js,mjs,json,mts,cjs,cts}"]
     },
     "typecheck": {
       "dependsOn": ["test:types"],

--- a/turbo.json
+++ b/turbo.json
@@ -22,10 +22,20 @@
       "outputs": []
     },
     "test:lint": {
-      "outputs": []
+      "outputs": [],
+      // We manually manage inputs
+      // because we have nested workspaces.
+      // We want to omit the tests workspace
+      // for example.
+      "inputs": ["src/**", "*.{ts,js,mjs,json,mts,cjs,cts"]
     },
     "test:types": {
-      "outputs": []
+      "outputs": [],
+      // We manually manage inputs
+      // because we have nested workspaces.
+      // We want to omit the tests workspace
+      // for example.
+      "inputs": ["src/**", "*.{ts,js,mjs,json,mts,cjs,cts"]
     },
     "typecheck": {
       "dependsOn": ["test:types"],


### PR DESCRIPTION
Running `pnpm turbo lint`
1. should work
2. should really help speed things up, as we're not going to be working in most packages all the time.

Main changes:
- every package needs access to the bins. eslint, prettier, etc.
- so every package needs those added as deps, and have appropriate configs