### PR TITLE
Only unstable-tag @starbeam deps

### DIFF
--- a/workspace/unstable-release/src/workspaces.js
+++ b/workspace/unstable-release/src/workspaces.js
@@ -10,8 +10,7 @@ import { readPackageJson } from "./read-package-json.js";
  */
 export async function listPublicWorkspaces() {
   let filePaths = await globby([
-    "packages/**/package.json", 
-    "workspace/@domtree/**/package.json"
+    "packages/**/package.json"
   ], {
     gitignore: true,
     ignore: ["**/tests/**", "**/node_modules/**"],
@@ -24,6 +23,7 @@ export async function listPublicWorkspaces() {
   for (let filePath of filePaths) {
     let packageJson = await readPackageJson(filePath);
 
+    if (!packageJson.name?.startsWith('@starbeam/')) continue;
     if (packageJson.private) continue;
 
     result.push(filePath);


### PR DESCRIPTION
Previously, the `@domtree` dependencies were included in the unstable publish.

This was because the `@domtree` dependencies were incorrectly published... not built.

that's still the case today...