### PR TITLE
Better production stripping - 61KB smaller, 63% of `main`'s size, 2.7x smaller

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     },
     "overrides": {
       "@rollup/pluginutils": "latest",
-      "@starbeam-dev/compile": "github:starbeamjs/dev-compile#9873982",
+      "@starbeam-dev/compile": "1.2.0",
       "@types/eslint": "$@types/eslint",
       "@types/node": "$@types/node",
       "eslint": "$eslint",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     },
     "overrides": {
       "@rollup/pluginutils": "latest",
-      "@starbeam-dev/compile": "github:starbeamjs/dev-compile#1fe1af7",
+      "@starbeam-dev/compile": "github:starbeamjs/dev-compile#9873982",
       "@types/eslint": "$@types/eslint",
       "@types/node": "$@types/node",
       "eslint": "$eslint",

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     },
     "overrides": {
       "@rollup/pluginutils": "latest",
+      "@starbeam-dev/compile": "github:starbeamjs/dev-compile#1fe1af7",
       "@types/eslint": "$@types/eslint",
       "@types/node": "$@types/node",
       "eslint": "$eslint",

--- a/packages/universal/debug/rollup.config.mjs
+++ b/packages/universal/debug/rollup.config.mjs
@@ -1,3 +1,7 @@
 import { compile } from "@starbeam-dev/compile";
 
-export default compile(import.meta);
+const config = compile(import.meta);
+
+console.log(config);
+
+export default config;

--- a/packages/universal/debug/rollup.config.mjs
+++ b/packages/universal/debug/rollup.config.mjs
@@ -1,7 +1,3 @@
 import { compile } from "@starbeam-dev/compile";
 
-const config = compile(import.meta);
-
-console.log(config);
-
-export default config;
+export default compile(import.meta);

--- a/packages/universal/debug/src/call-stack/entry.ts
+++ b/packages/universal/debug/src/call-stack/entry.ts
@@ -29,17 +29,17 @@ export class EntryPoints {
     this: void,
     options?:
       | {
-          caller?: CallStack | undefined;
-          description?: EntryPointDescriptionArg | string | undefined;
-          force?: boolean | undefined;
-        }
+        caller?: CallStack | undefined;
+        description?: EntryPointDescriptionArg | string | undefined;
+        force?: boolean | undefined;
+      }
       | EntryPointDescriptionArg
       | EntryPoint
       | string,
-  ): EntryPoint {
+  ): void {
     if (options instanceof EntryPointImpl) {
       ENTRY_POINTS.#upsert(options, false);
-      return options;
+      return;
     }
 
     let caller: CallStack | undefined;
@@ -64,7 +64,8 @@ export class EntryPoints {
       force = false;
     }
 
-    return ENTRY_POINTS.mark(caller, description, force);
+    ENTRY_POINTS.mark(caller, description, force);
+    return;
   }
 
   #entry: EntryPointImpl | undefined;
@@ -199,10 +200,10 @@ function stringify(value: unknown): string {
 function collectionOp(
   arg: [
     operation:
-      | "collection:has"
-      | "collection:get"
-      | "collection:insert"
-      | "collection:delete",
+    | "collection:has"
+    | "collection:get"
+    | "collection:insert"
+    | "collection:delete",
     entity: DescriptionDetails | string | undefined,
     key: unknown,
   ],

--- a/packages/universal/debug/src/debug.ts
+++ b/packages/universal/debug/src/debug.ts
@@ -13,13 +13,29 @@ const untrackedReadBarrier = (() => {
   /* FIXME: do nothing for now */
 }) satisfies DebugRuntime["untrackedReadBarrier"];
 
-export default {
-  Desc,
-  callerStack,
-  getUserFacing,
-  untrackedReadBarrier,
-  describe,
-  describeTagged,
-  markEntryPoint,
-  getEntryPoint,
+let debugEnv = {
+  Desc: () => undefined,
+  callerStack: () => undefined,
+  getUserFacing: (x) => x,
+  untrackedReadBarrier: () => undefined,
+  describe: () => '',
+  describeTagged: () => '',
+  markEntryPoint: () => undefined,
+  getEntryPoint: () => undefined,
 } satisfies DebugRuntime;
+
+if (import.meta.env.DEV) {
+  debugEnv = {
+    Desc,
+    callerStack,
+    getUserFacing,
+    untrackedReadBarrier,
+    describe,
+    describeTagged,
+    markEntryPoint,
+    getEntryPoint,
+  } satisfies DebugRuntime;
+}
+
+export default debugEnv;
+

--- a/packages/universal/debug/src/debug.ts
+++ b/packages/universal/debug/src/debug.ts
@@ -14,7 +14,7 @@ const untrackedReadBarrier = (() => {
 }) satisfies DebugRuntime["untrackedReadBarrier"];
 
 let debugEnv = {
-  Desc: () => undefined,
+  Desc: (() => undefined),
   callerStack: () => undefined,
   getUserFacing: (x) => x,
   untrackedReadBarrier: () => undefined,
@@ -22,7 +22,7 @@ let debugEnv = {
   describeTagged: () => '',
   markEntryPoint: () => undefined,
   getEntryPoint: () => undefined,
-} satisfies DebugRuntime;
+} as DebugRuntime;
 
 if (import.meta.env.DEV) {
   debugEnv = {

--- a/packages/universal/debug/src/setup.ts
+++ b/packages/universal/debug/src/setup.ts
@@ -2,21 +2,23 @@ import { defineDebug } from "@starbeam/reactive";
 
 import debug from "./debug.js";
 
-if (
-  (globalThis.Buffer as BufferConstructor | undefined) === undefined &&
-  typeof require === "function"
-) {
-  try {
-    // this is for CJS only, so require is the only option here
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const buffer = require("node:buffer") as { Buffer: BufferConstructor };
+if (import.meta.env.DEV) {
+  if (
+    (globalThis.Buffer as BufferConstructor | undefined) === undefined &&
+    typeof require === "function"
+  ) {
+    try {
+      // this is for CJS only, so require is the only option here
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const buffer = require("node:buffer") as { Buffer: BufferConstructor };
+      globalThis.Buffer = buffer.Buffer;
+    } catch {
+      // ignore
+    }
+  } else {
+    const buffer = await import("node:buffer");
     globalThis.Buffer = buffer.Buffer;
-  } catch {
-    // ignore
   }
-} else {
-  const buffer = await import("node:buffer");
-  globalThis.Buffer = buffer.Buffer;
-}
 
-defineDebug(debug);
+  defineDebug(debug);
+}

--- a/packages/universal/debug/tests/stack.spec.ts
+++ b/packages/universal/debug/tests/stack.spec.ts
@@ -17,7 +17,7 @@ describe("Error stacks", () => {
 });
 
 function anOuterFunction(): CallStack | undefined {
-  return DEBUG.callerStack();
+  return void DEBUG.callerStack();
 }
 
 function callerStackInArgs(

--- a/packages/universal/interfaces/src/debug/debug-runtime.ts
+++ b/packages/universal/interfaces/src/debug/debug-runtime.ts
@@ -7,8 +7,8 @@ import type { DescFn, DescriptionDetails } from "./description.js";
 
 export type DescribeOptions =
   | {
-      id: boolean | undefined;
-    }
+    id: boolean | undefined;
+  }
   | undefined;
 
 export interface DebugRuntime {
@@ -41,14 +41,14 @@ export interface DebugRuntime {
   markEntryPoint: (
     options?:
       | {
-          caller?: CallStack | undefined;
-          description?: EntryPointDescriptionArg | string | undefined;
-          force?: boolean | undefined;
-        }
+        caller?: CallStack | undefined;
+        description?: EntryPointDescriptionArg | string | undefined;
+        force?: boolean | undefined;
+      }
       | EntryPointDescriptionArg
       | EntryPoint
       | string
-  ) => EntryPoint;
+  ) => void;
   getEntryPoint: () => EntryPoint | undefined;
 
   readonly Desc: DescFn;
@@ -68,36 +68,36 @@ export interface EntryPointDescription {
 export type EntryPointDescriptionArg =
   | ["label", string]
   | [
-      operation: "reactive:read" | "reactive:write" | "reactive:call",
-      entity: DescriptionDetails | string | undefined,
-      api?: PropertyKey
-    ]
+    operation: "reactive:read" | "reactive:write" | "reactive:call",
+    entity: DescriptionDetails | string | undefined,
+    api?: PropertyKey
+  ]
   | [
-      operation:
-        | "object:get"
-        | "object:set"
-        | "object:has"
-        | "object:call"
-        | "object:define"
-        | "object:delete"
-        | "object:meta:get",
-      entity: DescriptionDetails | string | undefined,
-      target: PropertyKey
-    ]
+    operation:
+    | "object:get"
+    | "object:set"
+    | "object:has"
+    | "object:call"
+    | "object:define"
+    | "object:delete"
+    | "object:meta:get",
+    entity: DescriptionDetails | string | undefined,
+    target: PropertyKey
+  ]
   | [
-      operation: "object:meta:keys",
-      entity: DescriptionDetails | string | undefined
-    ]
+    operation: "object:meta:keys",
+    entity: DescriptionDetails | string | undefined
+  ]
   | [
-      operation: "function:call",
-      entity: DescriptionDetails | string | undefined
-    ]
+    operation: "function:call",
+    entity: DescriptionDetails | string | undefined
+  ]
   | [
-      operation:
-        | "collection:has"
-        | "collection:get"
-        | "collection:insert"
-        | "collection:delete",
-      entity: DescriptionDetails | string | undefined,
-      key: unknown
-    ];
+    operation:
+    | "collection:has"
+    | "collection:get"
+    | "collection:insert"
+    | "collection:delete",
+    entity: DescriptionDetails | string | undefined,
+    key: unknown
+  ];

--- a/packages/universal/verify/index.ts
+++ b/packages/universal/verify/index.ts
@@ -1,5 +1,13 @@
+import { isOneOf as isOneOfDev } from "./src/assertions/multi.js";
+import { hasType as hasTypeDev } from "./src/assertions/types.js";
 import type { VerifyFn } from "./src/verify.js";
-import { verified as verifiedDev, verify as verifyDev } from "./src/verify.js";
+import {
+  expected as expectedDev,
+  verified as verifiedDev,
+  verify as verifyDev
+} from "./src/verify.js";
+
+const noop: unknown = () => { };
 
 export {
   exhaustive,
@@ -12,13 +20,16 @@ export {
   isPresent,
   isWeakKey,
 } from "./src/assertions/basic.js";
-export { isOneOf } from "./src/assertions/multi.js";
-export { hasType, type TypeOf } from "./src/assertions/types.js";
-export { type Expectation, expected, VerificationError } from "./src/verify.js";
+export { type TypeOf } from "./src/assertions/types.js";
+export { type Expectation, VerificationError } from "./src/verify.js";
+
+export const expected: typeof expectedDev = import.meta.env.DEV ? expectedDev : (noop as typeof expectedDev)
+export const hasType: typeof hasTypeDev = import.meta.env.DEV ? hasTypeDev : (noop as typeof hasTypeDev)
+export const isOneOf: typeof isOneOfDev = import.meta.env.DEV ? isOneOfDev : (noop as typeof isOneOfDev)
 
 export const verify: VerifyFn = import.meta.env.DEV
   ? verifyDev
-  : verifyDev.noop;
+  : (noop as VerifyFn);
 export const verified: (typeof verifiedDev)["noop"] = import.meta.env.DEV
   ? verifiedDev
-  : verifiedDev.noop;
+  : (noop as typeof verifiedDev);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@rollup/pluginutils': latest
+  '@starbeam-dev/compile': github:starbeamjs/dev-compile#1fe1af7
   '@types/eslint': ^8.56.0
   '@types/node': ^20.10.5
   eslint: ^8.56.0
@@ -32,8 +33,8 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1(@pnpm/logger@5.0.0)
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/core':
         specifier: ^1.0.2
         version: 1.0.2
@@ -242,8 +243,8 @@ importers:
         version: 10.17.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -273,8 +274,8 @@ importers:
         version: 10.17.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -338,8 +339,8 @@ importers:
         version: 10.17.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -488,8 +489,8 @@ importers:
         version: 0.23.0
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -577,8 +578,8 @@ importers:
         version: 0.23.0
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -608,8 +609,8 @@ importers:
         version: 0.23.0
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -679,8 +680,8 @@ importers:
         version: 0.5.3
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@swc/helpers@0.5.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@swc/helpers@0.5.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -711,8 +712,8 @@ importers:
         version: link:../universal
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -723,8 +724,8 @@ importers:
   packages/universal/core-utils:
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -773,8 +774,8 @@ importers:
         version: 2.1.8
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: link:../../../../dev-compile
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -808,8 +809,8 @@ importers:
         version: link:../shared
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -842,8 +843,8 @@ importers:
         specifier: workspace:^
         version: link:../../../workspace/@domtree/flavors
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -870,8 +871,8 @@ importers:
         version: link:../verify
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -926,8 +927,8 @@ importers:
         version: link:../shared
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -973,8 +974,8 @@ importers:
         version: link:../verify
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1041,8 +1042,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.0
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1103,8 +1104,8 @@ importers:
         version: link:../shared
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1149,8 +1150,8 @@ importers:
   packages/universal/shared:
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1199,8 +1200,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1242,8 +1243,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1283,8 +1284,8 @@ importers:
         version: link:../core-utils
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1345,8 +1346,8 @@ importers:
         version: 3.3.4
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1379,8 +1380,8 @@ importers:
         version: 3.3.4
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1508,8 +1509,8 @@ importers:
         version: link:../../universal/reactive
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1533,8 +1534,8 @@ importers:
         version: link:../../universal/reactive
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1583,8 +1584,8 @@ importers:
         version: link:../../universal/universal
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1607,8 +1608,8 @@ importers:
         specifier: 2.0.0-beta.21
         version: 2.0.0-beta.21
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam/react':
         specifier: workspace:^
         version: link:../../../react/react
@@ -1675,8 +1676,8 @@ importers:
         version: link:../minimal
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1688,8 +1689,8 @@ importers:
         version: link:../interface
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1707,8 +1708,8 @@ importers:
         version: link:../minimal
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1716,8 +1717,8 @@ importers:
   workspace/@domtree/interface:
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1729,8 +1730,8 @@ importers:
         version: link:../interface
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1766,8 +1767,8 @@ importers:
         version: 1.1.0(@edge-runtime/vm@3.1.7)(@types/node@20.10.5)(@vitest/ui@1.1.0)(happy-dom@12.10.3)(jsdom@23.0.1)
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#1fe1af7
+        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -3931,50 +3932,6 @@ packages:
       commander: 4.1.1
       ignore: 5.2.4
       p-map: 4.0.0
-    dev: true
-
-  /@starbeam-dev/compile@1.1.0(@babel/core@7.23.3):
-    resolution: {integrity: sha512-3kiQXxwzGVQFDThRM+A84oVjK8lyBopWaupAOc10VS7XDd7fwaBURVtPyAJmYDF76I9+aLkXu8On9gW62JeU3w==}
-    dependencies:
-      '@rollup/plugin-commonjs': 25.0.7(rollup@4.4.1)
-      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.4.1)
-      '@starbeam-dev/core': 1.0.2
-      '@swc/core': 1.3.96(@swc/helpers@0.5.3)
-      get-tsconfig: 4.7.2
-      magic-string: 0.30.5
-      rollup: 4.4.1
-      rollup-plugin-copy: 3.5.0
-      rollup-plugin-ts: 3.4.5(@babel/core@7.23.3)(@swc/core@1.3.96)(rollup@4.4.1)(typescript@5.3.3)
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/plugin-transform-runtime'
-      - '@babel/preset-env'
-      - '@babel/preset-typescript'
-      - '@babel/runtime'
-      - '@swc/helpers'
-    dev: true
-
-  /@starbeam-dev/compile@1.1.0(@swc/helpers@0.5.3):
-    resolution: {integrity: sha512-3kiQXxwzGVQFDThRM+A84oVjK8lyBopWaupAOc10VS7XDd7fwaBURVtPyAJmYDF76I9+aLkXu8On9gW62JeU3w==}
-    dependencies:
-      '@rollup/plugin-commonjs': 25.0.7(rollup@4.4.1)
-      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.4.1)
-      '@starbeam-dev/core': 1.0.2
-      '@swc/core': 1.3.96(@swc/helpers@0.5.3)
-      get-tsconfig: 4.7.2
-      magic-string: 0.30.5
-      rollup: 4.4.1
-      rollup-plugin-copy: 3.5.0
-      rollup-plugin-ts: 3.4.5(@swc/core@1.3.96)(@swc/helpers@0.5.3)(rollup@4.4.1)(typescript@5.3.3)
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/plugin-transform-runtime'
-      - '@babel/preset-env'
-      - '@babel/preset-typescript'
-      - '@babel/runtime'
-      - '@swc/helpers'
     dev: true
 
   /@starbeam-dev/core@1.0.2:
@@ -10842,4 +10799,58 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: true
+
+  github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3):
+    resolution: {tarball: https://codeload.github.com/starbeamjs/dev-compile/tar.gz/1fe1af7}
+    id: github.com/starbeamjs/dev-compile/1fe1af7
+    name: '@starbeam-dev/compile'
+    version: 1.1.0
+    prepare: true
+    requiresBuild: true
+    dependencies:
+      '@rollup/plugin-commonjs': 25.0.7(rollup@4.4.1)
+      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.4.1)
+      '@starbeam-dev/core': 1.0.2
+      '@swc/core': 1.3.96(@swc/helpers@0.5.3)
+      get-tsconfig: 4.7.2
+      magic-string: 0.30.5
+      rollup: 4.4.1
+      rollup-plugin-copy: 3.5.0
+      rollup-plugin-ts: 3.4.5(@babel/core@7.23.3)(@swc/core@1.3.96)(rollup@4.4.1)(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/preset-env'
+      - '@babel/preset-typescript'
+      - '@babel/runtime'
+      - '@swc/helpers'
+    dev: true
+
+  github.com/starbeamjs/dev-compile/1fe1af7(@swc/helpers@0.5.3):
+    resolution: {tarball: https://codeload.github.com/starbeamjs/dev-compile/tar.gz/1fe1af7}
+    id: github.com/starbeamjs/dev-compile/1fe1af7
+    name: '@starbeam-dev/compile'
+    version: 1.1.0
+    prepare: true
+    requiresBuild: true
+    dependencies:
+      '@rollup/plugin-commonjs': 25.0.7(rollup@4.4.1)
+      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.4.1)
+      '@starbeam-dev/core': 1.0.2
+      '@swc/core': 1.3.96(@swc/helpers@0.5.3)
+      get-tsconfig: 4.7.2
+      magic-string: 0.30.5
+      rollup: 4.4.1
+      rollup-plugin-copy: 3.5.0
+      rollup-plugin-ts: 3.4.5(@swc/core@1.3.96)(@swc/helpers@0.5.3)(rollup@4.4.1)(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/preset-env'
+      - '@babel/preset-typescript'
+      - '@babel/runtime'
+      - '@swc/helpers'
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@rollup/pluginutils': latest
-  '@starbeam-dev/compile': github:starbeamjs/dev-compile#1fe1af7
+  '@starbeam-dev/compile': github:starbeamjs/dev-compile#9873982
   '@types/eslint': ^8.56.0
   '@types/node': ^20.10.5
   eslint: ^8.56.0
@@ -33,8 +33,8 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1(@pnpm/logger@5.0.0)
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/core':
         specifier: ^1.0.2
         version: 1.0.2
@@ -243,8 +243,8 @@ importers:
         version: 10.17.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -274,8 +274,8 @@ importers:
         version: 10.17.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -339,8 +339,8 @@ importers:
         version: 10.17.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -489,8 +489,8 @@ importers:
         version: 0.23.0
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -578,8 +578,8 @@ importers:
         version: 0.23.0
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -609,8 +609,8 @@ importers:
         version: 0.23.0
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -680,8 +680,8 @@ importers:
         version: 0.5.3
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@swc/helpers@0.5.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@swc/helpers@0.5.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -712,8 +712,8 @@ importers:
         version: link:../universal
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -724,8 +724,8 @@ importers:
   packages/universal/core-utils:
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -774,8 +774,8 @@ importers:
         version: 2.1.8
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -809,8 +809,8 @@ importers:
         version: link:../shared
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -843,8 +843,8 @@ importers:
         specifier: workspace:^
         version: link:../../../workspace/@domtree/flavors
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -871,8 +871,8 @@ importers:
         version: link:../verify
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -927,8 +927,8 @@ importers:
         version: link:../shared
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -974,8 +974,8 @@ importers:
         version: link:../verify
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1042,8 +1042,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.0
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1104,8 +1104,8 @@ importers:
         version: link:../shared
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1150,8 +1150,8 @@ importers:
   packages/universal/shared:
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1200,8 +1200,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1243,8 +1243,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1284,8 +1284,8 @@ importers:
         version: link:../core-utils
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1346,8 +1346,8 @@ importers:
         version: 3.3.4
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1380,8 +1380,8 @@ importers:
         version: 3.3.4
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1509,8 +1509,8 @@ importers:
         version: link:../../universal/reactive
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1534,8 +1534,8 @@ importers:
         version: link:../../universal/reactive
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1584,8 +1584,8 @@ importers:
         version: link:../../universal/universal
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1608,8 +1608,8 @@ importers:
         specifier: 2.0.0-beta.21
         version: 2.0.0-beta.21
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam/react':
         specifier: workspace:^
         version: link:../../../react/react
@@ -1676,8 +1676,8 @@ importers:
         version: link:../minimal
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1689,8 +1689,8 @@ importers:
         version: link:../interface
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1708,8 +1708,8 @@ importers:
         version: link:../minimal
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1717,8 +1717,8 @@ importers:
   workspace/@domtree/interface:
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1730,8 +1730,8 @@ importers:
         version: link:../interface
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1767,8 +1767,8 @@ importers:
         version: 1.1.0(@edge-runtime/vm@3.1.7)(@types/node@20.10.5)(@vitest/ui@1.1.0)(happy-dom@12.10.3)(jsdom@23.0.1)
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#1fe1af7
-        version: github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3)
+        specifier: github:starbeamjs/dev-compile#9873982
+        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -3144,6 +3144,13 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: true
 
+  /@jridgewell/source-map@0.3.5:
+    resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.20
+    dev: true
+
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
@@ -3801,6 +3808,21 @@ packages:
       is-module: 1.0.0
       resolve: 1.22.8
       rollup: 4.4.1
+    dev: true
+
+  /@rollup/plugin-terser@0.4.4(rollup@4.4.1):
+    resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      rollup: 4.4.1
+      serialize-javascript: 6.0.2
+      smob: 1.4.1
+      terser: 5.26.0
     dev: true
 
   /@rollup/pluginutils@5.1.0(rollup@4.4.1):
@@ -5367,6 +5389,10 @@ packages:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
     dev: false
+
+  /commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+    dev: true
 
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -8931,6 +8957,12 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
+  /randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
+
   /rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -9398,6 +9430,12 @@ packages:
     dependencies:
       lru-cache: 6.0.0
 
+  /serialize-javascript@6.0.2:
+    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+    dependencies:
+      randombytes: 2.1.0
+    dev: true
+
   /set-function-length@1.1.1:
     resolution: {integrity: sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==}
     engines: {node: '>= 0.4'}
@@ -9481,6 +9519,10 @@ packages:
   /smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+    dev: true
+
+  /smob@1.4.1:
+    resolution: {integrity: sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ==}
     dev: true
 
   /socks-proxy-agent@6.2.1:
@@ -9796,6 +9838,17 @@ packages:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+    dev: true
+
+  /terser@5.26.0:
+    resolution: {integrity: sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      '@jridgewell/source-map': 0.3.5
+      acorn: 8.10.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
     dev: true
 
   /text-table@0.2.0:
@@ -10801,9 +10854,9 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: true
 
-  github.com/starbeamjs/dev-compile/1fe1af7(@babel/core@7.23.3):
-    resolution: {tarball: https://codeload.github.com/starbeamjs/dev-compile/tar.gz/1fe1af7}
-    id: github.com/starbeamjs/dev-compile/1fe1af7
+  github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3):
+    resolution: {tarball: https://codeload.github.com/starbeamjs/dev-compile/tar.gz/9873982}
+    id: github.com/starbeamjs/dev-compile/9873982
     name: '@starbeam-dev/compile'
     version: 1.1.0
     prepare: true
@@ -10811,6 +10864,7 @@ packages:
     dependencies:
       '@rollup/plugin-commonjs': 25.0.7(rollup@4.4.1)
       '@rollup/plugin-node-resolve': 15.2.3(rollup@4.4.1)
+      '@rollup/plugin-terser': 0.4.4(rollup@4.4.1)
       '@starbeam-dev/core': 1.0.2
       '@swc/core': 1.3.96(@swc/helpers@0.5.3)
       get-tsconfig: 4.7.2
@@ -10828,9 +10882,9 @@ packages:
       - '@swc/helpers'
     dev: true
 
-  github.com/starbeamjs/dev-compile/1fe1af7(@swc/helpers@0.5.3):
-    resolution: {tarball: https://codeload.github.com/starbeamjs/dev-compile/tar.gz/1fe1af7}
-    id: github.com/starbeamjs/dev-compile/1fe1af7
+  github.com/starbeamjs/dev-compile/9873982(@swc/helpers@0.5.3):
+    resolution: {tarball: https://codeload.github.com/starbeamjs/dev-compile/tar.gz/9873982}
+    id: github.com/starbeamjs/dev-compile/9873982
     name: '@starbeam-dev/compile'
     version: 1.1.0
     prepare: true
@@ -10838,6 +10892,7 @@ packages:
     dependencies:
       '@rollup/plugin-commonjs': 25.0.7(rollup@4.4.1)
       '@rollup/plugin-node-resolve': 15.2.3(rollup@4.4.1)
+      '@rollup/plugin-terser': 0.4.4(rollup@4.4.1)
       '@starbeam-dev/core': 1.0.2
       '@swc/core': 1.3.96(@swc/helpers@0.5.3)
       get-tsconfig: 4.7.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -774,7 +774,7 @@ importers:
     devDependencies:
       '@starbeam-dev/compile':
         specifier: ^1.1.0
-        version: 1.1.0(@babel/core@7.23.3)
+        version: link:../../../../dev-compile
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@rollup/pluginutils': latest
-  '@starbeam-dev/compile': github:starbeamjs/dev-compile#9873982
+  '@starbeam-dev/compile': 1.2.0
   '@types/eslint': ^8.56.0
   '@types/node': ^20.10.5
   eslint: ^8.56.0
@@ -33,8 +33,8 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1(@pnpm/logger@5.0.0)
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/core':
         specifier: ^1.0.2
         version: 1.0.2
@@ -243,8 +243,8 @@ importers:
         version: 10.17.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -274,8 +274,8 @@ importers:
         version: 10.17.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -339,8 +339,8 @@ importers:
         version: 10.17.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -489,8 +489,8 @@ importers:
         version: 0.23.0
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -578,8 +578,8 @@ importers:
         version: 0.23.0
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -609,8 +609,8 @@ importers:
         version: 0.23.0
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -680,8 +680,8 @@ importers:
         version: 0.5.3
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@swc/helpers@0.5.3)
+        specifier: 1.2.0
+        version: 1.2.0(@swc/helpers@0.5.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -712,8 +712,8 @@ importers:
         version: link:../universal
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -724,8 +724,8 @@ importers:
   packages/universal/core-utils:
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -774,8 +774,8 @@ importers:
         version: 2.1.8
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -809,8 +809,8 @@ importers:
         version: link:../shared
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -843,8 +843,8 @@ importers:
         specifier: workspace:^
         version: link:../../../workspace/@domtree/flavors
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -871,8 +871,8 @@ importers:
         version: link:../verify
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -927,8 +927,8 @@ importers:
         version: link:../shared
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -974,8 +974,8 @@ importers:
         version: link:../verify
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1042,8 +1042,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.0
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1104,8 +1104,8 @@ importers:
         version: link:../shared
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1150,8 +1150,8 @@ importers:
   packages/universal/shared:
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1200,8 +1200,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1243,8 +1243,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1284,8 +1284,8 @@ importers:
         version: link:../core-utils
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1346,8 +1346,8 @@ importers:
         version: 3.3.4
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1380,8 +1380,8 @@ importers:
         version: 3.3.4
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1509,8 +1509,8 @@ importers:
         version: link:../../universal/reactive
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1534,8 +1534,8 @@ importers:
         version: link:../../universal/reactive
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1584,8 +1584,8 @@ importers:
         version: link:../../universal/universal
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1608,8 +1608,8 @@ importers:
         specifier: 2.0.0-beta.21
         version: 2.0.0-beta.21
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam/react':
         specifier: workspace:^
         version: link:../../../react/react
@@ -1676,8 +1676,8 @@ importers:
         version: link:../minimal
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1689,8 +1689,8 @@ importers:
         version: link:../interface
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1708,8 +1708,8 @@ importers:
         version: link:../minimal
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1717,8 +1717,8 @@ importers:
   workspace/@domtree/interface:
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1730,8 +1730,8 @@ importers:
         version: link:../interface
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -1767,8 +1767,8 @@ importers:
         version: 1.1.0(@edge-runtime/vm@3.1.7)(@types/node@20.10.5)(@vitest/ui@1.1.0)(happy-dom@12.10.3)(jsdom@23.0.1)
     devDependencies:
       '@starbeam-dev/compile':
-        specifier: github:starbeamjs/dev-compile#9873982
-        version: github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3)
+        specifier: 1.2.0
+        version: 1.2.0(@babel/core@7.23.3)
       '@starbeam-dev/eslint-plugin':
         specifier: ^1.0.4
         version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
@@ -3954,6 +3954,52 @@ packages:
       commander: 4.1.1
       ignore: 5.2.4
       p-map: 4.0.0
+    dev: true
+
+  /@starbeam-dev/compile@1.2.0(@babel/core@7.23.3):
+    resolution: {integrity: sha512-vfvPsMblAs0M6aLHQO5N5VpjHrLc29605bLudlHRTfoudkLCmOFNJEZcuNKb7myhckP6inRn6nuotK8jZ4gMfw==}
+    dependencies:
+      '@rollup/plugin-commonjs': 25.0.7(rollup@4.4.1)
+      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.4.1)
+      '@rollup/plugin-terser': 0.4.4(rollup@4.4.1)
+      '@starbeam-dev/core': 1.0.2
+      '@swc/core': 1.3.96(@swc/helpers@0.5.3)
+      get-tsconfig: 4.7.2
+      magic-string: 0.30.5
+      rollup: 4.4.1
+      rollup-plugin-copy: 3.5.0
+      rollup-plugin-ts: 3.4.5(@babel/core@7.23.3)(@swc/core@1.3.96)(rollup@4.4.1)(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/preset-env'
+      - '@babel/preset-typescript'
+      - '@babel/runtime'
+      - '@swc/helpers'
+    dev: true
+
+  /@starbeam-dev/compile@1.2.0(@swc/helpers@0.5.3):
+    resolution: {integrity: sha512-vfvPsMblAs0M6aLHQO5N5VpjHrLc29605bLudlHRTfoudkLCmOFNJEZcuNKb7myhckP6inRn6nuotK8jZ4gMfw==}
+    dependencies:
+      '@rollup/plugin-commonjs': 25.0.7(rollup@4.4.1)
+      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.4.1)
+      '@rollup/plugin-terser': 0.4.4(rollup@4.4.1)
+      '@starbeam-dev/core': 1.0.2
+      '@swc/core': 1.3.96(@swc/helpers@0.5.3)
+      get-tsconfig: 4.7.2
+      magic-string: 0.30.5
+      rollup: 4.4.1
+      rollup-plugin-copy: 3.5.0
+      rollup-plugin-ts: 3.4.5(@swc/core@1.3.96)(@swc/helpers@0.5.3)(rollup@4.4.1)(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/preset-env'
+      - '@babel/preset-typescript'
+      - '@babel/runtime'
+      - '@swc/helpers'
     dev: true
 
   /@starbeam-dev/core@1.0.2:
@@ -10852,60 +10898,4 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
-    dev: true
-
-  github.com/starbeamjs/dev-compile/9873982(@babel/core@7.23.3):
-    resolution: {tarball: https://codeload.github.com/starbeamjs/dev-compile/tar.gz/9873982}
-    id: github.com/starbeamjs/dev-compile/9873982
-    name: '@starbeam-dev/compile'
-    version: 1.1.0
-    prepare: true
-    requiresBuild: true
-    dependencies:
-      '@rollup/plugin-commonjs': 25.0.7(rollup@4.4.1)
-      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.4.1)
-      '@rollup/plugin-terser': 0.4.4(rollup@4.4.1)
-      '@starbeam-dev/core': 1.0.2
-      '@swc/core': 1.3.96(@swc/helpers@0.5.3)
-      get-tsconfig: 4.7.2
-      magic-string: 0.30.5
-      rollup: 4.4.1
-      rollup-plugin-copy: 3.5.0
-      rollup-plugin-ts: 3.4.5(@babel/core@7.23.3)(@swc/core@1.3.96)(rollup@4.4.1)(typescript@5.3.3)
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/plugin-transform-runtime'
-      - '@babel/preset-env'
-      - '@babel/preset-typescript'
-      - '@babel/runtime'
-      - '@swc/helpers'
-    dev: true
-
-  github.com/starbeamjs/dev-compile/9873982(@swc/helpers@0.5.3):
-    resolution: {tarball: https://codeload.github.com/starbeamjs/dev-compile/tar.gz/9873982}
-    id: github.com/starbeamjs/dev-compile/9873982
-    name: '@starbeam-dev/compile'
-    version: 1.1.0
-    prepare: true
-    requiresBuild: true
-    dependencies:
-      '@rollup/plugin-commonjs': 25.0.7(rollup@4.4.1)
-      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.4.1)
-      '@rollup/plugin-terser': 0.4.4(rollup@4.4.1)
-      '@starbeam-dev/core': 1.0.2
-      '@swc/core': 1.3.96(@swc/helpers@0.5.3)
-      get-tsconfig: 4.7.2
-      magic-string: 0.30.5
-      rollup: 4.4.1
-      rollup-plugin-copy: 3.5.0
-      rollup-plugin-ts: 3.4.5(@swc/core@1.3.96)(@swc/helpers@0.5.3)(rollup@4.4.1)(typescript@5.3.3)
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/plugin-transform-runtime'
-      - '@babel/preset-env'
-      - '@babel/preset-typescript'
-      - '@babel/runtime'
-      - '@swc/helpers'
     dev: true


### PR DESCRIPTION
Paired with work here, and will require local linking: https://github.com/starbeamjs/dev-compile/pull/5

Each package creates an `index.production.js`.

Before this PR:
```bash
❯ pnpm turbo build --force --no-cache

❯ du --ignore_hidden --only-file --reverse --apparent-size \
     --filter "packages\/universal\/.+\/dist\/index\.production\.js$" \
     --no-percent-bars \
     --ignore-directory packages/universal/verify/
 97K └─┬ .
 26K   ├── ./packages/universal/debug/dist/index.production.js
 24K   ├── ./packages/universal/collections/dist/index.production.js
7.8K   ├── ./packages/universal/universal/dist/index.production.js
7.1K   ├── ./packages/universal/core-utils/dist/index.production.js
6.7K   ├── ./packages/universal/runtime/dist/index.production.js
6.2K   ├── ./packages/universal/reactive/dist/index.production.js
5.3K   ├── ./packages/universal/shared/dist/index.production.js
5.1K   ├── ./packages/universal/resource/dist/index.production.js
2.7K   ├── ./packages/universal/tags/dist/index.production.js
2.0K   ├── ./packages/universal/renderer/dist/index.production.js
1.7K   ├── ./packages/universal/service/dist/index.production.js
1.2K   ├── ./packages/universal/modifier/dist/index.production.js
264B   └── ./packages/universal/core/dist/index.production.js


```

After this PR:
```bash
❯ pnpm turbo build --force --no-cache
# not using cache, because locally, I've been changing things outside of what turbo can see

❯ du --ignore_hidden --only-file --reverse --apparent-size \
     --filter "packages\/universal\/.+\/dist\/index\.production\.js$" \
     --no-percent-bars \
     --ignore-directory packages/universal/verify/
 36K └─┬ .
 12K   ├── ./packages/universal/collections/dist/index.production.js
4.2K   ├── ./packages/universal/universal/dist/index.production.js
3.3K   ├── ./packages/universal/reactive/dist/index.production.js
3.3K   ├── ./packages/universal/runtime/dist/index.production.js
2.7K   ├── ./packages/universal/core-utils/dist/index.production.js
2.3K   ├── ./packages/universal/shared/dist/index.production.js
1.9K   ├── ./packages/universal/resource/dist/index.production.js
1.6K   ├── ./packages/universal/debug/dist/index.production.js
1.4K   ├── ./packages/universal/tags/dist/index.production.js
1.3K   ├── ./packages/universal/renderer/dist/index.production.js
876B   ├── ./packages/universal/modifier/dist/index.production.js
829B   ├── ./packages/universal/service/dist/index.production.js
220B   └── ./packages/universal/core/dist/index.production.js
```


--------

Notes:
- `@starbeam/universal` is an optional package that has some very helpful reactive collections for map, array, weakmap, etc
- `@starbeam/verify` is a testing utilities package

- Smallerness calculated via: 1 - 36/97 =~ 63%. and 97/36 =~ 2.7 