### PR TITLE
Add CI check for forbidden texts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
       - run: pnpm build 
+      - name: "Ensure Certain dependencies don't end up in the production bundles"
+        run: node ./workspace/scripts/build-verify.js 
 
   test:
     name: "Tests"

--- a/@types/ansicolor/package.json
+++ b/@types/ansicolor/package.json
@@ -22,7 +22,7 @@
     "test:types": "tsc -b"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@types/node": "18.16.18"
   }
 }

--- a/@types/fsify/index.d.ts
+++ b/@types/fsify/index.d.ts
@@ -16,8 +16,8 @@ export interface Options {
    */
   cwd?: string;
   /**
-   * A persistent fsify tree remains on the file system after the process exits.
-   * Defaults to true.
+   * A persistent fsify tree remains on the file system after the process
+   * exits. Defaults to true.
    */
   persistent?: boolean;
   /**

--- a/@types/fsify/package.json
+++ b/@types/fsify/package.json
@@ -21,7 +21,7 @@
     "test:types": "tsc -b"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@types/node": "18.16.1"
   }
 }

--- a/@types/lines-and-columns/package.json
+++ b/@types/lines-and-columns/package.json
@@ -20,7 +20,7 @@
     "test:types": "tsc -b"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@types/node": "18.16.1"
   }
 }

--- a/@types/plugin-commonjs/package.json
+++ b/@types/plugin-commonjs/package.json
@@ -24,6 +24,6 @@
     "@rollup/plugin-commonjs": "25.0.5"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.3"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/@types/plugin-node-resolve/package.json
+++ b/@types/plugin-node-resolve/package.json
@@ -24,6 +24,6 @@
     "@rollup/plugin-node-resolve": "^15.2.3"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.3"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/@types/rollup-plugin-polyfill-node/package.json
+++ b/@types/rollup-plugin-polyfill-node/package.json
@@ -24,6 +24,6 @@
     "rollup": "^4.0.2"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/@types/shell-escape-tag/package.json
+++ b/@types/shell-escape-tag/package.json
@@ -20,7 +20,7 @@
     "test:types": "tsc -b"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@types/node": "18.16.1"
   }
 }

--- a/@types/shell-split/package.json
+++ b/@types/shell-split/package.json
@@ -21,7 +21,7 @@
     "test:types": "tsc -b"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@types/node": "18.16.1"
   }
 }

--- a/@types/vite-env/package.json
+++ b/@types/vite-env/package.json
@@ -24,6 +24,6 @@
     "vitest": "^1.0.0-beta.2"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -110,13 +110,13 @@
     "@nrr/pnpm-duplicate-cli": "^0.0.1",
     "@starbeam-dev/compile": "workspace:*",
     "@starbeam-dev/core": "^1.0.2",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@types/eslint": "^8.56.0",
     "@types/node": "^20.10.5",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
     "@vitest/ui": "^1.1.0",
-    "eslint": "^8.56.0",
+    "eslint": "^8.57.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.6.1",
@@ -162,7 +162,8 @@
       "preact": "10.17.1",
       "typescript": "$typescript",
       "vite": "$vite",
-      "vue": "3.3.4"
+      "vue": "3.3.4",
+      "terser": "^5.31.0"
     },
     "peerDependencyRules": {
       "allowAny": [

--- a/packages/preact/preact-testing-utils/package.json
+++ b/packages/preact/preact-testing-utils/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "preact-render-to-string": "^6.2.1",
     "rollup": "^4.0.2"
   },

--- a/packages/preact/preact-testing-utils/tests/package.json
+++ b/packages/preact/preact-testing-utils/tests/package.json
@@ -25,7 +25,7 @@
     "preact": "*"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "preact-render-to-string": "^6.2.1"
   }
 }

--- a/packages/preact/preact-utils/package.json
+++ b/packages/preact/preact-utils/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   },
   "peerDependencies": {

--- a/packages/preact/preact-utils/tests/package.json
+++ b/packages/preact/preact-utils/tests/package.json
@@ -24,7 +24,7 @@
     "preact": "*"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "preact-render-to-string": "^6.2.1"
   }
 }

--- a/packages/preact/preact/package.json
+++ b/packages/preact/preact/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   },
   "peerDependencies": {

--- a/packages/preact/preact/src/frame.ts
+++ b/packages/preact/preact/src/frame.ts
@@ -52,10 +52,10 @@ export class ComponentFrame {
   ): FinalizedFormula {
     const frame = ComponentFrame.#frames.get(component);
 
-    verify(
+    verify?.(
       frame,
       isPresent,
-      expected.when("in Preact's _diff hook").as("a tracking frame"),
+      expected?.when("in Preact's _diff hook").as("a tracking frame"),
     );
 
     const end = frame.#end(subscription);
@@ -101,10 +101,10 @@ export class ComponentFrame {
   }
 
   #end(subscription: (() => void) | undefined) {
-    verify(
+    verify?.(
       this.#active,
       isPresent,
-      expected.when("in preact's _diff hook").as("an active tracking frame"),
+      expected?.when("in preact's _diff hook").as("an active tracking frame"),
     );
 
     const frame = (this.#frame = this.#active.done());

--- a/packages/preact/preact/tests/create.spec.ts
+++ b/packages/preact/preact/tests/create.spec.ts
@@ -1,7 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
+ 
+ 
+ 
+ 
 // @vitest-environment jsdom
 
 import { install, setup } from "@starbeam/preact";

--- a/packages/preact/preact/tests/package.json
+++ b/packages/preact/preact/tests/package.json
@@ -26,7 +26,7 @@
     "preact": "*"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "preact-render-to-string": "^6.2.1"
   }
 }

--- a/packages/preact/preact/tests/reactive.spec.ts
+++ b/packages/preact/preact/tests/reactive.spec.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
+ 
+ 
+ 
+ 
 // @vitest-environment jsdom
 
 import { install, setupReactive, useReactive } from "@starbeam/preact";

--- a/packages/preact/preact/tests/resources.spec.ts
+++ b/packages/preact/preact/tests/resources.spec.ts
@@ -1,7 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
+ 
+ 
+ 
+ 
 // @vitest-environment jsdom
 
 import { install, setupResource, useResource } from "@starbeam/preact";

--- a/packages/preact/preact/tests/services.spec.ts
+++ b/packages/preact/preact/tests/services.spec.ts
@@ -1,7 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
+ 
+ 
+ 
+ 
 // @vitest-environment jsdom
 
 import { install, useService } from "@starbeam/preact";

--- a/packages/preact/preact/tests/sync.spec.ts
+++ b/packages/preact/preact/tests/sync.spec.ts
@@ -1,7 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
+ 
+ 
+ 
+ 
 // @vitest-environment jsdom
 
 import { install, setupSync } from "@starbeam/preact";

--- a/packages/react/react/package.json
+++ b/packages/react/react/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@types/node": "18.16.1",
     "@types/react": "^18.2.22",
     "@types/scheduler": "^0.16.3",

--- a/packages/react/react/src/hooks/setup.ts
+++ b/packages/react/react/src/hooks/setup.ts
@@ -152,8 +152,8 @@ interface ScheduledHandler {
  * Creates a {@linkcode ScheduledHandler} that will keep track of the
  * synchronization functions to run.
  *
- * This function sets up a `useEffect` to run the handlers. This `useEffect` has
- * a dependency on a `useState` that represents the set of handlers. The
+ * This function sets up a `useEffect` to run the handlers. This `useEffect`
+ * has a dependency on a `useState` that represents the set of handlers. The
  * `useState` invalidates whenever a handler is added or whenever
  * {@linkcode scheduleDep} is explicitly run.
  *

--- a/packages/react/react/tests/package.json
+++ b/packages/react/react/tests/package.json
@@ -24,6 +24,6 @@
     "vitest": "^0.34.4"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/packages/react/react/tests/test-use.ts
+++ b/packages/react/react/tests/test-use.ts
@@ -73,8 +73,8 @@ type DefineSetupReactiveComponent = (
 ) => Promise<void>;
 
 /**
- * Sets up a test suite for a reactive component using `setupReactive` to create
- * subscribe to a reactive value.
+ * Sets up a test suite for a reactive component using `setupReactive` to
+ * create subscribe to a reactive value.
  *
  * Each test case has three variations, representing the three overloads of
  * `IntoReactiveBlueprint`.
@@ -105,8 +105,8 @@ export function testSetupReactive(
 }
 
 /**
- * Sets up a test suite for a reactive component using `setupReactive` to create
- * subscribe to a reactive value.
+ * Sets up a test suite for a reactive component using `setupReactive` to
+ * create subscribe to a reactive value.
  *
  * Each test case has three variations, representing the three overloads of
  * `IntoReactiveBlueprint`.

--- a/packages/react/test-utils/package.json
+++ b/packages/react/test-utils/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@testing-library/react": "^14.0.0",
     "@types/react": "^18.2.22",
     "@types/scheduler": "^0.16.3",

--- a/packages/react/use-strict-lifecycle/package.json
+++ b/packages/react/use-strict-lifecycle/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@types/react": "^18.2.22",
     "@types/scheduler": "^0.16.3",
     "rollup": "^4.0.2"

--- a/packages/react/use-strict-lifecycle/src/lifecycle.ts
+++ b/packages/react/use-strict-lifecycle/src/lifecycle.ts
@@ -64,10 +64,10 @@
  *
  * ## The Solution
  *
- * The `useLifecycle` hook gives you a way to create a new instance of something
- * when the component is first instantiated, clean it up when the component is
- * unmounted, and create a brand **new** instance when the component is
- * reactivated.
+ * The `useLifecycle` hook gives you a way to create a new instance of
+ * something when the component is first instantiated, clean it up when the
+ * component is unmounted, and create a brand **new** instance when the
+ * component is reactivated.
  *
  * TL;DR It works almost the same way that per-component state in React works,
  * but gives you a fresh copy whenever React re-attaches the component.

--- a/packages/react/use-strict-lifecycle/tests/package.json
+++ b/packages/react/use-strict-lifecycle/tests/package.json
@@ -18,7 +18,7 @@
     "react": "18.2.0"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@types/react": "^18.2.22",
     "jsdom": "^22.1.0"
   }

--- a/packages/universal/collections/package.json
+++ b/packages/universal/collections/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   },
   "files": [

--- a/packages/universal/collections/src/decorator.ts
+++ b/packages/universal/collections/src/decorator.ts
@@ -10,10 +10,10 @@ export const cached = <T>(
 ): void => {
   const get = descriptor.get;
 
-  verify(
+  verify?.(
     get,
     isPresent,
-    expected(`the target of @cached`)
+    expected?.(`the target of @cached`)
       .toBe(`a getter`)
       .butGot(() =>
         typeof descriptor.value === "function" ? `a method` : `a field`,

--- a/packages/universal/collections/tests/package.json
+++ b/packages/universal/collections/tests/package.json
@@ -17,6 +17,6 @@
     "@starbeam-workspace/test-utils": "workspace:^"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/packages/universal/core-utils/package.json
+++ b/packages/universal/core-utils/package.json
@@ -29,7 +29,7 @@
   "dependencies": {},
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   }
 }

--- a/packages/universal/core-utils/tests/package.json
+++ b/packages/universal/core-utils/tests/package.json
@@ -15,6 +15,6 @@
     "@starbeam/core-utils": "workspace:^"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/packages/universal/core/package.json
+++ b/packages/universal/core/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   },
   "files": [

--- a/packages/universal/debug/.eslintrc.json
+++ b/packages/universal/debug/.eslintrc.json
@@ -1,4 +1,7 @@
 {
   "root": true,
-  "extends": ["plugin:@starbeam-dev/library:recommended"]
+  "extends": ["plugin:@starbeam-dev/library:recommended"],
+  "rules": {
+    "etc/no-commented-out-code": "off"
+  }
 }

--- a/packages/universal/debug/package.json
+++ b/packages/universal/debug/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@types/node": "18.16.1",
     "rollup": "^4.0.2"
   },

--- a/packages/universal/debug/src/call-stack/debug/module.ts
+++ b/packages/universal/debug/src/call-stack/debug/module.ts
@@ -37,8 +37,8 @@ function stripLeadingSlash(path: string) {
 
 /**
  * The whole `Stack` system is only intended to be used for logging, so the
- * edge-cases where this normalization wouldn't work (verbatim paths on Windows)
- * shouldn't matter.
+ * edge-cases where this normalization wouldn't work (verbatim paths on
+ * Windows) shouldn't matter.
  */
 function normalizePath(...pathParts: (string | null | undefined)[]): string {
   return pathParts
@@ -48,8 +48,8 @@ function normalizePath(...pathParts: (string | null | undefined)[]): string {
 }
 
 /**
- * This function takes two paths and returns the suffix of the target that comes
- * after any shared prefix with the source.
+ * This function takes two paths and returns the suffix of the target that
+ * comes after any shared prefix with the source.
  *
  * For example, if the source is `/src/app/foo/bar` and the target is
  * `/src/app/baz/qux`, this function will return `baz/qux`.

--- a/packages/universal/debug/src/call-stack/debug/stack.ts
+++ b/packages/universal/debug/src/call-stack/debug/stack.ts
@@ -33,7 +33,7 @@ export function callerStack(
       "An error created in the internals of Stack.create",
     ).stack;
 
-    verify(stack, hasType("string"));
+    verify?.(stack, hasType("string"));
     return callStack(stack)?.slice(internal + CALLER);
   }
 }

--- a/packages/universal/debug/src/call-stack/debug/stack.ts
+++ b/packages/universal/debug/src/call-stack/debug/stack.ts
@@ -9,8 +9,8 @@ import {
   mapArray,
 } from "@starbeam/core-utils";
 import type { CallStack, StackFrame } from "@starbeam/interfaces";
-import { hasType, verified, verify } from "@starbeam/verify";
-import StackTracey from "stacktracey";
+import { hasType, verified, verify } /*#__PURE__*/ from "@starbeam/verify";
+import StackTracey /*#__PURE__*/ from "stacktracey";
 
 import { parseModule } from "./module.js";
 

--- a/packages/universal/debug/tests/.eslintrc.json
+++ b/packages/universal/debug/tests/.eslintrc.json
@@ -2,6 +2,7 @@
   "root": true,
   "extends": ["plugin:@starbeam-dev/library:recommended"],
   "rules": {
-    "@typescript-eslint/prefer-readonly": "off"
+    "@typescript-eslint/prefer-readonly": "off",
+    "etc/no-commented-out-code": "off"
   }
 }

--- a/packages/universal/debug/tests/description.spec.ts
+++ b/packages/universal/debug/tests/description.spec.ts
@@ -1,4 +1,4 @@
-import { DEBUG } from "@starbeam/debug";
+import { DEBUG }/*#__PURE__*/ from "@starbeam/debug";
 import { expect, test } from "@starbeam-workspace/test-utils";
 
 test("inferred api", () => {

--- a/packages/universal/debug/tests/package.json
+++ b/packages/universal/debug/tests/package.json
@@ -16,6 +16,6 @@
     "@starbeam-workspace/test-utils": "workspace:^"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/packages/universal/debug/tests/stack.spec.ts
+++ b/packages/universal/debug/tests/stack.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
-import { DEBUG } from "@starbeam/debug";
+import { DEBUG }/*#__PURE__*/ from "@starbeam/debug";
 import type { CallStack } from "@starbeam/interfaces";
 import { describe, expect, test } from "vitest";
 

--- a/packages/universal/debug/tests/tree.spec.ts
+++ b/packages/universal/debug/tests/tree.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
-import { Tree } from "@starbeam/debug";
+import { Tree }/*#__PURE__*/ from "@starbeam/debug";
 import { describe, expect, test } from "vitest";
 
 describe("a tree", () => {

--- a/packages/universal/interfaces/package.json
+++ b/packages/universal/interfaces/package.json
@@ -31,6 +31,6 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/packages/universal/interfaces/src/debug/debug-runtime.ts
+++ b/packages/universal/interfaces/src/debug/debug-runtime.ts
@@ -26,8 +26,8 @@ export interface DebugRuntime {
   readonly callerStack: CallerStackFn;
 
   /**
-   * Mark the current function as a debug entry point. The immediate caller of a
-   * debug entry point becomes the call stack associated with any debug
+   * Mark the current function as a debug entry point. The immediate caller of
+   * a debug entry point becomes the call stack associated with any debug
    * information generated for that entry point.
    *
    * @param options.caller Optionally specify an explicit caller. By default,

--- a/packages/universal/interfaces/src/protocol.ts
+++ b/packages/universal/interfaces/src/protocol.ts
@@ -65,9 +65,9 @@ export interface FormulaTag extends TagMethods {
    * necessarily mean that the formula is static, because a formula has no
    * children before it was first initialized.
    *
-   * Data structures built on `FormulaTag` should always read the formula before
-   * attempting to read the children if they plan to rely on the absence of
-   * children as a strong indicator of staticness.
+   * Data structures built on `FormulaTag` should always read the formula
+   * before attempting to read the children if they plan to rely on the absence
+   * of children as a strong indicator of staticness.
    */
   children: () => ReadonlySet<Tag>;
 }
@@ -137,8 +137,8 @@ export type SubscriptionTarget = CellTag | FormulaTag;
  *
  * NOTE: In previous versions of Starbeam, it was legal to change the tag after
  * the tagged object was initially created. However, this made it impossible to
- * use an tagged object's tag as a key in a WeakMap, which meant that the tagged
- * object itself had to be passed around even when it was semantically
+ * use an tagged object's tag as a key in a WeakMap, which meant that the
+ * tagged object itself had to be passed around even when it was semantically
  * unimportant.
  *
  * These days, the `[TAG]` property must not change once it has been read. For

--- a/packages/universal/interfaces/src/runtime.ts
+++ b/packages/universal/interfaces/src/runtime.ts
@@ -5,8 +5,8 @@ import type { Timestamp } from "./timestamp.js";
 import type { Unsubscribe } from "./utils.js";
 
 /**
- * The runtime is the interface that defines the core operations of the reactive
- * system.
+ * The runtime is the interface that defines the core operations of the
+ * reactive system.
  *
  * ## Cells and Formulas
  *
@@ -24,8 +24,8 @@ import type { Unsubscribe } from "./utils.js";
  *
  * ## Lifetime Management
  *
- * - `onFinalize(object, handler)`: Registers a finalizer handler for an object.
- * - `finalize(object)`: Finalizes an object.
+ * - `onFinalize(object, handler)`: Registers a finalizer handler for an
+ * object. - `finalize(object)`: Finalizes an object.
  * - `link(parent, child)`: Link two objects together: when the parent is
  *   finalized, the child will be finalized as well.
  */
@@ -50,8 +50,8 @@ export interface Runtime {
   readonly update: (formula: FormulaTag) => void;
 
   /**
-   * Subscribe to notifications that the given tag has updates ready ("readiness
-   * notifications").
+   * Subscribe to notifications that the given tag has updates ready
+   * ("readiness notifications").
    *
    * The second parameter to `subscribe` is a callback that will be called
    * *immediately* when the tag is updated.

--- a/packages/universal/interfaces/src/tag.ts
+++ b/packages/universal/interfaces/src/tag.ts
@@ -8,13 +8,13 @@ import type { Timestamp } from "./timestamp.js";
 export type TagSnapshot = ReadonlySet<Tag>;
 
 /**
- * Cell is the fundamental mutable reactive value. All subscriptions in Starbeam
- * are ultimately subscriptions to cells, and all mutations in Starbeam are
- * ultimately mutations to cells.
+ * Cell is the fundamental mutable reactive value. All subscriptions in
+ * Starbeam are ultimately subscriptions to cells, and all mutations in
+ * Starbeam are ultimately mutations to cells.
  *
  * If a cell has `undefined` dependencies, that means that the cell cannot
- * change anymore. This allows it to be removed from any formulas that depend on
- * it.
+ * change anymore. This allows it to be removed from any formulas that depend
+ * on it.
  */
 export interface CellTag {
   readonly type: "cell";

--- a/packages/universal/interfaces/src/tagged.ts
+++ b/packages/universal/interfaces/src/tagged.ts
@@ -14,8 +14,8 @@ export type HasTag<T extends Tag = Tag> = T | Tagged<T>;
  *
  * NOTE: In previous versions of Starbeam, it was legal to change the tag after
  * the tagged object was initially created. However, this made it impossible to
- * use an tagged object's tag as a key in a WeakMap, which meant that the tagged
- * object itself had to be passed around even when it was semantically
+ * use an tagged object's tag as a key in a WeakMap, which meant that the
+ * tagged object itself had to be passed around even when it was semantically
  * unimportant.
  */
 export interface Tagged<I extends Tag = Tag> {

--- a/packages/universal/modifier/package.json
+++ b/packages/universal/modifier/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@domtree/flavors": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   },
   "files": [

--- a/packages/universal/modifier/src/modifier.ts
+++ b/packages/universal/modifier/src/modifier.ts
@@ -42,10 +42,10 @@ export function ElementPlaceholder<E extends anydom.Element>(
 
     initialize(value: anydom.Element): void {
       const element = verified(REFS.get(ref), isPresent);
-      verify(
+      verify?.(
         value,
         (anyElement): anyElement is E => anyElement instanceof type,
-        expected(`A ref (${describe(description)})`)
+        expected?.(`A ref (${describe(description)})`)
           .toBe(`initialized with an instance of ${type.name}`)
           .butGot(() => `an instance of ${value.constructor.name}`),
       );

--- a/packages/universal/reactive/package.json
+++ b/packages/universal/reactive/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   },
   "files": [

--- a/packages/universal/reactive/tests/package.json
+++ b/packages/universal/reactive/tests/package.json
@@ -20,6 +20,6 @@
     "@starbeam-workspace/test-utils": "workspace:^"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/packages/universal/renderer/package.json
+++ b/packages/universal/renderer/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   },
   "files": [

--- a/packages/universal/renderer/src/renderer.ts
+++ b/packages/universal/renderer/src/renderer.ts
@@ -14,8 +14,8 @@ import type { IntoResourceBlueprint } from "./resource.js";
  * and returns a value.
  *
  * In the simplest case, you can simply call setup with a function with no
- * parameters. The function will run during the setup phase, and return a stable
- * result for the lifetime of the component.
+ * parameters. The function will run during the setup phase, and return a
+ * stable result for the lifetime of the component.
  *
  * You can also make use of the {@linkcode Lifecycle} to use resources, get
  * services or register code to run during the _idle_ or _layout_ phase.
@@ -26,8 +26,8 @@ export type SetupBlueprint<T> = (lifecycle: Lifecycle) => T;
  * `ReactiveBlueprint` is a function that takes a {@linkcode Lifecycle} and
  * returns an optionally reactive value. You can pass it to
  * {@linkcode useReactive} or {@linkcode setupReactive}. These functions will
- * instantiate the blueprint during the setup phase and return a stable reactive
- * value.
+ * instantiate the blueprint during the setup phase and return a stable
+ * reactive value.
  *
  * If you pass a `ReactiveBlueprint` to {@linkcode useReactive}, you must also
  * pass dependencies to {@linkcode useReactive}. If the dependencies change,

--- a/packages/universal/renderer/tests/package.json
+++ b/packages/universal/renderer/tests/package.json
@@ -16,6 +16,6 @@
     "@starbeam-workspace/test-utils": "workspace:^"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/packages/universal/resource/package.json
+++ b/packages/universal/resource/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   },
   "files": [

--- a/packages/universal/resource/tests/package.json
+++ b/packages/universal/resource/tests/package.json
@@ -23,6 +23,6 @@
     "inspect-utils": "^1.0.1"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/packages/universal/resource/tests/resource.spec.ts
+++ b/packages/universal/resource/tests/resource.spec.ts
@@ -565,8 +565,8 @@ class ResourceWrapper<T, U> {
   };
 
   /**
-   * The `act` method takes an action definition and thoroughly tests the action
-   * by performing this sequence of steps **twice**:
+   * The `act` method takes an action definition and thoroughly tests the
+   * action by performing this sequence of steps **twice**:
    *
    * 1. Verify that the event list is empty.
    * 2. Run the action.

--- a/packages/universal/runtime/package.json
+++ b/packages/universal/runtime/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.0",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2",
     "vite-env": "^1.0.0"
   },

--- a/packages/universal/runtime/tests/package.json
+++ b/packages/universal/runtime/tests/package.json
@@ -20,6 +20,6 @@
     "@starbeam-workspace/test-utils": "workspace:^"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/packages/universal/service/package.json
+++ b/packages/universal/service/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   },
   "files": [

--- a/packages/universal/service/tests/package.json
+++ b/packages/universal/service/tests/package.json
@@ -23,6 +23,6 @@
     "@starbeam-workspace/test-utils": "workspace:^"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/packages/universal/shared/package.json
+++ b/packages/universal/shared/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   },
   "files": [

--- a/packages/universal/shared/src/env.ts
+++ b/packages/universal/shared/src/env.ts
@@ -33,8 +33,8 @@ export interface Lifetime {
   /**
    * Like {@linkcode pushFinalizationScope}, but does not add the scope to the
    * parent scope when complete. This is useful for scopes that represent
-   * long-lived stacks, such as async functions or reactive resources (which can
-   * have nested scopes that evolve over time).
+   * long-lived stacks, such as async functions or reactive resources (which
+   * can have nested scopes that evolve over time).
    */
   mountFinalizationScope: (child?: object) => () => FinalizationScope;
 

--- a/packages/universal/shared/src/types.ts
+++ b/packages/universal/shared/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * A registration function takes a handler function and returns a function that,
- * when called, removes the handler.
+ * A registration function takes a handler function and returns a function
+ * that, when called, removes the handler.
  */
 export type Unregister = () => void;

--- a/packages/universal/shared/tests/package.json
+++ b/packages/universal/shared/tests/package.json
@@ -20,6 +20,6 @@
     "strip-ansi": "^7.1.0"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/packages/universal/tags/package.json
+++ b/packages/universal/tags/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   },
   "files": [

--- a/packages/universal/universal/package.json
+++ b/packages/universal/universal/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   },
   "files": [

--- a/packages/universal/universal/tests/package.json
+++ b/packages/universal/universal/tests/package.json
@@ -19,7 +19,7 @@
     "@starbeam/universal": "workspace:^"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@starbeam-workspace/test-utils": "workspace:^"
   }
 }

--- a/packages/universal/verify/index.ts
+++ b/packages/universal/verify/index.ts
@@ -3,8 +3,11 @@ import { hasType as hasTypeDev } from "./src/assertions/types.js";
 import type { VerifyFn } from "./src/verify.js";
 import {
   expected as expectedDev,
-  verified as verifiedDev,
   verify as verifyDev
+} from "./src/verify.js";
+
+export {
+  verified
 } from "./src/verify.js";
 
 const noop: unknown = () => { };
@@ -23,13 +26,10 @@ export {
 export { type TypeOf } from "./src/assertions/types.js";
 export { type Expectation, VerificationError } from "./src/verify.js";
 
-export const expected: typeof expectedDev = import.meta.env.DEV ? expectedDev : (noop as typeof expectedDev)
+export const expected: typeof expectedDev = import.meta.env.DEV ? expectedDev : null as unknown as typeof expectedDev
 export const hasType: typeof hasTypeDev = import.meta.env.DEV ? hasTypeDev : (noop as typeof hasTypeDev)
 export const isOneOf: typeof isOneOfDev = import.meta.env.DEV ? isOneOfDev : (noop as typeof isOneOfDev)
 
 export const verify: VerifyFn = import.meta.env.DEV
   ? verifyDev
-  : (noop as VerifyFn);
-export const verified: (typeof verifiedDev)["noop"] = import.meta.env.DEV
-  ? verifiedDev
-  : (noop as typeof verifiedDev);
+  : null as unknown as VerifyFn;

--- a/packages/universal/verify/package.json
+++ b/packages/universal/verify/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   },
   "files": [

--- a/packages/universal/verify/src/assertions/basic.ts
+++ b/packages/universal/verify/src/assertions/basic.ts
@@ -127,3 +127,22 @@ export function isNullable<In, Out extends In>(
 
   return verify;
 }
+
+
+if (import.meta.env.DEV) {
+  expected.associate(isPresent, expected.toBe("present"));
+  expected.associate(hasItems, expected.toHave(`at least one item`));
+  expected.associate(
+    isWeakKey,
+    expected
+      .toBe("an object or function")
+      .butGot((value) => (value === null ? "null" : typeof value)),
+  );
+  expected.associate(
+    isObject,
+    expected
+      .toBe("an object")
+      .butGot((value) => (value === null ? "null" : typeof value)),
+  );
+
+}

--- a/packages/universal/verify/src/assertions/basic.ts
+++ b/packages/universal/verify/src/assertions/basic.ts
@@ -8,8 +8,6 @@ export function isPresent<T>(value: T): value is Exclude<T, null | undefined> {
   return value !== null && value !== undefined;
 }
 
-expected.associate(isPresent, expected.toBe("present"));
-
 export function exhaustive(_value: never, type?: string): never {
   if (type) {
     throw Error(`unexpected types left in ${type}`);
@@ -66,25 +64,11 @@ export function isObject(value: unknown): value is object {
   return typeof value === "object" && value !== null;
 }
 
-expected.associate(
-  isObject,
-  expected
-    .toBe("an object")
-    .butGot((value) => (value === null ? "null" : typeof value)),
-);
-
 export function isWeakKey(value: unknown): value is Record<string, unknown> {
   return (
     (typeof value === "object" || typeof value === "function") && value !== null
   );
 }
-
-expected.associate(
-  isWeakKey,
-  expected
-    .toBe("an object or function")
-    .butGot((value) => (value === null ? "null" : typeof value)),
-);
 
 interface HasLength<L extends number> {
   <T>(value: T[]): value is FixedArray<T, L>;
@@ -106,8 +90,6 @@ export const hasItems = isPresentArray;
 // ): value is [T, ...(readonly T[])] {
 //   return value.length > 0;
 // }
-
-expected.associate(hasItems, expected.toHave(`at least one item`));
 
 export function isNullable<In, Out extends In>(
   verifier: (value: In) => value is Out,

--- a/packages/universal/verify/src/verify.ts
+++ b/packages/universal/verify/src/verify.ts
@@ -19,7 +19,14 @@ export function verify<Value, Narrow extends Value>(
   check: (input: Value) => input is Narrow,
   error?: Expectation<Value>,
 ): asserts value is Narrow;
-export function verify(
+export function verify(): void {
+  // eslint-disable-next-line prefer-rest-params
+  const params = [...arguments] as Parameters<typeof verifyFunc>;
+  if (import.meta.env.DEV) {
+    verifyFunc(...params) 
+  }
+}
+function verifyFunc(
   value: unknown,
   check: (input: unknown) => boolean,
   error?: Expectation<unknown>,
@@ -40,33 +47,20 @@ export function verify(
   }
 }
 
-verify.noop = (() => {
-  /** noop */
-}) as unknown as Exclude<typeof verify, "noop">;
-
-function noop(): void {
-  return;
-}
-
-verify.noop = noop as unknown as VerifyFn;
-
 export function verified<T, U extends T>(
   value: T,
   check: (input: T) => input is U,
   error?: Expectation<T>,
-): U {
-  verify(value, check, error);
-  return value;
+): U;
+
+export function verified(v: unknown): unknown {
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line prefer-rest-params
+    const [value, check, error] = [...arguments] as Parameters<typeof verified>;
+    verify(value, check, error);
+  }
+  return v;
 }
-
-verified.noop = <const T, const U extends T>(
-  value: T,
-  _check: (input: T) => input is U,
-  _error?: Expectation<T>,
-): U => {
-  return value as U;
-};
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class Expectation<In = any> {
   static create<In>(description?: string): Expectation<In> {
@@ -221,28 +215,40 @@ export function expected(description?: string): Expectation {
   return Expectation.create(description);
 }
 
-expected.as = expected;
-expected.toBe = (kind: string): Expectation => expected().toBe(kind);
-expected.toHave = (items: string): Expectation => expected().toHave(items);
-expected.when = (situation: string): Expectation => expected().when(situation);
-expected.butGot = <In>(
-  kind: string | ((input: In) => string),
-): Expectation<In> => expected().butGot(kind);
+if (import.meta.env.DEV) {
+  expected.as = expected;
+  expected.toBe = (kind: string): Expectation => expected().toBe(kind);
+  expected.toHave = (items: string): Expectation => expected().toHave(items);
+  expected.when = (situation: string): Expectation => expected().when(situation);
+  expected.butGot = <In>(
+    kind: string | ((input: In) => string),
+  ): Expectation<In> => expected().butGot(kind);
+
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+  expected.associate = <Check extends (input: In) => any, In>(
+    check: Check,
+    expectation: Expectation<In>,
+  ): Check extends infer C ? C : never => {
+    ASSOCIATED.set(check, expectation);
+    return check as Check extends infer C ? C : never;
+  };
+  expected.updated = <In, NewIn = In>(
+    check: (input: In) => boolean,
+    updater: Updater<In, NewIn>,
+  ): Expectation<NewIn> => {
+    const expectation = ASSOCIATED.get(check) ?? expected();
+
+    return expectation.update(updater);
+  };  
+}
+
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyFn = (...args: any[]) => any;
 
 // eslint-disable-next-line @typescript-eslint/consistent-generic-constructors
 const ASSOCIATED: WeakMap<AnyFn, Expectation> = new WeakMap();
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-expected.associate = <Check extends (input: In) => any, In>(
-  check: Check,
-  expectation: Expectation<In>,
-): Check extends infer C ? C : never => {
-  ASSOCIATED.set(check, expectation);
-  return check as Check extends infer C ? C : never;
-};
 
 interface Updater<In, NewIn = In> {
   description?: (description: string | undefined) => string | undefined;
@@ -253,11 +259,3 @@ interface Updater<In, NewIn = In> {
   when?: (when: string | undefined) => string | undefined;
 }
 
-expected.updated = <In, NewIn = In>(
-  check: (input: In) => boolean,
-  updater: Updater<In, NewIn>,
-): Expectation<NewIn> => {
-  const expectation = ASSOCIATED.get(check) ?? expected();
-
-  return expectation.update(updater);
-};

--- a/packages/universal/verify/tests/package.json
+++ b/packages/universal/verify/tests/package.json
@@ -26,6 +26,6 @@
     "@starbeam/verify": "workspace:^"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/packages/vue/vue-testing-utils/package.json
+++ b/packages/vue/vue-testing-utils/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@vue/shared": "^3.3.4",
     "rollup": "^4.0.2"
   },

--- a/packages/vue/vue-testing-utils/src/testing.ts
+++ b/packages/vue/vue-testing-utils/src/testing.ts
@@ -80,17 +80,17 @@ function defComponent<Props extends PropTypes>(
 /**
  * Define a Vue component for testing with specified props.
  *
- * This component should not be rendered directly in testing. Instead, it should
- * be invoked from the app (specified via {@linkcode App}) or a descendant of
- * the app.
+ * This component should not be rendered directly in testing. Instead, it
+ * should be invoked from the app (specified via {@linkcode App}) or a
+ * descendant of the app.
  *
  * @param props The props of the component, as passed to
  * {@linkcode defineComponent} in Vue.
  * @param definition The setup function of the component.
  *
- * The `definition` parameter may be may either be specified as a plain function
- * that takes props as specified by the `props` parameter, or it may be
- * specified as:
+ * The `definition` parameter may be may either be specified as a plain
+ * function that takes props as specified by the `props` parameter, or it may
+ * be specified as:
  *
  * `{ setup: (props) => () => VNodeChild }`
  */

--- a/packages/vue/vue-testing-utils/tests/package.json
+++ b/packages/vue/vue-testing-utils/tests/package.json
@@ -28,7 +28,7 @@
     "vue": ">=3.0.0"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@vue/shared": "^3.3.4",
     "preact-render-to-string": "^6.2.1",
     "vue": "^3.3.4"

--- a/packages/vue/vue/package.json
+++ b/packages/vue/vue/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   },
   "peerDependencies": {

--- a/packages/vue/vue/tests/create.spec.ts
+++ b/packages/vue/vue/tests/create.spec.ts
@@ -1,6 +1,6 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+ 
+ 
+ 
 // @vitest-environment jsdom
 
 import { Cell } from "@starbeam/universal";

--- a/packages/vue/vue/tests/package.json
+++ b/packages/vue/vue/tests/package.json
@@ -27,7 +27,7 @@
     "vue": ">=3.0.0"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "vue": "^3.3.4"
   }
 }

--- a/packages/vue/vue/tests/resources.spec.ts
+++ b/packages/vue/vue/tests/resources.spec.ts
@@ -1,6 +1,6 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+ 
+ 
+ 
 // @vitest-environment jsdom
 
 import { setupResource } from "@starbeam/vue";

--- a/packages/vue/vue/tests/services.spec.ts
+++ b/packages/vue/vue/tests/services.spec.ts
@@ -1,7 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+ 
+ 
+ 
+ 
 // @vitest-environment jsdom
 
 import { setupService } from "@starbeam/vue";

--- a/packages/x/headless-form/package.json
+++ b/packages/x/headless-form/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   }
 }

--- a/packages/x/store/package.json
+++ b/packages/x/store/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   }
 }

--- a/packages/x/store/tests/package.json
+++ b/packages/x/store/tests/package.json
@@ -18,6 +18,6 @@
     "@starbeamx/store": "workspace:^"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/packages/x/vanilla/package.json
+++ b/packages/x/vanilla/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   }
 }

--- a/packages/x/vanilla/tests/package.json
+++ b/packages/x/vanilla/tests/package.json
@@ -17,6 +17,6 @@
     "@starbeamx/vanilla": "workspace:^"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1814,6 +1814,12 @@ importers:
         specifier: ^8.56.0
         version: 8.56.0
 
+  workspace/scripts:
+    devDependencies:
+      globby:
+        specifier: ^13.2.2
+        version: 13.2.2
+
   workspace/test-utils:
     dependencies:
       '@starbeam/resource':
@@ -7050,7 +7056,6 @@ packages:
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
-    dev: false
 
   /globby@14.0.0:
     resolution: {integrity: sha512-/1WM/LNHRAOH9lZta77uGbq0dAEQM+XjNesWwhlERDVenqothRbnzTrL3/LrIoEPPjeUHC3vrS6TwoyxeHs7MQ==}
@@ -9541,7 +9546,6 @@ packages:
   /slash@4.0.0:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
-    dev: false
 
   /slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,12 @@ overrides:
   '@starbeam-dev/compile': workspace:*
   '@types/eslint': ^8.56.0
   '@types/node': ^20.10.5
-  eslint: ^8.56.0
+  eslint: ^8.57.0
   preact: 10.17.1
   typescript: ^5.3.3
   vite: ^5.0.10
   vue: 3.3.4
+  terser: ^5.31.0
 
 importers:
 
@@ -39,8 +40,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@types/eslint':
         specifier: ^8.56.0
         version: 8.56.0
@@ -49,43 +50,43 @@ importers:
         version: 20.10.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.15.0
-        version: 6.15.0(@typescript-eslint/parser@6.15.0)(eslint@8.56.0)(typescript@5.3.3)
+        version: 6.15.0(@typescript-eslint/parser@6.15.0)(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/parser':
         specifier: ^6.15.0
-        version: 6.15.0(eslint@8.56.0)(typescript@5.3.3)
+        version: 6.15.0(eslint@8.57.0)(typescript@5.3.3)
       '@vitest/ui':
         specifier: ^1.1.0
         version: 1.1.0(vitest@1.1.0)
       eslint:
-        specifier: ^8.56.0
-        version: 8.56.0
+        specifier: ^8.57.0
+        version: 8.57.0
       eslint-config-airbnb:
         specifier: ^19.0.4
-        version: 19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint@8.56.0)
+        version: 19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint@8.57.0)
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.0(eslint@8.56.0)
+        version: 9.1.0(eslint@8.57.0)
       eslint-import-resolver-typescript:
         specifier: ^3.6.1
-        version: 3.6.1(@typescript-eslint/parser@6.15.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+        version: 3.6.1(@typescript-eslint/parser@6.15.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.1
-        version: 2.29.1(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+        version: 2.29.1(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-json:
         specifier: ^3.1.0
         version: 3.1.0
       eslint-plugin-jsonc:
         specifier: ^2.11.2
-        version: 2.11.2(eslint@8.56.0)
+        version: 2.11.2(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: ^5.1.0
-        version: 5.1.0(@types/eslint@8.56.0)(eslint-config-prettier@9.1.0)(eslint@8.56.0)(prettier@3.1.1)
+        version: 5.1.0(@types/eslint@8.56.0)(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.1.1)
       eslint-plugin-simple-import-sort:
         specifier: ^10.0.0
-        version: 10.0.0(eslint@8.56.0)
+        version: 10.0.0(eslint@8.57.0)
       eslint-plugin-unused-imports:
         specifier: ^3.0.0
-        version: 3.0.0(@typescript-eslint/eslint-plugin@6.15.0)(eslint@8.56.0)
+        version: 3.0.0(@typescript-eslint/eslint-plugin@6.15.0)(eslint@8.57.0)
       esyes:
         specifier: ^1.0.2
         version: 1.0.2
@@ -129,8 +130,8 @@ importers:
   '@types/ansicolor':
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@types/node':
         specifier: ^20.10.5
         version: 20.10.5
@@ -138,8 +139,8 @@ importers:
   '@types/fsify':
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@types/node':
         specifier: ^20.10.5
         version: 20.10.5
@@ -147,8 +148,8 @@ importers:
   '@types/lines-and-columns':
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@types/node':
         specifier: ^20.10.5
         version: 20.10.5
@@ -160,8 +161,8 @@ importers:
         version: 25.0.5
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.3
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   '@types/plugin-node-resolve':
     dependencies:
@@ -170,8 +171,8 @@ importers:
         version: 15.2.3(rollup@4.4.1)
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.3
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   '@types/rollup-plugin-polyfill-node':
     dependencies:
@@ -180,14 +181,14 @@ importers:
         version: 4.4.1
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   '@types/shell-escape-tag':
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@types/node':
         specifier: ^20.10.5
         version: 20.10.5
@@ -195,8 +196,8 @@ importers:
   '@types/shell-split':
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@types/node':
         specifier: ^20.10.5
         version: 20.10.5
@@ -211,8 +212,8 @@ importers:
         version: 1.1.0(@edge-runtime/vm@3.1.7)(@types/node@20.10.5)(@vitest/ui@1.1.0)(happy-dom@12.10.3)(jsdom@23.0.1)
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   packages/preact/preact:
     dependencies:
@@ -266,8 +267,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -297,8 +298,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       preact-render-to-string:
         specifier: ^6.2.1
         version: 6.2.1(preact@10.17.1)
@@ -343,8 +344,8 @@ importers:
         version: 10.17.1
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       preact-render-to-string:
         specifier: ^6.2.1
         version: 6.2.1(preact@10.17.1)
@@ -362,8 +363,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -402,8 +403,8 @@ importers:
         version: 10.17.1
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       preact-render-to-string:
         specifier: ^6.2.1
         version: 6.2.1(preact@10.17.1)
@@ -448,8 +449,8 @@ importers:
         version: 10.17.1
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       preact-render-to-string:
         specifier: ^6.2.1
         version: 6.2.1(preact@10.17.1)
@@ -512,8 +513,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@types/node':
         specifier: ^20.10.5
         version: 20.10.5
@@ -561,8 +562,8 @@ importers:
         version: 0.34.6(@edge-runtime/vm@3.1.7)(@vitest/ui@1.1.0)(happy-dom@12.10.3)(jsdom@22.1.0)
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   packages/react/test-utils:
     dependencies:
@@ -601,8 +602,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
@@ -632,8 +633,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@types/react':
         specifier: ^18.2.22
         version: 18.2.22
@@ -660,8 +661,8 @@ importers:
         version: 18.2.0
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@types/react':
         specifier: ^18.2.22
         version: 18.2.22
@@ -703,8 +704,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -722,8 +723,8 @@ importers:
         version: link:../../universal
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   packages/universal/core:
     dependencies:
@@ -735,8 +736,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -747,8 +748,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -760,8 +761,8 @@ importers:
         version: link:..
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   packages/universal/debug:
     dependencies:
@@ -797,8 +798,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@types/node':
         specifier: ^20.10.5
         version: 20.10.5
@@ -816,8 +817,8 @@ importers:
         version: link:..
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   packages/universal/interfaces:
     dependencies:
@@ -832,8 +833,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   packages/universal/modifier:
     dependencies:
@@ -866,8 +867,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -894,8 +895,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -922,8 +923,8 @@ importers:
         version: link:../../shared
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   packages/universal/renderer:
     dependencies:
@@ -950,8 +951,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -966,8 +967,8 @@ importers:
         version: link:..
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   packages/universal/resource:
     dependencies:
@@ -997,8 +998,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -1034,8 +1035,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   packages/universal/runtime:
     dependencies:
@@ -1065,8 +1066,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.0
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -1096,8 +1097,8 @@ importers:
         version: link:../../shared
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   packages/universal/service:
     dependencies:
@@ -1127,8 +1128,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -1164,8 +1165,8 @@ importers:
         version: link:../../shared
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   packages/universal/shared:
     devDependencies:
@@ -1173,8 +1174,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -1201,8 +1202,8 @@ importers:
         version: 7.1.0
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   packages/universal/tags:
     dependencies:
@@ -1223,8 +1224,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -1266,8 +1267,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -1291,8 +1292,8 @@ importers:
         version: link:..
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@starbeam-workspace/test-utils':
         specifier: workspace:^
         version: link:../../../../workspace/test-utils
@@ -1307,8 +1308,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -1320,8 +1321,8 @@ importers:
         version: link:..
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   packages/vue/vue:
     dependencies:
@@ -1369,8 +1370,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -1403,8 +1404,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@vue/shared':
         specifier: ^3.3.4
         version: 3.3.4
@@ -1458,8 +1459,8 @@ importers:
         version: 3.3.4
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@vue/shared':
         specifier: ^3.3.4
         version: 3.3.4
@@ -1510,8 +1511,8 @@ importers:
         version: 3.3.4
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   packages/x/headless-form:
     dependencies:
@@ -1532,8 +1533,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -1557,8 +1558,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -1579,8 +1580,8 @@ importers:
         version: link:..
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   packages/x/vanilla:
     dependencies:
@@ -1607,8 +1608,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -1643,8 +1644,8 @@ importers:
         specifier: ^8.0.1
         version: 8.2.2
       eslint:
-        specifier: ^8.56.0
-        version: 8.56.0
+        specifier: ^8.57.0
+        version: 8.57.0
       prettier:
         specifier: ^2.8.7
         version: 2.8.8
@@ -1680,8 +1681,8 @@ importers:
         version: link:..
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   workspace/@domtree/any:
     dependencies:
@@ -1699,8 +1700,8 @@ importers:
         specifier: workspace:*
         version: link:../../dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   workspace/@domtree/browser:
     dependencies:
@@ -1712,8 +1713,8 @@ importers:
         specifier: workspace:*
         version: link:../../dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   workspace/@domtree/flavors:
     dependencies:
@@ -1731,8 +1732,8 @@ importers:
         specifier: workspace:*
         version: link:../../dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   workspace/@domtree/interface:
     devDependencies:
@@ -1740,8 +1741,8 @@ importers:
         specifier: workspace:*
         version: link:../../dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   workspace/@domtree/minimal:
     dependencies:
@@ -1753,8 +1754,8 @@ importers:
         specifier: workspace:*
         version: link:../../dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
 
   workspace/dev-compile:
     dependencies:
@@ -1785,6 +1786,9 @@ importers:
       rollup-plugin-copy:
         specifier: ^3.5.0
         version: 3.5.0
+      rollup-plugin-prettier:
+        specifier: ^4.1.1
+        version: 4.1.1(prettier@3.1.1)(rollup@4.4.1)
       rollup-plugin-ts:
         specifier: ^3.4.5
         version: 3.4.5(@swc/core@1.3.96)(@swc/helpers@0.5.3)(rollup@4.4.1)(typescript@5.3.3)
@@ -1793,8 +1797,8 @@ importers:
         version: 5.3.3
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.3
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@swc/helpers':
         specifier: ^0.5.3
         version: 0.5.3
@@ -1811,8 +1815,8 @@ importers:
         specifier: workspace:^
         version: link:../../@types/plugin-node-resolve
       eslint:
-        specifier: ^8.56.0
-        version: 8.56.0
+        specifier: ^8.57.0
+        version: 8.57.0
 
   workspace/scripts:
     devDependencies:
@@ -1854,8 +1858,8 @@ importers:
         specifier: workspace:*
         version: link:../dev-compile
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       rollup:
         specifier: ^4.0.2
         version: 4.4.1
@@ -1876,8 +1880,8 @@ importers:
         version: 7.0.0
     devDependencies:
       '@starbeam-dev/eslint-plugin':
-        specifier: ^1.0.4
-        version: 1.0.4(eslint@8.56.0)(typescript@5.3.3)
+        specifier: ^1.0.6
+        version: 1.0.6(eslint@8.57.0)(typescript@5.3.3)
       '@types/fs-extra':
         specifier: ^11.0.2
         version: 11.0.2
@@ -2924,13 +2928,13 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.56.0):
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.57.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     dependencies:
-      eslint: 8.56.0
+      eslint: 8.57.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -2946,7 +2950,7 @@ packages:
       ajv: 6.12.6
       debug: 4.3.4
       espree: 9.6.1
-      globals: 13.22.0
+      globals: 13.24.0
       ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -2956,8 +2960,8 @@ packages:
       - supports-color
     dev: true
 
-  /@eslint/js@8.56.0:
-    resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
+  /@eslint/js@8.57.0:
+    resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -3171,11 +3175,11 @@ packages:
     resolution: {integrity: sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==}
     dev: true
 
-  /@humanwhocodes/config-array@0.11.13:
-    resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
+  /@humanwhocodes/config-array@0.11.14:
+    resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
     dependencies:
-      '@humanwhocodes/object-schema': 2.0.1
+      '@humanwhocodes/object-schema': 2.0.3
       debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
@@ -3187,8 +3191,8 @@ packages:
     engines: {node: '>=12.22'}
     dev: true
 
-  /@humanwhocodes/object-schema@2.0.1:
-    resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
+  /@humanwhocodes/object-schema@2.0.3:
+    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     dev: true
 
   /@isaacs/cliui@8.0.2:
@@ -3919,7 +3923,7 @@ packages:
       rollup: 4.4.1
       serialize-javascript: 6.0.2
       smob: 1.4.1
-      terser: 5.26.0
+      terser: 5.31.0
     dev: false
 
   /@rollup/pluginutils@5.1.0(rollup@4.4.1):
@@ -4056,29 +4060,29 @@ packages:
   /@starbeam-dev/core@1.0.2:
     resolution: {integrity: sha512-gYY9jg8Qzr5t+VBzKsCiJ0qZ8H9v3p8cht4ipN7EW4STOEQezChFmbgfPpq2r4s8ZaKykrbIBLdMn/pNfmoRaQ==}
 
-  /@starbeam-dev/eslint-plugin@1.0.4(eslint@8.56.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-ykiWbPr3js1LrIK+QgcV371mmax8wQamgwByFVfbtZsW1Suuyv4wd+SlBC17AVoBSZXrqW9kgVQ5z3dNFPWAaQ==}
+  /@starbeam-dev/eslint-plugin@1.0.6(eslint@8.57.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-MBVRjkeBLv9ANKhw7Fe0jU+EIGyYwVSm0TpBp58QxsB12umIvZUuXfSVLNvB5T838IlR4FNOxfvC0tAZyk5ksw==}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
       typescript: '*'
     dependencies:
       '@types/eslint': 8.56.0
-      '@typescript-eslint/eslint-plugin': 6.15.0(@typescript-eslint/parser@6.15.0)(eslint@8.56.0)(typescript@5.3.3)
-      '@typescript-eslint/parser': 6.15.0(eslint@8.56.0)(typescript@5.3.3)
-      eslint: 8.56.0
-      eslint-config-prettier: 9.1.0(eslint@8.56.0)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.15.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-comment-length: 1.7.2(eslint@8.56.0)(typescript@5.3.3)
-      eslint-plugin-eslint-comments: 3.2.0(eslint@8.56.0)
-      eslint-plugin-etc: 2.0.3(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/eslint-plugin': 6.15.0(@typescript-eslint/parser@6.15.0)(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.15.0(eslint@8.57.0)(typescript@5.3.3)
+      eslint: 8.57.0
+      eslint-config-prettier: 9.1.0(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.15.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-plugin-comment-length: 1.7.2(eslint@8.57.0)(typescript@5.3.3)
+      eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
+      eslint-plugin-etc: 2.0.3(eslint@8.57.0)(typescript@5.3.3)
       eslint-plugin-file-extension-in-import-ts: 1.0.2
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-json: 3.1.0
-      eslint-plugin-jsonc: 2.11.2(eslint@8.56.0)
-      eslint-plugin-prettier: 5.1.0(@types/eslint@8.56.0)(eslint-config-prettier@9.1.0)(eslint@8.56.0)(prettier@3.1.1)
-      eslint-plugin-simple-import-sort: 10.0.0(eslint@8.56.0)
-      eslint-plugin-unicorn: 48.0.1(eslint@8.56.0)
-      eslint-plugin-unused-imports: 3.0.0(@typescript-eslint/eslint-plugin@6.15.0)(eslint@8.56.0)
+      eslint-plugin-jsonc: 2.11.2(eslint@8.57.0)
+      eslint-plugin-prettier: 5.1.0(@types/eslint@8.56.0)(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.1.1)
+      eslint-plugin-simple-import-sort: 10.0.0(eslint@8.57.0)
+      eslint-plugin-unicorn: 48.0.1(eslint@8.57.0)
+      eslint-plugin-unused-imports: 3.0.0(@typescript-eslint/eslint-plugin@6.15.0)(eslint@8.57.0)
       jsonc-eslint-parser: 2.3.0
       prettier: 3.1.1
       typescript: 5.3.3
@@ -4405,6 +4409,13 @@ packages:
     resolution: {integrity: sha512-219LSCO9HPcoXcRTC6DbCs0FRhZgBnEMzf16RRqkT40WbkKx3mOeQuz3e2XqbfhOz/AHfbru0kzB1n1RCAsIIg==}
     dev: false
 
+  /@types/prettier@3.0.0:
+    resolution: {integrity: sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==}
+    deprecated: This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.
+    dependencies:
+      prettier: 3.1.1
+    dev: false
+
   /@types/prop-types@15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
     dev: true
@@ -4458,25 +4469,25 @@ packages:
       '@types/yargs-parser': 21.0.1
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.15.0(@typescript-eslint/parser@6.15.0)(eslint@8.56.0)(typescript@5.3.3):
+  /@typescript-eslint/eslint-plugin@6.15.0(@typescript-eslint/parser@6.15.0)(eslint@8.57.0)(typescript@5.3.3):
     resolution: {integrity: sha512-j5qoikQqPccq9QoBAupOP+CBu8BaJ8BLjaXSioDISeTZkVO3ig7oSIKh3H+rEpee7xCXtWwSB4KIL5l6hWZzpg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
-      eslint: ^8.56.0
+      eslint: ^8.57.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.9.1
-      '@typescript-eslint/parser': 6.15.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.15.0(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/scope-manager': 6.15.0
-      '@typescript-eslint/type-utils': 6.15.0(eslint@8.56.0)(typescript@5.3.3)
-      '@typescript-eslint/utils': 6.15.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/type-utils': 6.15.0(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.15.0(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.15.0
       debug: 4.3.4
-      eslint: 8.56.0
+      eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.2.4
       natural-compare: 1.4.0
@@ -4487,24 +4498,24 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils@5.62.0(eslint@8.56.0)(typescript@5.3.3):
+  /@typescript-eslint/experimental-utils@5.62.0(eslint@8.57.0)(typescript@5.3.3):
     resolution: {integrity: sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.3.3)
-      eslint: 8.56.0
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.3.3)
+      eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/parser@6.15.0(eslint@8.56.0)(typescript@5.3.3):
+  /@typescript-eslint/parser@6.15.0(eslint@8.57.0)(typescript@5.3.3):
     resolution: {integrity: sha512-MkgKNnsjC6QwcMdlNAel24jjkEO/0hQaMDLqP4S9zq5HBAUJNQB6y+3DwLjX7b3l2b37eNAxMPLwb3/kh8VKdA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -4515,7 +4526,7 @@ packages:
       '@typescript-eslint/typescript-estree': 6.15.0(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.15.0
       debug: 4.3.4
-      eslint: 8.56.0
+      eslint: 8.57.0
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -4537,20 +4548,20 @@ packages:
       '@typescript-eslint/visitor-keys': 6.15.0
     dev: true
 
-  /@typescript-eslint/type-utils@6.15.0(eslint@8.56.0)(typescript@5.3.3):
+  /@typescript-eslint/type-utils@6.15.0(eslint@8.57.0)(typescript@5.3.3):
     resolution: {integrity: sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 6.15.0(typescript@5.3.3)
-      '@typescript-eslint/utils': 6.15.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.15.0(eslint@8.57.0)(typescript@5.3.3)
       debug: 4.3.4
-      eslint: 8.56.0
+      eslint: 8.57.0
       ts-api-utils: 1.0.3(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -4609,19 +4620,19 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.56.0)(typescript@5.3.3):
+  /@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@5.3.3):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@types/json-schema': 7.0.13
       '@types/semver': 7.5.3
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.3.3)
-      eslint: 8.56.0
+      eslint: 8.57.0
       eslint-scope: 5.1.1
       semver: 7.5.4
     transitivePeerDependencies:
@@ -4629,19 +4640,19 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@6.15.0(eslint@8.56.0)(typescript@5.3.3):
+  /@typescript-eslint/utils@6.15.0(eslint@8.57.0)(typescript@5.3.3):
     resolution: {integrity: sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@types/json-schema': 7.0.13
       '@types/semver': 7.5.3
       '@typescript-eslint/scope-manager': 6.15.0
       '@typescript-eslint/types': 6.15.0
       '@typescript-eslint/typescript-estree': 6.15.0(typescript@5.3.3)
-      eslint: 8.56.0
+      eslint: 8.57.0
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
@@ -5759,6 +5770,11 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  /diff@5.1.0:
+    resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
+    engines: {node: '>=0.3.1'}
+    dev: false
+
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -6148,67 +6164,67 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-compat-utils@0.1.2(eslint@8.56.0):
+  /eslint-compat-utils@0.1.2(eslint@8.57.0):
     resolution: {integrity: sha512-Jia4JDldWnFNIru1Ehx1H5s9/yxiRHY/TimCuUc0jNexew3cF1gI6CYZil1ociakfWO3rRqFjl1mskBblB3RYg==}
     engines: {node: '>=12'}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     dependencies:
-      eslint: 8.56.0
+      eslint: 8.57.0
     dev: true
 
-  /eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.29.1)(eslint@8.56.0):
+  /eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     resolution: {integrity: sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
       eslint-plugin-import: ^2.25.2
     dependencies:
       confusing-browser-globals: 1.0.11
-      eslint: 8.56.0
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint: 8.57.0
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       object.assign: 4.1.4
       object.entries: 1.1.7
       semver: 6.3.1
     dev: true
 
-  /eslint-config-airbnb@19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint@8.56.0):
+  /eslint-config-airbnb@19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint@8.57.0):
     resolution: {integrity: sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==}
     engines: {node: ^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
       eslint-plugin-import: ^2.25.3
       eslint-plugin-jsx-a11y: ^6.5.1
       eslint-plugin-react: ^7.28.0
       eslint-plugin-react-hooks: ^4.3.0
     dependencies:
-      eslint: 8.56.0
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
-      eslint-plugin-react: 7.33.2(eslint@8.56.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
+      eslint: 8.57.0
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
+      eslint-plugin-react: 7.33.2(eslint@8.57.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
       object.assign: 4.1.4
       object.entries: 1.1.7
     dev: true
 
-  /eslint-config-prettier@9.1.0(eslint@8.56.0):
+  /eslint-config-prettier@9.1.0(eslint@8.57.0):
     resolution: {integrity: sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==}
     hasBin: true
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     dependencies:
-      eslint: 8.56.0
+      eslint: 8.57.0
     dev: true
 
-  /eslint-etc@5.2.1(eslint@8.56.0)(typescript@5.3.3):
+  /eslint-etc@5.2.1(eslint@8.57.0)(typescript@5.3.3):
     resolution: {integrity: sha512-lFJBSiIURdqQKq9xJhvSJFyPA+VeTh5xvk24e8pxVL7bwLBtGF60C/KRkLTMrvCZ6DA3kbPuYhLWY0TZMlqTsg==}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
       typescript: '*'
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.56.0)(typescript@5.3.3)
-      eslint: 8.56.0
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.0)(typescript@5.3.3)
+      eslint: 8.57.0
       tsutils: 3.21.0(typescript@5.3.3)
       tsutils-etc: 1.4.2(tsutils@3.21.0)(typescript@5.3.3)
       typescript: 5.3.3
@@ -6226,18 +6242,18 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.15.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
+  /eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.15.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     resolution: {integrity: sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
       eslint-plugin-import: '*'
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
-      eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint: 8.57.0
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -6249,7 +6265,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -6270,48 +6286,48 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.15.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.15.0(eslint@8.57.0)(typescript@5.3.3)
       debug: 3.2.7
-      eslint: 8.56.0
+      eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.15.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.15.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-comment-length@1.7.2(eslint@8.56.0)(typescript@5.3.3):
+  /eslint-plugin-comment-length@1.7.2(eslint@8.57.0)(typescript@5.3.3):
     resolution: {integrity: sha512-HrS2UcGp0MEZwPWJ8pDIpG0Op5gjNw1sipDkOMVzRqc3wzANLf2s6YTLMUp85nHYvcc2L/3YFIQj+7gQ9Hg1yg==}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     dependencies:
-      '@typescript-eslint/utils': 6.15.0(eslint@8.56.0)(typescript@5.3.3)
-      eslint: 8.56.0
+      '@typescript-eslint/utils': 6.15.0(eslint@8.57.0)(typescript@5.3.3)
+      eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-eslint-comments@3.2.0(eslint@8.56.0):
+  /eslint-plugin-eslint-comments@3.2.0(eslint@8.57.0):
     resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
     engines: {node: '>=6.5.0'}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     dependencies:
       escape-string-regexp: 1.0.5
-      eslint: 8.56.0
+      eslint: 8.57.0
       ignore: 5.2.4
     dev: true
 
-  /eslint-plugin-etc@2.0.3(eslint@8.56.0)(typescript@5.3.3):
+  /eslint-plugin-etc@2.0.3(eslint@8.57.0)(typescript@5.3.3):
     resolution: {integrity: sha512-o5RS/0YwtjlGKWjhKojgmm82gV1b4NQUuwk9zqjy9/EjxNFKKYCaF+0M7DkYBn44mJ6JYFZw3Ft249dkKuR1ew==}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
       typescript: '*'
     dependencies:
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.3.3)
-      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.56.0)(typescript@5.3.3)
-      eslint: 8.56.0
-      eslint-etc: 5.2.1(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.0)(typescript@5.3.3)
+      eslint: 8.57.0
+      eslint-etc: 5.2.1(eslint@8.57.0)(typescript@5.3.3)
       requireindex: 1.2.0
       tslib: 2.6.2
       tsutils: 3.21.0(typescript@5.3.3)
@@ -6327,26 +6343,26 @@ packages:
       resolve: 1.22.8
     dev: true
 
-  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.15.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.15.0(eslint@8.57.0)(typescript@5.3.3)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.56.0
+      eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.15.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -6370,26 +6386,26 @@ packages:
       vscode-json-languageservice: 4.2.1
     dev: true
 
-  /eslint-plugin-jsonc@2.11.2(eslint@8.56.0):
+  /eslint-plugin-jsonc@2.11.2(eslint@8.57.0):
     resolution: {integrity: sha512-F6A0MZhIGRBPOswzzn4tJFXXkPLiLwJaMlQwz/Qj1qx+bV5MCn79vBeJh2ynMmtqqHloi54KDCnsT/KWrcCcnQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
-      eslint: 8.56.0
-      eslint-compat-utils: 0.1.2(eslint@8.56.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      eslint: 8.57.0
+      eslint-compat-utils: 0.1.2(eslint@8.57.0)
       espree: 9.6.1
       graphemer: 1.4.0
       jsonc-eslint-parser: 2.3.0
       natural-compare: 1.4.0
     dev: true
 
-  /eslint-plugin-jsx-a11y@6.8.0(eslint@8.56.0):
+  /eslint-plugin-jsx-a11y@6.8.0(eslint@8.57.0):
     resolution: {integrity: sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==}
     engines: {node: '>=4.0'}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     dependencies:
       '@babel/runtime': 7.23.7
       aria-query: 5.3.0
@@ -6401,7 +6417,7 @@ packages:
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
       es-iterator-helpers: 1.0.15
-      eslint: 8.56.0
+      eslint: 8.57.0
       hasown: 2.0.0
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -6410,12 +6426,12 @@ packages:
       object.fromentries: 2.0.7
     dev: true
 
-  /eslint-plugin-prettier@5.1.0(@types/eslint@8.56.0)(eslint-config-prettier@9.1.0)(eslint@8.56.0)(prettier@3.1.1):
+  /eslint-plugin-prettier@5.1.0(@types/eslint@8.56.0)(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.1.1):
     resolution: {integrity: sha512-hQc+2zbnMeXcIkg+pKZtVa+3Yqx4WY7SMkn1PLZ4VbBEU7jJIpVn9347P8BBhTbz6ne85aXvQf30kvexcqBeWw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       '@types/eslint': ^8.56.0
-      eslint: ^8.56.0
+      eslint: ^8.57.0
       eslint-config-prettier: '*'
       prettier: '>=3.0.0'
     peerDependenciesMeta:
@@ -6425,34 +6441,34 @@ packages:
         optional: true
     dependencies:
       '@types/eslint': 8.56.0
-      eslint: 8.56.0
-      eslint-config-prettier: 9.1.0(eslint@8.56.0)
+      eslint: 8.57.0
+      eslint-config-prettier: 9.1.0(eslint@8.57.0)
       prettier: 3.1.1
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.5
     dev: true
 
-  /eslint-plugin-react-hooks@4.6.0(eslint@8.56.0):
+  /eslint-plugin-react-hooks@4.6.0(eslint@8.57.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     dependencies:
-      eslint: 8.56.0
+      eslint: 8.57.0
     dev: true
 
-  /eslint-plugin-react@7.33.2(eslint@8.56.0):
+  /eslint-plugin-react@7.33.2(eslint@8.57.0):
     resolution: {integrity: sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     dependencies:
       array-includes: 3.1.7
       array.prototype.flatmap: 1.3.2
       array.prototype.tosorted: 1.1.2
       doctrine: 2.1.0
       es-iterator-helpers: 1.0.15
-      eslint: 8.56.0
+      eslint: 8.57.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.2
@@ -6466,25 +6482,25 @@ packages:
       string.prototype.matchall: 4.0.10
     dev: true
 
-  /eslint-plugin-simple-import-sort@10.0.0(eslint@8.56.0):
+  /eslint-plugin-simple-import-sort@10.0.0(eslint@8.57.0):
     resolution: {integrity: sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     dependencies:
-      eslint: 8.56.0
+      eslint: 8.57.0
     dev: true
 
-  /eslint-plugin-unicorn@48.0.1(eslint@8.56.0):
+  /eslint-plugin-unicorn@48.0.1(eslint@8.57.0):
     resolution: {integrity: sha512-FW+4r20myG/DqFcCSzoumaddKBicIPeFnTrifon2mWIzlfyvzwyqZjqVP7m4Cqr/ZYisS2aiLghkUWaPg6vtCw==}
     engines: {node: '>=16'}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     dependencies:
       '@babel/helper-validator-identifier': 7.22.20
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       ci-info: 3.9.0
       clean-regexp: 1.0.0
-      eslint: 8.56.0
+      eslint: 8.57.0
       esquery: 1.5.0
       indent-string: 4.0.0
       is-builtin-module: 3.2.1
@@ -6498,18 +6514,18 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
-  /eslint-plugin-unused-imports@3.0.0(@typescript-eslint/eslint-plugin@6.15.0)(eslint@8.56.0):
+  /eslint-plugin-unused-imports@3.0.0(@typescript-eslint/eslint-plugin@6.15.0)(eslint@8.57.0):
     resolution: {integrity: sha512-sduiswLJfZHeeBJ+MQaG+xYzSWdRXoSw61DpU13mzWumCkR0ufD0HmO4kdNokjrkluMHpj/7PJeN35pgbhW3kw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': '*'
-      eslint: ^8.56.0
+      eslint: ^8.57.0
     peerDependenciesMeta:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.15.0(@typescript-eslint/parser@6.15.0)(eslint@8.56.0)(typescript@5.3.3)
-      eslint: 8.56.0
+      '@typescript-eslint/eslint-plugin': 6.15.0(@typescript-eslint/parser@6.15.0)(eslint@8.57.0)(typescript@5.3.3)
+      eslint: 8.57.0
       eslint-rule-composer: 0.3.0
     dev: true
 
@@ -6539,16 +6555,16 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint@8.56.0:
-    resolution: {integrity: sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==}
+  /eslint@8.57.0:
+    resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@eslint-community/regexpp': 4.9.1
       '@eslint/eslintrc': 2.1.4
-      '@eslint/js': 8.56.0
-      '@humanwhocodes/config-array': 0.11.13
+      '@eslint/js': 8.57.0
+      '@humanwhocodes/config-array': 0.11.14
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.2.0
@@ -6567,7 +6583,7 @@ packages:
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.22.0
+      globals: 13.24.0
       graphemer: 1.4.0
       ignore: 5.2.4
       imurmurhash: 0.1.4
@@ -6738,7 +6754,7 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
-      flat-cache: 3.0.4
+      flat-cache: 3.2.0
     dev: true
 
   /fill-range@7.0.1:
@@ -6772,11 +6788,12 @@ packages:
       path-exists: 4.0.0
     dev: true
 
-  /flat-cache@3.0.4:
-    resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
+  /flat-cache@3.2.0:
+    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       flatted: 3.2.9
+      keyv: 4.5.4
       rimraf: 3.0.2
     dev: true
 
@@ -7003,8 +7020,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /globals@13.22.0:
-    resolution: {integrity: sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==}
+  /globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
@@ -7792,7 +7809,6 @@ packages:
 
   /json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-    dev: false
 
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
@@ -7875,6 +7891,12 @@ packages:
     dependencies:
       json-buffer: 3.0.1
     dev: false
+
+  /keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+    dependencies:
+      json-buffer: 3.0.1
+    dev: true
 
   /knip@3.8.4(@types/node@20.10.5)(typescript@5.3.3):
     resolution: {integrity: sha512-pmgUD7LSe3tRf84qogBnIe8uXcfTR+bjbVwW+TrKeHLayOhpw5Xa2vSqXOQ68fMQ8lBrpp8cW+c+hsYMc2YE+w==}
@@ -7995,9 +8017,25 @@ packages:
     resolution: {integrity: sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA==}
     dev: true
 
+  /lodash.hasin@4.5.2:
+    resolution: {integrity: sha512-AFAitwTSq1Ka/1J9uBaVxpLBP5OI3INQvkl4wKcgIYxoA0S3aqO1QWXHR9aCcOrWtPFqP7GzlFncZfe0Jz0kNw==}
+    dev: false
+
+  /lodash.isempty@4.4.0:
+    resolution: {integrity: sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==}
+    dev: false
+
+  /lodash.isnil@4.0.0:
+    resolution: {integrity: sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==}
+    dev: false
+
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
+
+  /lodash.omitby@4.6.0:
+    resolution: {integrity: sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ==}
+    dev: false
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -8946,7 +8984,6 @@ packages:
     resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
     engines: {node: '>=14'}
     hasBin: true
-    dev: true
 
   /pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -9327,6 +9364,24 @@ packages:
       fs-extra: 8.1.0
       globby: 10.0.1
       is-plain-object: 3.0.1
+    dev: false
+
+  /rollup-plugin-prettier@4.1.1(prettier@3.1.1)(rollup@4.4.1):
+    resolution: {integrity: sha512-ugpi/EqW12yJa4NO3o4f/wt/YHwiQovVGC2jxZgxuKO9osjt4lVxVA427+itl87XmQc6089ZkpDc6OpaOZKWgQ==}
+    engines: {node: '>=6.0.0'}
+    peerDependencies:
+      prettier: ^1.0.0 || ^2.0.0 || ^3.0.0
+      rollup: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
+    dependencies:
+      '@types/prettier': 3.0.0
+      diff: 5.1.0
+      lodash.hasin: 4.5.2
+      lodash.isempty: 4.4.0
+      lodash.isnil: 4.0.0
+      lodash.omitby: 4.6.0
+      magic-string: 0.30.5
+      prettier: 3.1.1
+      rollup: 4.4.1
     dev: false
 
   /rollup-plugin-ts@3.4.5(@swc/core@1.3.96)(@swc/helpers@0.5.3)(rollup@4.4.1)(typescript@5.3.3):
@@ -9874,8 +9929,8 @@ packages:
       yallist: 4.0.0
     dev: true
 
-  /terser@5.26.0:
-    resolution: {integrity: sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==}
+  /terser@5.31.0:
+    resolution: {integrity: sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -10411,7 +10466,7 @@ packages:
       sass: '*'
       stylus: '*'
       sugarss: '*'
-      terser: ^5.4.0
+      terser: ^5.31.0
     peerDependenciesMeta:
       '@types/node':
         optional: true

--- a/workspace/@domtree/any/package.json
+++ b/workspace/@domtree/any/package.json
@@ -31,6 +31,6 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/workspace/@domtree/browser/package.json
+++ b/workspace/@domtree/browser/package.json
@@ -29,6 +29,6 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/workspace/@domtree/flavors/package.json
+++ b/workspace/@domtree/flavors/package.json
@@ -31,6 +31,6 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/workspace/@domtree/interface/package.json
+++ b/workspace/@domtree/interface/package.json
@@ -26,6 +26,6 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/workspace/@domtree/minimal/package.json
+++ b/workspace/@domtree/minimal/package.json
@@ -29,6 +29,6 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4"
+    "@starbeam-dev/eslint-plugin": "^1.0.6"
   }
 }

--- a/workspace/dev-compile/package.json
+++ b/workspace/dev-compile/package.json
@@ -25,11 +25,12 @@
     "magic-string": "^0.30.5",
     "rollup": "^4.1.4",
     "rollup-plugin-copy": "^3.5.0",
+    "rollup-plugin-prettier": "^4.1.1",
     "rollup-plugin-ts": "^3.4.5",
     "typescript": "^5.2.2"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.3",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@swc/helpers": "^0.5.3",
     "@swc/types": "^0.1.5",
     "@types/node": "^18",

--- a/workspace/dev-compile/src/rollup/plugins/external.ts
+++ b/workspace/dev-compile/src/rollup/plugins/external.ts
@@ -241,7 +241,6 @@ function external(pkg: PackageInfo, mode: 'development' | 'production') {
 
     // Resolve custom rules. These rules include the default behavior of
     // well-known helper libraries.
-    console.log(pkg.starbeam);
     for (const rule of pkg.starbeam.inline) {
       const isExternal = resolveIsExternal(rule, id);
       if (isExternal !== undefined) return isExternal;

--- a/workspace/dev-compile/src/rollup/plugins/external.ts
+++ b/workspace/dev-compile/src/rollup/plugins/external.ts
@@ -204,8 +204,8 @@ import type { RollupPlugin } from "../utils.js";
  * @param {PackageInfo} pkg
  * @returns {import("rollup").Plugin}
  */
-export default function externals(pkg: PackageInfo): RollupPlugin {
-  const isExternal = external(pkg);
+export default function externals(pkg: PackageInfo, mode: 'development' | 'production'): RollupPlugin {
+  const isExternal = external(pkg, mode);
 
   return {
     name: "starbeam:externals",
@@ -222,7 +222,7 @@ export default function externals(pkg: PackageInfo): RollupPlugin {
  * @param {PackageInfo} pkg
  * @returns
  */
-function external(pkg: PackageInfo) {
+function external(pkg: PackageInfo, mode: 'development' | 'production') {
   /**
    * @param {string} id
    * @returns {boolean}
@@ -233,8 +233,15 @@ function external(pkg: PackageInfo) {
       return INLINE;
     }
 
+    if (mode === 'production') {
+      if (id.startsWith('@starbeam/debug') || id.startsWith('@starbeam/verify')) {
+        return INLINE;
+      }
+    }
+
     // Resolve custom rules. These rules include the default behavior of
     // well-known helper libraries.
+    console.log(pkg.starbeam);
     for (const rule of pkg.starbeam.inline) {
       const isExternal = resolveIsExternal(rule, id);
       if (isExternal !== undefined) return isExternal;

--- a/workspace/dev-compile/src/rollup/plugins/external.ts
+++ b/workspace/dev-compile/src/rollup/plugins/external.ts
@@ -24,7 +24,8 @@ import type { RollupPlugin } from "../utils.js";
  * import is "inline", it is combined with the built package's main file and
  * further optimized.
  *
- * In general, it's better to inline an import if any of the following are true:
+ * In general, it's better to inline an import if any of the following are
+ * true:
  *
  * 1. It is only used by this package.
  * 2. Its exports are easy to optimize by a minifier in production builds (e.g.
@@ -40,12 +41,13 @@ import type { RollupPlugin } from "../utils.js";
  * 1. Relative imports: If the import starts with a `.`, then it is an inline
  *    import.
  * 2. Custom rules: If the `starbeam:inline` key in `package.json` specifies a
- *    rule for a dependency, use it. You can use custom rules to override any of
- *    the default rules below.
+ *    rule for a dependency, use it. You can use custom rules to override any
+ *    of the default rules below.
  * 3. [TODO] Custom workspace rules: If the `starbeam:inline` key in the
  *    `package.json` for the workspace root specifies a rule for a dependency,
  *    use it.
- * 4. Helper libraries: If the import is one of the well-known helper libraries,
+ * 4. Helper libraries: If the import is one of the well-known helper
+ * libraries,
  *    then it is an inline import.
  * 5. Absolute imports: If the import starts with `/`, then it is an inline
  *    import. This is because absolute imports are usually relative imports
@@ -108,8 +110,8 @@ import type { RollupPlugin } from "../utils.js";
  *
  * ### Rules Object
  *
- * Each key in the object is a rule pattern, and the value is either "inline" or
- * "external".
+ * Each key in the object is a rule pattern, and the value is either "inline"
+ * or "external".
  *
  * Example:
  *
@@ -129,8 +131,8 @@ import type { RollupPlugin } from "../utils.js";
  * In this example, the `react` dependency is externalized, and the `lodash`
  * dependency is inlined.
  *
- * The default behavior is to externalize all dependencies, so you don't need to
- * specify "external" in a rules object unless you want to supersede a later
+ * The default behavior is to externalize all dependencies, so you don't need
+ * to specify "external" in a rules object unless you want to supersede a later
  * rule.
  *
  * Example:
@@ -157,8 +159,8 @@ import type { RollupPlugin } from "../utils.js";
  * ### Rule Objects in a Rules Array
  *
  * When you have a lot of inline rules and only a handful of externals
- * overrides, it's nice to be able to avoid repeating `: "inline"` over and over
- * again.
+ * overrides, it's nice to be able to avoid repeating `: "inline"` over and
+ * over again.
  *
  * In this situation, you can include rule objects in a rules array.
  *
@@ -204,7 +206,7 @@ import type { RollupPlugin } from "../utils.js";
  * @param {PackageInfo} pkg
  * @returns {import("rollup").Plugin}
  */
-export default function externals(pkg: PackageInfo, mode: 'development' | 'production'): RollupPlugin {
+export default function externals(pkg: PackageInfo, mode: 'development' | 'production' | undefined): RollupPlugin {
   const isExternal = external(pkg, mode);
 
   return {
@@ -222,7 +224,7 @@ export default function externals(pkg: PackageInfo, mode: 'development' | 'produ
  * @param {PackageInfo} pkg
  * @returns
  */
-function external(pkg: PackageInfo, mode: 'development' | 'production') {
+function external(pkg: PackageInfo, mode: 'development' | 'production' | undefined) {
   /**
    * @param {string} id
    * @returns {boolean}

--- a/workspace/dev-compile/src/rollup/plugins/import-meta.ts
+++ b/workspace/dev-compile/src/rollup/plugins/import-meta.ts
@@ -13,11 +13,12 @@ import { createReplacePlugin } from "./replace.js";
  *
  * Replacements:
  *
- * | source                 | replacement rule                                 |
- * | ---------------------- | ------------------------------------------------ |
- * | `import.meta.env.MODE` | the specified mode (string)                      |
- * | `import.meta.env.DEV`  | true if the mode is "development" (boolean)      |
- * | `import.meta.env.PROD` | true if the mode is "production" (boolean)       |
+ * | source                 | replacement rule
+ * | | ---------------------- |
+ * ------------------------------------------------ | | `import.meta.env.MODE`
+ * | the specified mode (string)                      | | `import.meta.env.DEV`
+ *  | true if the mode is "development" (boolean)      | |
+ * `import.meta.env.PROD` | true if the mode is "production" (boolean)       |
  *
  * It is possible for both `DEV` and `PROD` to be false (if the specified mode
  * is something other than `"development"` or `"production"`). In general, this

--- a/workspace/dev-compile/src/rollup/plugins/replace.ts
+++ b/workspace/dev-compile/src/rollup/plugins/replace.ts
@@ -26,8 +26,8 @@ const { default: MagicString } = await import("magic-string");
  * };
  * ```
  *
- * This will replace any instances of `import.meta.hello` in source modules with
- * the content `"world"`.
+ * This will replace any instances of `import.meta.hello` in source modules
+ * with the content `"world"`.
  *
  * The main purpose of this plugin is to replace dynamic variables with
  * build-time constant values, which can then be further processed by a
@@ -36,8 +36,8 @@ const { default: MagicString } = await import("magic-string");
  * For example, the `importMeta` plugin replaces `import.meta.env.DEV` with
  * `true` in development mode and `false` in production mode. In production,
  * source code guarded with `if (import.meta.env.DEV)` will be emitted as `if
- * (false)`. The subsequent minification pass will remove the entire `if` block,
- * including its contents.
+ * (false)`. The subsequent minification pass will remove the entire `if`
+ * block, including its contents.
  *
  * @param {(id: string) => boolean} test
  * @param {Record<string, string>} replacements @param {boolean} sourcemap

--- a/workspace/dev-compile/src/rollup/plugins/typescript.ts
+++ b/workspace/dev-compile/src/rollup/plugins/typescript.ts
@@ -31,7 +31,8 @@ const rollupTS =
  *   into normal enums.
  * - All import paths that refer to non-existent JavaScript modules (type-only
  *   modules) are imported using `import type`.
- * - All imports that do not refer to a JavaScript value are imported as part of
+ * - All imports that do not refer to a JavaScript value are imported as part
+ * of
  *   an `import type` statement or are annotated with `type` (i.e. `import {
  *   map, type MapFn } from "map"`).
  *
@@ -48,11 +49,11 @@ const rollupTS =
  *   </dd>
  * </dl>
  *
- * We also recommend the use of `@typescript-eslint/consistent-type-imports` and
- * `@typescript-eslint/no-import-type-side-effects`. These auto-fixable lints
- * will error if you don't use `import type` on an import statement that is
- * never used as a value. These lints will also ensure that any named imports
- * that are only used as types are annotated with `type`.
+ * We also recommend the use of `@typescript-eslint/consistent-type-imports`
+ * and `@typescript-eslint/no-import-type-side-effects`. These auto-fixable
+ * lints will error if you don't use `import type` on an import statement that
+ * is never used as a value. These lints will also ensure that any named
+ * imports that are only used as types are annotated with `type`.
  *
  * If you're using vscode, you can enable "source.fixAll" in
  * `editor.codeActionOnSave` and imports will automatically be updated if you
@@ -61,8 +62,8 @@ const rollupTS =
  * ## Type Checking
  *
  * > **TL;DR** This plugin does **not** typecheck your code. It is intended to
- * > be run after verifying your code using tools such as `tsc` and `eslint` and
- * > after successfully running your tests.
+ * > be run after verifying your code using tools such as `tsc` and `eslint`
+ * and > after successfully running your tests.
  *
  * Now for the longer version...
  *
@@ -84,8 +85,8 @@ const rollupTS =
  *
  * > Adding to the confusion, the tool that you use to *verify* your TypeScript
  * > code is called `tsc`. Even more confusingly, `tsc` is intended to be a
- * > good-enough reference compiler for TypeScript code. In practice, though, it
- * > makes more sense to use `tsc` as part of a comprehensive *verification*
+ * > good-enough reference compiler for TypeScript code. In practice, though,
+ * it > makes more sense to use `tsc` as part of a comprehensive *verification*
  * > strategy and to use other tools (such as `esbuild` or `swc`) to compile
  * > your TypeScript code.
  *

--- a/workspace/dev-compile/src/rollup/rollup.ts
+++ b/workspace/dev-compile/src/rollup/rollup.ts
@@ -2,8 +2,8 @@ import { execSync } from 'node:child_process';
 import { join, resolve } from "node:path";
 
 import terser from '@rollup/plugin-terser';
-import type {PackageInfo} from "@starbeam-dev/core";
-import { Package,  rootAt } from "@starbeam-dev/core";
+import type { PackageInfo } from "@starbeam-dev/core";
+import { Package, rootAt } from "@starbeam-dev/core";
 import type { RollupOptions } from "rollup";
 import copy from 'rollup-plugin-copy'
 
@@ -63,11 +63,8 @@ function compilePackage(pkg: PackageInfo, options: CompileOptions): RollupOption
       PLUGINS.push(importMeta(mode));
     }
 
-    const deps = Object.keys(pkg.dependencies);
-
     const entries = entryPoints(pkg, mode).map((options) => ({
       ...options,
-      external: deps,
       plugins: [
         ...PLUGINS,
         externals(pkg),
@@ -125,15 +122,15 @@ function entryPoints(
         hoistTransitiveImports: false,
         exports: "auto",
       },
-      onwarn: (warning, warn) => {
-        switch (warning.code) {
-          case "CIRCULAR_DEPENDENCY":
-          case "EMPTY_BUNDLE":
-            return;
-          default:
-            warn(warning);
-        }
-      },
+      // onwarn: (warning, warn) => {
+      //   switch (warning.code) {
+      //     case "CIRCULAR_DEPENDENCY":
+      //     case "EMPTY_BUNDLE":
+      //       return;
+      //     default:
+      //       warn(warning);
+      //   }
+      // },
     };
   }
 

--- a/workspace/dev-compile/src/rollup/rollup.ts
+++ b/workspace/dev-compile/src/rollup/rollup.ts
@@ -67,7 +67,7 @@ function compilePackage(pkg: PackageInfo, options: CompileOptions): RollupOption
       ...options,
       plugins: [
         ...PLUGINS,
-        externals(pkg),
+        externals(pkg, mode),
         typescript(mode)(pkg, {
           target: "esnext",
           module: "esnext",

--- a/workspace/dev-compile/src/rollup/rollup.ts
+++ b/workspace/dev-compile/src/rollup/rollup.ts
@@ -6,6 +6,7 @@ import type { PackageInfo } from "@starbeam-dev/core";
 import { Package, rootAt } from "@starbeam-dev/core";
 import type { RollupOptions } from "rollup";
 import copy from 'rollup-plugin-copy'
+import prettier from 'rollup-plugin-prettier';
 
 import externals from "./plugins/external.js";
 import importMeta from "./plugins/import-meta.js";
@@ -81,10 +82,16 @@ function compilePackage(pkg: PackageInfo, options: CompileOptions): RollupOption
             format: {
               comments: false
             },
-            // prevent any compression
-            compress: false,
+            compress: {
+              dead_code: true,
+              module: true,
+              keep_fargs: false
+            },
             mangle: false,
           }),
+          prettier({
+            parser: 'babel'
+          })
         ] : [])
       ],
     }));

--- a/workspace/dev-compile/src/rollup/rollup.ts
+++ b/workspace/dev-compile/src/rollup/rollup.ts
@@ -114,7 +114,9 @@ function entryPoints(
   function entryPoint([exportName, ts]: [string, string]): RollupOptions {
     return {
       input: resolve(root, ts),
-      treeshake: true,
+      treeshake: {
+        moduleSideEffects: false,
+      },
       output: {
         file: filename({ root, name: exportName, mode, ext: "js" }),
         format: "esm",

--- a/workspace/dev-compile/src/rollup/rollup.ts
+++ b/workspace/dev-compile/src/rollup/rollup.ts
@@ -82,7 +82,8 @@ function compilePackage(pkg: PackageInfo, options: CompileOptions): RollupOption
               comments: false
             },
             // prevent any compression
-            compress: false
+            compress: false,
+            mangle: false,
           }),
         ] : [])
       ],

--- a/workspace/scripts/build-verify.js
+++ b/workspace/scripts/build-verify.js
@@ -1,0 +1,28 @@
+import { globby } from "globby";
+import { readFile } from "node:fs/promises";
+
+const FORBIDDEN = ["stacktracey", "@starbeam/debug", "@starbeam/verify"];
+
+let files = await globby("**/index.production.js", {
+  ignore: ["node_modules", "**/node_modules"],
+});
+
+let errors = [];
+
+for (let filePath of files) {
+  let file = await readFile(filePath);
+  let content = file.toString();
+
+  for (let searchFor of FORBIDDEN) {
+    if (content.includes(searchFor)) {
+      errors.push({ filePath, found: searchFor });
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error(errors);
+  throw new Error(`The forbidden texts were encountered in the above files`);
+}
+
+console.info("No forbidden texts!");

--- a/workspace/scripts/build-verify.js
+++ b/workspace/scripts/build-verify.js
@@ -1,17 +1,45 @@
 import { globby } from "globby";
 import { readFile } from "node:fs/promises";
+import { fileURLToPath } from 'node:url'
+import { resolve, dirname } from 'node:path'
+
+const currentDir = fileURLToPath(import.meta.url);
 
 const FORBIDDEN = ["stacktracey", "@starbeam/debug", "@starbeam/verify"];
+const FORBIDDEN_PATHS = [
+  resolve(currentDir, '../../../packages/universal/debug'),
+  resolve(currentDir, '../../../packages/universal/verify'),
+];
 
-let files = await globby("**/index.production.{js,js.map}", {
+let files = await globby(resolve(currentDir, "../../../packages/**/index.production.{js,js.map}"), {
   ignore: ["node_modules", "**/node_modules"],
 });
+
 
 let errors = [];
 
 for (let filePath of files) {
   let file = await readFile(filePath);
   let content = file.toString();
+  
+  if (filePath.includes('packages/universal/debug') || filePath.includes('packages/universal/verify')) {
+    continue;
+  }
+  
+  if (filePath.endsWith('.js.map')) {
+    const jsMap = JSON.parse(content);
+    const sources = jsMap.sources;
+    const dir = dirname(filePath);
+    for (const source of sources) {
+      const resolved = resolve(dir, source);
+      for (let searchFor of FORBIDDEN_PATHS) {
+        if (resolved.includes(searchFor)) {
+          errors.push({ filePath, found: searchFor });
+        }
+      }
+    }
+    continue;
+  }
 
   for (let searchFor of FORBIDDEN) {
     if (content.includes(searchFor)) {

--- a/workspace/scripts/build-verify.js
+++ b/workspace/scripts/build-verify.js
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 
 const FORBIDDEN = ["stacktracey", "@starbeam/debug", "@starbeam/verify"];
 
-let files = await globby("**/index.production.js", {
+let files = await globby("**/index.production.{js,js.map}", {
   ignore: ["node_modules", "**/node_modules"],
 });
 

--- a/workspace/scripts/package.json
+++ b/workspace/scripts/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "name": "@starbeam-workspace/scripts",
+  "type": "module",
+  "devDependencies": {
+    "globby": "^13.2.2"
+  }
+}

--- a/workspace/test-utils/package.json
+++ b/workspace/test-utils/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "rollup": "^4.0.2"
   }
 }

--- a/workspace/unstable-release/package.json
+++ b/workspace/unstable-release/package.json
@@ -23,7 +23,7 @@
     "latest-version": "^7.0.0"
   },
   "devDependencies": {
-    "@starbeam-dev/eslint-plugin": "^1.0.4",
+    "@starbeam-dev/eslint-plugin": "^1.0.6",
     "@types/fs-extra": "^11.0.2"
   },
   "volta": {

--- a/workspace/unstable-release/src/workspaces.js
+++ b/workspace/unstable-release/src/workspaces.js
@@ -6,7 +6,8 @@ import { readPackageJson } from "./read-package-json.js";
 /**
  * All publishable packages are in packages/*
  *
- * We could read package.json#workspaces, but then we'd have more to filter out.
+ * We could read package.json#workspaces, but then we'd have more to filter
+ * out.
  */
 export async function listPublicWorkspaces() {
   let filePaths = await globby(["packages/**/package.json"], {


### PR DESCRIPTION
This will help keep us from accidentally build code in production that shouldn't be there.

(the production assets being what we expect the output to be when someone using starbeam builds for production with the appropriate minifier settings)

Resolves: https://github.com/starbeamjs/starbeam/issues/153

## Package Graph

[Whole Repo](https://studio.commonality.co/starbeamjs/starbeam)
[Just @starbeam (without integration libraries)](https://studio.commonality.co/starbeamjs/starbeam?packages=NoIgAgzgLghgTgIwKYwLYHoDGB7OSQA0408yaWuSAtAK5QCWANhIcbIihgCZII0DmrSOzIZ6AOyhI4AMxiYkLIsNKd0qbF3oz60oSQ7k88hgDd8yg6PR5xPPHH0i1eCNhpwFT1UZqT6qBZsPhgQ0qb0XpbO5BAAFvBIXN6GGLD8SsGp6H705nAQMIwp1vnaAJ4lajiMjEiYDNjiLAC6QA)

Can this be the published set of packages: https://studio.commonality.co/starbeamjs/starbeam?packages=NoIgAgzgLghgTgIwKYwLYHoDGB7ANrpTKAS2wDsIQAacaeZNdVbAE2IDNik5rbZEUGOCiLEAbkl6R%2BDIUjItu3KXQGNhEbAFc4mSTWn1B6OFrIlU%2BvkcYRuY4npUzjEABbwkLZzYxnx3BAwuCAAukA

<details><summary>on disk task graph</summary>

```bash
pnpm turbo run build --filter "@starbeam/*" --graph=graph.svg
```

![graph](https://github.com/starbeamjs/starbeam/assets/199018/fc80dc72-7b99-4951-9869-95bc1ff255f0)

</details>



