### PR TITLE
fix(verify): make prod bundle loadable; honest ci:prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,13 +85,13 @@
   },
   "scripts": {
     "build": "turbo build",
-    "ci:prod": "vitest --pool forks --run --mode production",
+    "ci:prod": "STARBEAM_TEST_PROD=1 vitest --pool forks --run",
     "ci:specs": "vitest --pool forks --run",
     "lint:fix": "pnpm --filter '*' test:lint --fix",
     "prepack": "pnpm run build",
     "sort-deps": "node workspace/scripts/sort-package-json-deps.mjs",
     "test:workspace:lint": "turbo run lint --output-logs errors-only --log-prefix none",
-    "test:workspace:prod": "PROD=1 DEV= vitest --pool forks --run",
+    "test:workspace:prod": "STARBEAM_TEST_PROD=1 vitest --pool forks --run",
     "test:workspace:specs": "vitest --pool forks --run",
     "test:workspace:types": "turbo run typecheck --output-logs errors-only --log-prefix none",
     "vitest": "vitest --pool forks"

--- a/packages/universal/debug/src/call-stack/debug/stack.ts
+++ b/packages/universal/debug/src/call-stack/debug/stack.ts
@@ -9,7 +9,7 @@ import {
   mapArray,
 } from "@starbeam/core-utils";
 import type { CallStack, StackFrame } from "@starbeam/interfaces";
-import { hasType, verified, verify } /*#__PURE__*/ from "@starbeam/verify";
+import { hasType, isObject, verified, verify } /*#__PURE__*/ from "@starbeam/verify";
 import StackTracey /*#__PURE__*/ from "stacktracey";
 
 import { parseModule } from "./module.js";
@@ -127,7 +127,7 @@ function parseStack(stack: string): ParsedStack | undefined {
 }
 
 function isErrorWithStack(value: unknown): value is Error & { stack: string } {
-  return hasType("object")(value) && hasType("string")((value as Error).stack);
+  return isObject(value) && typeof (value as Error).stack === "string";
 }
 
 if (import.meta.vitest) {

--- a/packages/universal/debug/src/call-stack/debug/stack.ts
+++ b/packages/universal/debug/src/call-stack/debug/stack.ts
@@ -134,12 +134,16 @@ if (import.meta.vitest) {
   const { test, expect, describe } = import.meta.vitest;
   const filename = new URL(import.meta.url).pathname;
 
+  // These in-source tests exercise DEV-only verify() behavior. In PROD
+  // mode, verify is null and the tests would crash on every call.
+  describe.skipIf(import.meta.env.PROD)("call-stack (DEV only)", () => {
+
   function anAction() {
     throw Error(ERROR_MESSAGE);
   }
 
   const ERROR_LOC = {
-    line: 138,
+    line: 142,
     column: 11,
   };
 
@@ -224,5 +228,6 @@ if (import.meta.vitest) {
         expect(frame.loc).toEqual(ERROR_LOC);
       }
     });
+  });
   });
 }

--- a/packages/universal/debug/src/call-stack/debug/stack.ts
+++ b/packages/universal/debug/src/call-stack/debug/stack.ts
@@ -9,7 +9,12 @@ import {
   mapArray,
 } from "@starbeam/core-utils";
 import type { CallStack, StackFrame } from "@starbeam/interfaces";
-import { hasType, isObject, verified, verify } /*#__PURE__*/ from "@starbeam/verify";
+import {
+  hasType,
+  isObject,
+  verified,
+  verify /*#__PURE__*/,
+} from "@starbeam/verify";
 import StackTracey /*#__PURE__*/ from "stacktracey";
 
 import { parseModule } from "./module.js";
@@ -137,97 +142,100 @@ if (import.meta.vitest) {
   // These in-source tests exercise DEV-only verify() behavior. In PROD
   // mode, verify is null and the tests would crash on every call.
   describe.skipIf(import.meta.env.PROD)("call-stack (DEV only)", () => {
-
-  function anAction() {
-    throw Error(ERROR_MESSAGE);
-  }
-
-  const ERROR_LOC = {
-    line: 142,
-    column: 11,
-  };
-
-  function aCallerAction() {
-    return callerStack();
-  }
-
-  const ERROR_MESSAGE = "an error happened in an action";
-  const CALLER_FRAME = 1;
-
-  test("parseStack", () => {
-    try {
-      anAction();
-    } catch (e) {
-      const { header, entries, lines, trace } = verified(
-        parseStack(verified(e, isErrorWithStack).stack),
-        isPresent,
-      );
-
-      expect(header).toBe(`Error: ${ERROR_MESSAGE}`);
-      expect(lines).toHaveLength(entries.length);
-      expect(trace.items).toEqual(entries);
-      expect(getFirst(lines)).toMatch(/\banAction\b/);
+    function anAction() {
+      throw Error(ERROR_MESSAGE);
     }
-  });
 
-  {
-    function testCallStack() {
+    const ERROR_LOC = {
+      line: 146,
+      column: 13,
+    };
+
+    function aCallerAction() {
+      return callerStack();
+    }
+
+    const ERROR_MESSAGE = "an error happened in an action";
+    const CALLER_FRAME = 1;
+
+    test("parseStack", () => {
       try {
         anAction();
       } catch (e) {
-        const stack = verified(
-          callStack(verified(e, isErrorWithStack).stack, filename),
+        const { header, entries, lines, trace } = verified(
+          parseStack(verified(e, isErrorWithStack).stack),
           isPresent,
         );
 
-        expect(stack.header).toBe(`Error: ${ERROR_MESSAGE}`);
-        const frameSize = stack.frames.length;
-        expect(stack.slice(CALLER_FRAME)?.frames).toHaveLength(
-          frameSize - CALLER_FRAME,
-        );
-
-        const firstFrame = getFirst(stack.slice(CALLER_FRAME)?.frames ?? []);
-        expect(firstFrame?.action).toBe(TEST_NAME);
-      }
-    }
-
-    const TEST_NAME = testCallStack.name;
-
-    test("callStack", testCallStack);
-  }
-
-  {
-    function testCallerStack() {
-      const caller = verified(aCallerAction(), isPresent);
-
-      expect(getFirst(caller.frames).action).toBe(TEST_NAME);
-    }
-
-    const TEST_NAME = testCallerStack.name;
-
-    test("callerStack", testCallerStack);
-  }
-
-  describe("StackFrame", () => {
-    test("action", () => {
-      try {
-        anAction();
-      } catch (e) {
-        verify(e, isErrorWithStack);
-
-        const trace = new StackTracey(e.stack);
-        const first = verified(getFirst(trace.items), isPresent);
-
-        const frame = stackFrame(first, () => trace.withSource(first), filename);
-
-        expect(frame.action).toBe("anAction");
-        expect(frame.module).toEqual({
-          path: "stack.ts",
-          root: new URL(".", import.meta.url).pathname,
-        });
-        expect(frame.loc).toEqual(ERROR_LOC);
+        expect(header).toBe(`Error: ${ERROR_MESSAGE}`);
+        expect(lines).toHaveLength(entries.length);
+        expect(trace.items).toEqual(entries);
+        expect(getFirst(lines)).toMatch(/\banAction\b/);
       }
     });
-  });
+
+    {
+      function testCallStack() {
+        try {
+          anAction();
+        } catch (e) {
+          const stack = verified(
+            callStack(verified(e, isErrorWithStack).stack, filename),
+            isPresent,
+          );
+
+          expect(stack.header).toBe(`Error: ${ERROR_MESSAGE}`);
+          const frameSize = stack.frames.length;
+          expect(stack.slice(CALLER_FRAME)?.frames).toHaveLength(
+            frameSize - CALLER_FRAME,
+          );
+
+          const firstFrame = getFirst(stack.slice(CALLER_FRAME)?.frames ?? []);
+          expect(firstFrame?.action).toBe(TEST_NAME);
+        }
+      }
+
+      const TEST_NAME = testCallStack.name;
+
+      test("callStack", testCallStack);
+    }
+
+    {
+      function testCallerStack() {
+        const caller = verified(aCallerAction(), isPresent);
+
+        expect(getFirst(caller.frames).action).toBe(TEST_NAME);
+      }
+
+      const TEST_NAME = testCallerStack.name;
+
+      test("callerStack", testCallerStack);
+    }
+
+    describe("StackFrame", () => {
+      test("action", () => {
+        try {
+          anAction();
+        } catch (e) {
+          verify(e, isErrorWithStack);
+
+          const trace = new StackTracey(e.stack);
+          const first = verified(getFirst(trace.items), isPresent);
+
+          const frame = stackFrame(
+            first,
+            () => trace.withSource(first),
+            filename,
+          );
+
+          expect(frame.action).toBe("anAction");
+          expect(frame.module).toEqual({
+            path: "stack.ts",
+            root: new URL(".", import.meta.url).pathname,
+          });
+          expect(frame.loc).toEqual(ERROR_LOC);
+        }
+      });
+    });
   });
 }

--- a/packages/universal/resource/tests/sync.spec.ts
+++ b/packages/universal/resource/tests/sync.spec.ts
@@ -487,7 +487,7 @@ class Child<T, U> {
   }
 
   assertInitialized(expected: U): void {
-    verify(this.#lastValue, isEqual(UNINITIALIZED));
+    verify?.(this.#lastValue, isEqual(UNINITIALIZED));
 
     const next = this.#extract(this.#value);
     expect(next).toBe(expected);

--- a/packages/universal/verify/src/assertions/basic.ts
+++ b/packages/universal/verify/src/assertions/basic.ts
@@ -1,6 +1,6 @@
 import { isPresentArray } from "@starbeam/core-utils";
 
-import { expected, toKind } from "../verify.js";
+import { alwaysTrue, expected, toKind } from "../verify.js";
 import { format } from "./describe.js";
 import type { FixedArray, ReadonlyFixedArray } from "./type-utils.js";
 
@@ -26,14 +26,17 @@ export type Primitive =
   | undefined;
 
 export function isEqual<T>(value: T): (other: unknown) => other is T {
-  function verify(input: unknown): input is T {
-    return Object.is(input, value);
-  }
+  if (import.meta.env.DEV) {
+    function verify(input: unknown): input is T {
+      return Object.is(input, value);
+    }
 
-  return expected.associate(
-    verify,
-    expected.toBe(inspect(value)).butGot(format),
-  );
+    return expected.associate(
+      verify,
+      expected.toBe(inspect(value)).butGot(format),
+    );
+  }
+  return alwaysTrue as unknown as (other: unknown) => other is T;
 }
 
 function inspect(value: unknown): string {
@@ -50,14 +53,17 @@ function inspect(value: unknown): string {
 export function isNotEqual<T>(
   value: T,
 ): <U>(other: U) => other is Exclude<U, T> {
-  function verify<U>(input: U): input is Exclude<U, T> {
-    return !Object.is(input, value);
-  }
+  if (import.meta.env.DEV) {
+    function verify<U>(input: U): input is Exclude<U, T> {
+      return !Object.is(input, value);
+    }
 
-  return expected.associate(
-    verify,
-    expected.toBe(`not ${String(value)}`).butGot(format),
-  );
+    return expected.associate(
+      verify,
+      expected.toBe(`not ${String(value)}`).butGot(format),
+    );
+  }
+  return alwaysTrue as unknown as <U>(other: U) => other is Exclude<U, T>;
 }
 
 export function isObject(value: unknown): value is object {
@@ -76,11 +82,14 @@ interface HasLength<L extends number> {
 }
 
 export function hasLength<L extends number>(length: L): HasLength<L> {
-  function has<T>(value: T[] | readonly T[]): value is FixedArray<T, L> {
-    return value.length === length;
-  }
+  if (import.meta.env.DEV) {
+    function has<T>(value: T[] | readonly T[]): value is FixedArray<T, L> {
+      return value.length === length;
+    }
 
-  return expected.associate(has, expected.toHave(`${length} items`));
+    return expected.associate(has, expected.toHave(`${length} items`));
+  }
+  return alwaysTrue as unknown as HasLength<L>;
 }
 
 export const hasItems = isPresentArray;
@@ -94,38 +103,41 @@ export const hasItems = isPresentArray;
 export function isNullable<In, Out extends In>(
   verifier: (value: In) => value is Out,
 ): (value: In | null) => value is Out | null {
-  function verify(input: In | null): input is Out | null {
-    if (input === null) {
-      return true;
-    } else {
-      return verifier(input);
-    }
-  }
-
-  const expectation = expected.updated(verifier, {
-    to: (to) => {
-      if (to === undefined) {
-        return ["to be", "nullable"];
+  if (import.meta.env.DEV) {
+    function verify(input: In | null): input is Out | null {
+      if (input === null) {
+        return true;
       } else {
-        return `${toKind(to)} or null`;
+        return verifier(input);
       }
-    },
-    actual: (actual) => {
-      return (input: In | null) => {
-        if (input === null) {
-          return "null";
-        } else if (actual) {
-          return actual(input);
+    }
+
+    const expectation = expected.updated(verifier, {
+      to: (to) => {
+        if (to === undefined) {
+          return ["to be", "nullable"];
         } else {
-          return undefined;
+          return `${toKind(to)} or null`;
         }
-      };
-    },
-  });
+      },
+      actual: (actual) => {
+        return (input: In | null) => {
+          if (input === null) {
+            return "null";
+          } else if (actual) {
+            return actual(input);
+          } else {
+            return undefined;
+          }
+        };
+      },
+    });
 
-  expected.associate(verify, expectation);
+    expected.associate(verify, expectation);
 
-  return verify;
+    return verify;
+  }
+  return alwaysTrue as unknown as (value: In | null) => value is Out | null;
 }
 
 

--- a/packages/universal/verify/src/assertions/basic.ts
+++ b/packages/universal/verify/src/assertions/basic.ts
@@ -36,7 +36,7 @@ export function isEqual<T>(value: T): (other: unknown) => other is T {
       expected.toBe(inspect(value)).butGot(format),
     );
   }
-  return alwaysTrue as unknown as (other: unknown) => other is T;
+  return alwaysTrue;
 }
 
 function inspect(value: unknown): string {
@@ -63,7 +63,7 @@ export function isNotEqual<T>(
       expected.toBe(`not ${String(value)}`).butGot(format),
     );
   }
-  return alwaysTrue as unknown as <U>(other: U) => other is Exclude<U, T>;
+  return alwaysTrue;
 }
 
 export function isObject(value: unknown): value is object {
@@ -89,7 +89,7 @@ export function hasLength<L extends number>(length: L): HasLength<L> {
 
     return expected.associate(has, expected.toHave(`${length} items`));
   }
-  return alwaysTrue as unknown as HasLength<L>;
+  return alwaysTrue as HasLength<L>;
 }
 
 export const hasItems = isPresentArray;
@@ -137,7 +137,7 @@ export function isNullable<In, Out extends In>(
 
     return verify;
   }
-  return alwaysTrue as unknown as (value: In | null) => value is Out | null;
+  return alwaysTrue;
 }
 
 

--- a/packages/universal/verify/src/assertions/multi.ts
+++ b/packages/universal/verify/src/assertions/multi.ts
@@ -33,5 +33,5 @@ export function isOneOf<In, Out extends In>(
 
     return expected.associate(verify, expectation);
   }
-  return alwaysTrue as unknown as (value: In) => value is Out;
+  return alwaysTrue;
 }

--- a/packages/universal/verify/src/assertions/multi.ts
+++ b/packages/universal/verify/src/assertions/multi.ts
@@ -1,34 +1,37 @@
-import { expected, toKind } from "../verify.js";
+import { alwaysTrue, expected, toKind } from "../verify.js";
 
 export function isOneOf<In, Out extends In>(
   ...verifiers: ((value: In) => value is Out)[]
 ): (value: In) => value is Out {
-  function verify(input: In): input is Out {
-    for (const verifier of verifiers) {
-      if (verifier(input)) {
-        return true;
+  if (import.meta.env.DEV) {
+    function verify(input: In): input is Out {
+      for (const verifier of verifiers) {
+        if (verifier(input)) {
+          return true;
+        }
       }
+
+      return false;
     }
 
-    return false;
-  }
-
-  const expectation = expected.updated(verify, {
-    to: (to) => {
-      if (to === undefined) {
-        return ["to be one of", "any"];
-      } else {
-        return `${toKind(to)} or any`;
-      }
-    },
-    actual: (actual) => {
-      return (input: In) => {
-        if (actual) {
-          return actual(input);
+    const expectation = expected.updated(verify, {
+      to: (to) => {
+        if (to === undefined) {
+          return ["to be one of", "any"];
+        } else {
+          return `${toKind(to)} or any`;
         }
-      };
-    },
-  });
+      },
+      actual: (actual) => {
+        return (input: In) => {
+          if (actual) {
+            return actual(input);
+          }
+        };
+      },
+    });
 
-  return expected.associate(verify, expectation);
+    return expected.associate(verify, expectation);
+  }
+  return alwaysTrue as unknown as (value: In) => value is Out;
 }

--- a/packages/universal/verify/src/assertions/types.ts
+++ b/packages/universal/verify/src/assertions/types.ts
@@ -37,7 +37,7 @@ export function hasType<K extends keyof TypeOfTypes>(
   if (import.meta.env.DEV) {
     return IS_TYPEOF[type] as (value: unknown) => value is TypeOfTypes[K];
   }
-  return alwaysTrue as unknown as (value: unknown) => value is TypeOfTypes[K];
+  return alwaysTrue;
 }
 
 interface TypeOfTypes {
@@ -83,7 +83,7 @@ function isTypeof<K extends keyof TypeOfTypes>(
     );
   }
 
-  return alwaysTrue as unknown as (value: unknown) => value is TypeOfTypes[K];
+  return alwaysTrue;
 }
 
 function typeName(value: unknown): TypeOf {

--- a/packages/universal/verify/src/assertions/types.ts
+++ b/packages/universal/verify/src/assertions/types.ts
@@ -1,36 +1,43 @@
 import { define } from "../define.js";
-import { expected } from "../verify.js";
+import { alwaysTrue, expected } from "../verify.js";
 import { isEqual, isObject } from "./basic.js";
 
-const TYPE_DESC = {
-  object: "an object",
-  null: "null",
-  undefined: "undefined",
-  function: "a function",
-  string: "a string",
-  number: "a number",
-  boolean: "a boolean",
-  symbol: "a symbol",
-  bigint: "a bigint",
-};
+const TYPE_DESC = import.meta.env.DEV
+  ? {
+      object: "an object",
+      null: "null",
+      undefined: "undefined",
+      function: "a function",
+      string: "a string",
+      number: "a number",
+      boolean: "a boolean",
+      symbol: "a symbol",
+      bigint: "a bigint",
+    }
+  : (undefined as never);
 
-const IS_TYPEOF = {
-  object: isObject,
-  null: isEqual(null),
-  undefined: isTypeof("undefined"),
-  function: isTypeof("function"),
-  string: isTypeof("string"),
-  number: isTypeof("number"),
-  boolean: isTypeof("boolean"),
-  symbol: isTypeof("symbol"),
-  bigint: isTypeof("bigint"),
-} as const;
+const IS_TYPEOF = import.meta.env.DEV
+  ? ({
+      object: isObject,
+      null: isEqual(null),
+      undefined: isTypeof("undefined"),
+      function: isTypeof("function"),
+      string: isTypeof("string"),
+      number: isTypeof("number"),
+      boolean: isTypeof("boolean"),
+      symbol: isTypeof("symbol"),
+      bigint: isTypeof("bigint"),
+    } as const)
+  : (undefined as never);
 
 export function hasType<K extends keyof TypeOfTypes>(
   type: K
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): (value: any) => value is TypeOfTypes[K] {
-  return IS_TYPEOF[type] as (value: unknown) => value is TypeOfTypes[K];
+  if (import.meta.env.DEV) {
+    return IS_TYPEOF[type] as (value: unknown) => value is TypeOfTypes[K];
+  }
+  return alwaysTrue as unknown as (value: unknown) => value is TypeOfTypes[K];
 }
 
 interface TypeOfTypes {
@@ -59,20 +66,24 @@ function isTypeof<K extends keyof TypeOfTypes>(
     return isObject as (value: unknown) => value is TypeOfTypes[K];
   }
 
-  const verify = define.builtin(
-    (value: unknown): value is TypeOfTypes[K] => {
-      return typeof value === type;
-    },
-    "name",
-    `is:${type}`
-  );
+  if (import.meta.env.DEV) {
+    const verify = define.builtin(
+      (value: unknown): value is TypeOfTypes[K] => {
+        return typeof value === type;
+      },
+      "name",
+      `is:${type}`
+    );
 
-  define.builtin(verify, Symbol.toStringTag, `Verifier`);
+    define.builtin(verify, Symbol.toStringTag, `Verifier`);
 
-  return expected.associate(
-    verify,
-    expected.toBe(TYPE_DESC[type]).butGot(typeName)
-  );
+    return expected.associate(
+      verify,
+      expected.toBe(TYPE_DESC[type]).butGot(typeName)
+    );
+  }
+
+  return alwaysTrue as unknown as (value: unknown) => value is TypeOfTypes[K];
 }
 
 function typeName(value: unknown): TypeOf {

--- a/packages/universal/verify/src/verify.ts
+++ b/packages/universal/verify/src/verify.ts
@@ -7,7 +7,12 @@ export class VerificationError<T = unknown> extends Error {
   }
 }
 
-export function alwaysTrue(): true {
+/**
+ * A DEV-gated factory's PROD stub. In PROD, assertion factories return
+ * this function directly; its type-guard signature lets it stand in for
+ * any `(x: unknown) => x is T` verifier without casts.
+ */
+export function alwaysTrue<T>(_value: unknown): _value is T {
   return true;
 }
 

--- a/packages/universal/verify/src/verify.ts
+++ b/packages/universal/verify/src/verify.ts
@@ -7,6 +7,10 @@ export class VerificationError<T = unknown> extends Error {
   }
 }
 
+export function alwaysTrue(): true {
+  return true;
+}
+
 export type VerifyFn = typeof verify;
 
 export function verify<Value, Input extends Value, Output extends Input>(

--- a/packages/universal/verify/tests/messages.spec.ts
+++ b/packages/universal/verify/tests/messages.spec.ts
@@ -1,7 +1,9 @@
 import { expected } from "@starbeam/verify";
 import { describe, expect, test } from "vitest";
 
-describe("isPresent", () => {
+const isProd = import.meta.env.PROD;
+
+describe.skipIf(isProd)("isPresent", () => {
   test("a basic message", () => {
     expect(expected.toBe("present").message(null)).toEqual(
       "Expected value to be present"

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -9,7 +9,18 @@ import { defineConfig } from "vitest/config";
 // repo root regardless of where vitest is loading the config from.
 const root = process.cwd();
 
-const env = process.env["STARBEAM_TRACE"] ? { STARBEAM_TRACE: "true" } : {};
+// `ci:prod` sets STARBEAM_TEST_PROD=1; that flips the env vars vitest's
+// import.meta.env proxy reads, which is the only way to actually make
+// `import.meta.env.DEV === false` at runtime (vitest's own --mode
+// production doesn't; see vitest#5525). Without this, `ci:prod` was
+// running exactly the same code paths as `ci:specs`.
+const isProd = process.env["STARBEAM_TEST_PROD"] === "1";
+const env: Record<string, string> = {
+  ...(process.env["STARBEAM_TRACE"] ? { STARBEAM_TRACE: "true" } : {}),
+  ...(isProd
+    ? { PROD: "1", DEV: "", MODE: "production", NODE_ENV: "production" }
+    : {}),
+};
 
 const projects: TestProjectConfiguration[] = glob
   .sync([


### PR DESCRIPTION
Fixes a real shipped bug in `@starbeam/verify`: the published
`dist/index.production.js` was previously unloadable for any consumer
that touched the assertion factories. Also fixes the long-standing
misnomer where `pnpm ci:prod` ran exactly the same code paths as
`pnpm ci:specs`.

## The shipped bug

`@starbeam/verify`'s public index already exported `expected = DEV ?
real : null`, `verify = DEV ? real : null`, `hasType = DEV ? real :
noop`, and `isOneOf = DEV ? real : noop` — a symmetric "prod stub"
pattern that expects each DEV-only helper to have a PROD fallback.

The factories in `src/assertions/*.ts` never got their PROD fallbacks.
`isEqual`, `isNotEqual`, `hasLength`, `isNullable`, `hasType`
internals, and `isOneOf` all called `expected.toBe(...)` /
`expected.associate(...)` / `expected.toHave(...)` /
`expected.updated(...)` unconditionally in their function bodies.
Those helpers are attached onto `expected` inside an `if
(import.meta.env.DEV)` block in `verify.ts`; in PROD mode they were
undefined.

Worse: `types.ts` called `isEqual(null)` at module-evaluation time to
build its `IS_TYPEOF` dictionary, so `import "@starbeam/verify"`
crashed at module-init when DEV was false. The shipped
`dist/index.production.js` was effectively unloadable for any
consumer that touched the factory exports.

## The fix shape

Gate each factory body with `if (import.meta.env.DEV)` and return a
shared `alwaysTrue` constant in the PROD branch. Terser substitutes
`DEV=false`, dead-code-eliminates the DEV branches, and each factory
reduces to a 1-2 line form like `function isEqual() { return
alwaysTrue; }`.

This is exactly what the `@starbeam-dev/compile` pipeline is designed
for: replace `import.meta.env.DEV` with `false`, tree-shake, terser.
The pattern was already in use at the public index level — this PR
extends it down into the factories.

Same class of fix for one external bug:
`debug/src/call-stack/debug/stack.ts`'s `isErrorWithStack` was
calling `hasType("object")(value)`, which crashes in prod because
`hasType` is a noop lambda (so `hasType("object")` is `undefined` and
`undefined(value)` is a TypeError). Replaced with `isObject(value) &&
typeof (value as Error).stack === "string"`.

## ci:prod was lying

The `ci:prod` script passed `--mode production` to vitest, but
vitest's `import.meta.env.DEV` proxy is a separate machinery from
vite's mode — it's built from `process.env` via `process.env.PROD ??=
PROD ? "1" : ""` (see vitest#5525). The `??=` only assigns if
nullish, so pre-set shell env vars "work" in theory, but vitest's
default initialization runs first regardless of `--mode`. The script
was an alias for `ci:specs`.

The only reliable way to flip the proxy from inside the config is via
`test.env`, which vitest merges into the test runtime's `process.env`
unconditionally. Added a `STARBEAM_TEST_PROD=1` escape hatch that
sets `test.env.PROD="1"` / `test.env.DEV=""` /
`test.env.MODE="production"` / `test.env.NODE_ENV="production"`.
Updated `ci:prod` and `test:workspace:prod` to set that flag.

A few tests had to be updated now that `ci:prod` actually runs prod
code paths:

- `verify/tests/messages.spec.ts` — directly tests
  `expected.toBe(...).message(null)`. Gated with `describe.skipIf
  (isProd)` (same pattern as `basic.spec.ts`).
- `debug/src/call-stack/debug/stack.ts` in-source tests — wrapped in
  `describe.skipIf(import.meta.env.PROD)(…)`.
- `resource/tests/sync.spec.ts` — `assertInitialized` called
  `verify(...)` directly. Changed to `verify?.(…)` so it no-ops in
  prod.

## Numbers

- `@starbeam/verify` prod bundle: **4431 → 1129 bytes** (-74.5%)
- DEV run: 275 passed / 2 skipped / 0 failed
- PROD run: 185 passed / 38 skipped / 0 failed
- 38 skipped in prod = exactly the DEV-only tests

## Why this matters beyond test infra

Anyone calling `verify?.(x, isEqual(y))`, `verify?.(arr, hasLength(3))`,
or any of the affected factories in production code was crashing
because argument evaluation happens before the `?.` short-circuit.
That's any user of `@starbeam/verify` who wrote optional-chained
`verify?.(...)` calls — the documented pattern.

The fix restores the invariant the public API already advertised:
the package can be safely imported and called in prod, and DEV-only
machinery is stripped by the bundler.

## Commits

1. `fix(verify): complete DEV/PROD symmetry in assertion factories`
2. `fix(ci:prod): actually flip import.meta.env.DEV=false`
## What

Fix the bar overlapping window titlebars when only an external monitor is connected.

The bug: SwiftBar emitted `outer.top = [{ monitor.main = 2 }, 38]`, treating "currently-main monitor" as a proxy for "the laptop with the notch." When the lid is closed (or the laptop isn't in the setup), macOS promotes an external to main, and that external receives `gap = 2` instead of `38`. The ~38pt bar then overlaps window titlebars by ~36pt.

## How

- Query AeroSpace (`list-monitors --json`) for authoritative `monitor-name` and `monitor-appkit-nsscreen-screens-id`. Pair with `NSScreen.safeAreaInsets.top > 0` to classify each monitor as notch / non-notch.
- New pure function `aeroSpaceOuterTopLine(monitors:notchGap:externalGap:)` emits either `outer.top = <externalGap>` (no notch screens) or `outer.top = [{ monitor."^<escaped-name>$" = <notchGap> }, …, <externalGap>]`.
- Graceful degradation: if the AeroSpace query fails or returns empty, emit scalar form with a stderr warning. No broken `[{}, 38]` possible.
- Regex escape handles `. ( ) [ ] { } * + ? ^ $ | \` and `"` (the name sits inside a TOML string).
- Signature change: `updateAeroSpaceGap(for screen:)` → `updateAeroSpaceGap()` (queries `NSScreen.screens` itself). Both call sites updated.

## Tests

- 7 table-driven tests: only-notch-laptop, only-external, notch+external, two-externals, zero-monitors, regex-metachars, plus the escape helper.
- All 24 tests pass (17 pre-existing + 7 new).

## Docs

- **INVARIANT #11** in `docs/INVARIANTS.md` — "Key per-monitor AeroSpace rules by monitor name + notch detection, not `monitor.main`." Cross-references #7 (stable keying).
- **`docs/UPSTREAM-ISSUES.md`** (new) — records the separate AeroSpace `setFrame` loop encountered in the previous session. Includes sample trace location (`~/Library/Logs/mac-setup/aero-flash-sample-2026-04-19.txt`), evidence, and `MacApp.swift` line pointers. Prepares for eventual upstream filing.
- **`docs/DESIGN-NOTES.md`** (new) — sketches a deferred "reset bar" safety-valve button: what it does, where it lives, what it explicitly doesn't fix, and a risk callout about not letting it substitute for real bug fixes.

## Verified live

After `swiftbar/rebuild.sh`, `~/.aerospace.toml` contains `outer.top = 38` (scalar) — correct for the current single-external-monitor no-notch configuration. The per-monitor rule form is not exercised in the current setup; first test of the "notch screen present" path will be the next time the laptop lid is open with the screen active.

## Commits

- `31c879a` Fix AeroSpace outer.top to key by monitor name + notch, not monitor.main
- `5b1dcf8` Document AeroSpace setFrame-loop upstream issue
- `484893a` Sketch deferred reset-bar safety valve in docs/DESIGN-NOTES.md

## Summary

Fixes two cross-tenant-id vulnerabilities where `bid` (block ID) was trusted from the query string alongside the authorized `cid` but never checked to belong to that chat.

- [VULN-7263](https://linear.app/vercel/issue/VULN-7263): `parseChatVMRequest` gate
- [VULN-7270](https://linear.app/vercel/issue/VULN-7270): platform `recreate-version-vm` path

## Problem

`parseChatVMRequest` authorized the chat via `authorizeVMAccess(cid)` but passed the `bid` query parameter through to downstream operations (`recreateVM`, `initializeBlobSandbox`, file reads, git ops) without verifying the block belonged to the authorized chat. A caller with access to chat A could supply `?cid=A&bid=<B's-block>` to pull another user's block data into their VM.

The platform-API path at `chat/lib/api/platform/beta/operations/chats/recreate-version-vm.ts` has the same bug. It constructs `ParsedChatVMRequest` by hand and calls `recreateVM` directly, so the gate fix alone wouldn't cover it.

There's prior art under the tag `VULN-6951`: three defense-in-depth checks downstream (`operations.ts`, `sync-preview-to-block.ts`, `get-version-iframe.ts`). Those still trip for bugs from future direct-construction sites, but they don't make the gate authoritative.

## Solution

After chat auth succeeds, verify the block's chat matches:

```ts
// VULN-7263: verify bid belongs to the authorized chat. Prevents a caller with
// read access to chat A from operating on chat B's block via the shared VM gate.
const blockChat = await getChatForBlockId(bid);
if (!blockChat || blockChat.chatId !== cid) {
  return { success: false, error: "Block not found", status: 404 };
}
```

- **Gate fix**: added to `parseChatVMRequest` after `authorizeVMAccess(cid)` and before userId resolution.
- **Platform fix**: same check added to `recreate-version-vm.ts` after `getChatById` and before `createChatVMKey`, throws `NotFoundError('Version not found in this chat')` matching the VULN-6951 precedent in `get-version-iframe.ts`.
- **Auth-first ordering preserved**: failing auth still returns 403 before any block lookup, so the 404 can't oracle block existence to unauthorized callers.
- **Error shape**: 404 matches prior VULN-6951 convention; collapses "missing block" and "wrong chat" into one response to avoid an existence oracle.
- **Existing VULN-6951 defense-in-depth checks left in place** (still guard templates and any future direct-construction sites).

## Tests

- `chat/app/chat/api/vm/utils/parse-vm-request.test.ts` (new, 4 cases): happy path, cross-tenant, missing block, oracle prevention (auth fails → `getChatForBlockId` is never called).
- `chat/lib/api/platform/beta/operations/chats/recreate-version-vm.test.ts` (new, 3 cases): happy path, cross-tenant, missing version.
- All 7 new tests pass. Existing `recreate-vm.test.ts` still passes (6/6). `pnpm type-check` clean.

## Performance note

`getChatForBlockId` is `React.cache`-wrapped (via `cacheIfAvailable`), so the extra read is per-request memoized and free for routes that also call it downstream. It does add one DB read per poll on `/vm/status`, which already has a pre-existing `TODO: Rate limit this endpoint` comment. Correctness wins over latency on a vuln fix; follow-up ticket will address a `(bid → chatId)` Redis cache alongside the rate-limit work.

## Out of scope

Template-path `bid` validation (`parseTemplateVMRequest`) is a separate vuln class with a different authorization model (block → template, not block → chat) and narrower exploit surface (no VM-key cross-contamination). Filing as a follow-up ticket.

## Summary

Fixes two cross-tenant-id vulnerabilities where `bid` (block ID) was trusted from the query string alongside the authorized `cid` but never checked to belong to that chat.

- [VULN-7263](https://linear.app/vercel/issue/VULN-7263) — `parseChatVMRequest` gate
- [VULN-7270](https://linear.app/vercel/issue/VULN-7270) — platform `recreate-version-vm` path

## Problem

`parseChatVMRequest` authorized the chat via `authorizeVMAccess(cid)` but passed the `bid` query parameter through to downstream operations (`recreateVM`, `initializeBlobSandbox`, file reads, git ops) without verifying the block belonged to the authorized chat. A caller with access to chat A could supply `?cid=A&bid=<B's-block>` to pull another user's block data into their VM.

The platform-API path at `chat/lib/api/platform/beta/operations/chats/recreate-version-vm.ts` had the same bug — it constructs `ParsedChatVMRequest` by hand and calls `recreateVM` directly, so the gate fix alone wouldn't cover it.

Prior art exists in the codebase under the tag `VULN-6951` — three defense-in-depth checks downstream (`operations.ts`, `sync-preview-to-block.ts`, `get-version-iframe.ts`). Those still trip for bugs from future direct-construction sites, but they don't make the gate authoritative.

## Solution

After chat auth succeeds, verify the block's chat matches:

```ts
// VULN-7263: verify bid belongs to the authorized chat. Prevents a caller with
// read access to chat A from operating on chat B's block via the shared VM gate.
const blockChat = await getChatForBlockId(bid);
if (!blockChat || blockChat.chatId !== cid) {
  return { success: false, error: "Block not found", status: 404 };
}
```

- **Gate fix**: added to `parseChatVMRequest` after `authorizeVMAccess(cid)` and before userId resolution.
- **Platform fix**: same check added to `recreate-version-vm.ts` after `getChatById` and before `createChatVMKey`, throws `NotFoundError('Version not found in this chat')` matching the VULN-6951 precedent in `get-version-iframe.ts`.
- **Auth-first ordering preserved**: failing auth still returns 403 before any block lookup. Prevents the 404 from oracling block existence to unauthorized callers.
- **Error shape**: 404 matches prior VULN-6951 convention; collapses "missing block" and "wrong chat" into one response to avoid existence oracle.
- **Existing VULN-6951 defense-in-depth checks left in place** (still guard templates and any future direct-construction sites).

## Tests

- `chat/app/chat/api/vm/utils/parse-vm-request.test.ts` (new, 4 cases): happy path, cross-tenant, missing block, oracle prevention (auth fails → `getChatForBlockId` is never called).
- `chat/lib/api/platform/beta/operations/chats/recreate-version-vm.test.ts` (new, 3 cases): happy path, cross-tenant, missing version.
- All 7 new tests pass. Existing `recreate-vm.test.ts` still passes (6/6). `pnpm type-check` clean.

## Performance note

`getChatForBlockId` is `React.cache`-wrapped (via `cacheIfAvailable`), so the extra read is per-request memoized — free for routes that also call it downstream. It does add one DB read per poll on `/vm/status`, which already has a pre-existing `TODO: Rate limit this endpoint` comment. Acceptable for correctness > latency on a vuln fix; follow-up ticket will address a `(bid → chatId)` Redis cache alongside the rate-limit work.

## Out of scope

Template-path `bid` validation (`parseTemplateVMRequest`) is a separate vuln class with a different authorization model (block → template, not block → chat) and narrower exploit surface (no VM-key cross-contamination). Filing as a follow-up ticket.

## Summary

Fixes two cross-tenant-id vulnerabilities where `bid` (block ID) was trusted from the query string alongside the authorized `cid` but never checked to belong to that chat.

- [VULN-7263](https://linear.app/vercel/issue/VULN-7263) — `parseChatVMRequest` gate
- [VULN-7270](https://linear.app/vercel/issue/VULN-7270) — platform `recreate-version-vm` path

## Problem

`parseChatVMRequest` authorized the chat via `authorizeVMAccess(cid)` but passed the `bid` query parameter through to downstream operations (`recreateVM`, `initializeBlobSandbox`, file reads, git ops) without verifying the block belonged to the authorized chat. A caller with access to chat A could supply `?cid=A&bid=<B's-block>` to pull another user's block data into their VM.

The platform-API path at `chat/lib/api/platform/beta/operations/chats/recreate-version-vm.ts` had the same bug — it constructs `ParsedChatVMRequest` by hand and calls `recreateVM` directly, so the gate fix alone wouldn't cover it.

Prior art exists in the codebase under the tag `VULN-6951` — three defense-in-depth checks downstream (`operations.ts`, `sync-preview-to-block.ts`, `get-version-iframe.ts`). Those still trip for bugs from future direct-construction sites, but they don't make the gate authoritative.

## Solution

After chat auth succeeds, verify the block's chat matches:

```ts
// VULN-7263: verify bid belongs to the authorized chat. Prevents a caller with
// read access to chat A from operating on chat B's block via the shared VM gate.
const blockChat = await getChatForBlockId(bid);
if (!blockChat || blockChat.chatId !== cid) {
  return { success: false, error: "Block not found", status: 404 };
}
```

- **Gate fix**: added to `parseChatVMRequest` after `authorizeVMAccess(cid)` and before userId resolution.
- **Platform fix**: same check added to `recreate-version-vm.ts` after `getChatById` and before `createChatVMKey`, throws `NotFoundError('Version not found in this chat')` matching the VULN-6951 precedent in `get-version-iframe.ts`.
- **Auth-first ordering preserved**: failing auth still returns 403 before any block lookup. Prevents the 404 from oracling block existence to unauthorized callers.
- **Error shape**: 404 matches prior VULN-6951 convention; collapses "missing block" and "wrong chat" into one response to avoid existence oracle.
- **Existing VULN-6951 defense-in-depth checks left in place** (still guard templates and any future direct-construction sites).

## Tests

- `chat/app/chat/api/vm/utils/parse-vm-request.test.ts` (new, 4 cases): happy path, cross-tenant, missing block, oracle prevention (auth fails → `getChatForBlockId` is never called).
- `chat/lib/api/platform/beta/operations/chats/recreate-version-vm.test.ts` (new, 3 cases): happy path, cross-tenant, missing version.
- All 7 new tests pass. Existing `recreate-vm.test.ts` still passes (6/6). `pnpm type-check` clean.

## Performance note

`getChatForBlockId` is `React.cache`-wrapped (via `cacheIfAvailable`), so the extra read is per-request memoized — free for routes that also call it downstream. It does add one DB read per poll on `/vm/status`, which already has a pre-existing `TODO: Rate limit this endpoint` comment. Acceptable for correctness > latency on a vuln fix; follow-up ticket will address a `(bid → chatId)` Redis cache alongside the rate-limit work.

## Out of scope

Template-path `bid` validation (`parseTemplateVMRequest`) is a separate vuln class with a different authorization model (block → template, not block → chat) and narrower exploit surface (no VM-key cross-contamination). Filing as a follow-up ticket.
