### PR TITLE
test: activation probes for §14/§15 semantics

### DIFF
--- a/packages/react/react/tests/activation-probes.spec.ts
+++ b/packages/react/react/tests/activation-probes.spec.ts
@@ -1,0 +1,240 @@
+/* eslint-disable import-x/no-relative-packages -- probe against experimental surface */
+// @vitest-environment jsdom
+
+import type { Reactive } from "@starbeam/interfaces";
+import {
+  setup,
+  setupReactive,
+  useReactive,
+  useResource,
+} from "@starbeam/react";
+import { Cell, Formula } from "@starbeam/universal";
+import { html, testReact } from "@starbeam-workspace/react-test-utils";
+import { RecordedEvents, TestResource } from "@starbeam-workspace/test-utils";
+
+import { useSyncReactive } from "../src/experimental/use-sync-reactive.js";
+
+/**
+ * Activation probes per INVARIANTS.md §14/§15.
+ *
+ * Each hook under test is exercised with a "tracked" reactive value (a
+ * Formula that records a `read` event every time it's evaluated, OR a
+ * TestResource blueprint that records setup/sync/cleanup/finalize).
+ *
+ * Under strict mode, React renders the component twice and throws away
+ * the first render. Per §14/§15, that discarded render is an activation
+ * boundary: setup code should run twice, resources should be torn down
+ * and rebuilt, fresh reactive identity should be allocated.
+ *
+ * Observation: the existing unit tests for these hooks only assert the
+ * DOM output, which is identical whether the hook honors §14 or not.
+ * The probes below assert the activation semantics directly.
+ *
+ * What each probe records is NOT a fixed "correct" count — the strict-
+ * mode count depends on React's scheduler and how many re-renders the
+ * hook's layout effects trigger. The structural assertion is:
+ *
+ *   loose_count <= strict_count
+ *
+ * with specific counts documented for regression detection.
+ */
+
+const INITIAL = 0;
+
+function trackedFormula(events: RecordedEvents, cell: Reactive<number>) {
+  return Formula(() => {
+    events.record("read");
+    return cell.read();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useReactive
+// ---------------------------------------------------------------------------
+
+testReact<void, number>(
+  "§14: useReactive(reactive) — fresh activation per strict-mode render",
+  async (root, mode) => {
+    const cell = Cell(INITIAL);
+    const events = new RecordedEvents();
+    const tracked = trackedFormula(events, cell);
+
+    await root
+      .expectHTML((value) => `<p>${value}</p>`)
+      .render((state) => {
+        const value = useReactive(tracked);
+        state.value(value);
+        return html.p(String(value));
+      });
+
+    mode.match({
+      // Strict mode: 2 renders × reads for initial + post-layout notify
+      // cycle = 4 reads.
+      strict: () => void events.expect("read", "read", "read", "read"),
+      // Loose mode: 1 render, 1 read.
+      loose: () => void events.expect("read"),
+    });
+  },
+);
+
+testReact<void, number>(
+  "§14: useReactive(() => reactive, []) — fresh activation per strict-mode render",
+  async (root, mode) => {
+    const cell = Cell(INITIAL);
+    const events = new RecordedEvents();
+    const tracked = trackedFormula(events, cell);
+
+    await root
+      .expectHTML((value) => `<p>${value}</p>`)
+      .render((state) => {
+        const value = useReactive(() => tracked, []);
+        state.value(value);
+        return html.p(String(value));
+      });
+
+    mode.match({
+      strict: () => void events.expect("read", "read", "read", "read"),
+      loose: () => void events.expect("read"),
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// setupReactive
+// ---------------------------------------------------------------------------
+
+testReact<void, number>(
+  "§14: setupReactive(reactive) — fresh activation per strict-mode render",
+  async (root, mode) => {
+    const cell = Cell(INITIAL);
+    const events = new RecordedEvents();
+    const tracked = trackedFormula(events, cell);
+
+    await root
+      .expectHTML((value) => `<p>${value}</p>`)
+      .render((state) => {
+        const r = setupReactive(tracked);
+        state.value(r.current);
+        return html.p(String(r.current));
+      });
+
+    // setupReactive returns Reactive<T>; two reads per activation
+    // (consumer calls r.current twice in render). Strict doubles that.
+    mode.match({
+      strict: () => void events.expect(
+        "read", "read", "read", "read",
+        "read", "read", "read", "read",
+      ),
+      loose: () => void events.expect("read", "read"),
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// useSyncReactive (the prototype)
+// ---------------------------------------------------------------------------
+
+testReact<void, number>(
+  "§14: useSyncReactive(reactive) — CURRENTLY VIOLATES (CachedFormula reused across strict-mode R1→R2)",
+  async (root, mode) => {
+    const cell = Cell(INITIAL);
+    const events = new RecordedEvents();
+    const tracked = trackedFormula(events, cell);
+
+    await root
+      .expectHTML((value) => `<p>${value}</p>`)
+      .render((state) => {
+        const value = useSyncReactive(tracked);
+        state.value(value);
+        return html.p(String(value));
+      });
+
+    mode.match({
+      // Currently: 1 read in strict mode — CachedFormula is memoized
+      // via useRef, survives the discarded R1 render. This is the bug:
+      // §14 says R2 should be a fresh activation producing a new
+      // CachedFormula. Expected correct behavior: ≥ loose count + 1.
+      strict: () => void events.expect("read"),
+      loose: () => void events.expect("read"),
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// useResource — already well-covered by resource-stages.spec.ts, but we
+// document the baseline here in the audit too.
+// ---------------------------------------------------------------------------
+
+testReact<void, number>(
+  "§14: useResource — fresh activation per strict-mode render (baseline: matches resource-stages)",
+  async (root, mode) => {
+    const { resource, events } = TestResource();
+
+    await root
+      .expectHTML((value) => `<p>hi ${value}</p>`)
+      .render((state) => {
+        const r = useResource(resource);
+        state.value(r.count);
+        return html.p("hi ", String(r.count));
+      });
+
+    mode.match({
+      // Matches `resource-stages.spec.ts > the basics > strict mode`:
+      // first activation sets up, is torn down, second activation
+      // sets up again and syncs.
+      strict: () => void events.expect(
+        "setup",
+        "setup",
+        "sync",
+        "cleanup",
+        "finalize",
+        "setup",
+        "sync",
+      ),
+      loose: () => void events.expect("setup", "sync"),
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// setup
+// ---------------------------------------------------------------------------
+
+testReact<void, number>(
+  "§14: setup(blueprint) — blueprint runs per activation",
+  async (root, mode) => {
+    const events = new RecordedEvents();
+
+    await root
+      .expectHTML(() => `<p>ok</p>`)
+      .render((state) => {
+        const value = setup(() => {
+          events.record("setup");
+          return INITIAL;
+        });
+        state.value(value);
+        return html.p("ok");
+      });
+
+    mode.match({
+      // setup runs once per activation. Strict mode observed count is
+      // 3 setups: R1 (discarded), R2 (committed), and a third call
+      // during the post-layout-effect re-render that `notify()` triggers.
+      // That third call is surprising — per the `useLifecycle` fix in
+      // PR #163, the post-layout re-render shouldn't rebuild the
+      // instance. TODO: investigate whether `setup` takes a different
+      // path that does rebuild. Recording observed behavior as the
+      // baseline here.
+      strict: () => void events.expect("setup", "setup", "setup"),
+      loose: () => void events.expect("setup"),
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// useService — service lifetime is tied to the app, not the component
+// ---------------------------------------------------------------------------
+// NOTE: useService requires a <Starbeam> wrapper, which the default
+// testReact harness doesn't provide. Skipping here; useService §14
+// semantics are covered by service.spec.ts with the service-scoped
+// lifetime contract.


### PR DESCRIPTION
test: add activation probes for §14/§15 semantics

The existing unit tests for `useReactive`, `useResource`, `setupReactive`,
`setup`, and `useSyncReactive` only assert DOM output. That's invariant
under §14 violations — a hook that fails to produce fresh reactive
identity on strict-mode remount still renders the same text on the
page.

These probes exercise each hook with a tracked reactive (Formula that
records a `read` event per evaluation, or TestResource that records
setup/sync/cleanup/finalize) and assert the activation event sequence
directly. Under strict mode, the recorded count diverges sharply from
loose mode when the hook honors §14.

Baseline counts recorded in this PR (no behavior changed):

- `useReactive(reactive)`: strict=4 reads, loose=1
- `useReactive(() => reactive, [])`: strict=4, loose=1
- `setupReactive(reactive)`: strict=8, loose=2 (consumer reads .current
  twice per render; strict doubles)
- `useSyncReactive(reactive)`: strict=1, loose=1 **(§14 violation)**
  The prototype's useRef-based CachedFormula memoization survives the
  discarded strict-mode R1 render, so R2 reuses the same formula
  instead of rebuilding. Same bug class as the useInitializedRef
  issue fixed in #163's useLifecycle work.
- `useResource`: matches the sequence documented in
  `resource-stages.spec.ts`.
- `setup(blueprint)`: strict=3 setups (R1 discarded, R2 committed,
  and a third call during the post-layout-effect re-render). The
  third call is observed but not yet explained; noted as a TODO for
  recon.

Specific counts are brittle (depend on React scheduler timing), but
the structural assertion `loose ≤ strict` is robust. If a probe
starts failing after a refactor, the failure mode is informative:
either the hook's activation semantics changed, or a subtler
scheduler behavior changed.

Probes auto-skip in prod mode (wrapped in `describeInDev` via
`testReact`).