### PR TITLE
test: transition probe — scheduler does not participate in React transitions

### DIFF
--- a/packages/react/react/tests/transition-probe.spec.ts
+++ b/packages/react/react/tests/transition-probe.spec.ts
@@ -1,0 +1,109 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers -- probe counts */
+// @vitest-environment jsdom
+
+import { useReactive } from "@starbeam/react";
+import { Cell } from "@starbeam/universal";
+import { html, testReact } from "@starbeam-workspace/react-test-utils";
+import { RecordedEvents } from "@starbeam-workspace/test-utils";
+import { startTransition, useTransition } from "react";
+
+/**
+ * Transition probe: does Starbeam's scheduler participate in React 18+
+ * transitions?
+ *
+ * React 19 docs establish that `startTransition(fn)` marks as "transition"
+ * only those state updates that happen *synchronously* within `fn`:
+ *
+ *   https://react.dev/reference/react/useTransition — "The function you
+ *   pass to startTransition must be synchronous. You can't mark an update
+ *   as a Transition [from] setTimeout, for example."
+ *
+ * Starbeam's current scheduler (see
+ * `packages/react/react/src/hooks/lifecycle.ts`) pokes a `setState({})`
+ * from inside a `useEffect` callback — which fires asynchronously, after
+ * the `startTransition` call frame has exited. If that's the observable
+ * behavior, writing a cell from inside `startTransition` will NOT produce
+ * a transition-flagged re-render; `isPending` will never become true.
+ *
+ * This probe captures which observable actually holds. It does NOT assert
+ * correctness — it documents reality. Either outcome is the current
+ * behavior; the design conversation downstream will decide whether it
+ * matches user expectations.
+ */
+
+testReact<void, { count: number; isPending: boolean }>(
+  "transitions: cell write inside startTransition",
+  async (root, mode) => {
+    const cell = Cell(0);
+    const events = new RecordedEvents();
+
+    const result = await root
+      .expectHTML(({ count, isPending }) => {
+        const pending = isPending ? " pending" : "";
+        return `<p>${count}${pending}</p>`;
+      })
+      .render((state) => {
+        const count = useReactive(cell);
+        const [isPending] = useTransition();
+
+        events.record(`render:count=${count},isPending=${isPending}`);
+
+        state.value({ count, isPending });
+
+        return html.p(String(count) + (isPending ? " pending" : ""));
+      });
+
+    // Sanity: initial render observed. Under strict mode, 2 renders
+    // happen; under loose, 1. Both leave isPending=false.
+    mode.match({
+      strict: () => {
+        events.expect(
+          "render:count=0,isPending=false",
+          "render:count=0,isPending=false",
+          "render:count=0,isPending=false",
+          "render:count=0,isPending=false",
+        );
+      },
+      loose: () => {
+        events.expect("render:count=0,isPending=false");
+      },
+    });
+
+    // Write the cell from inside startTransition.
+    startTransition(() => {
+      cell.current = 1;
+    });
+
+    // Give React a chance to process the update.
+    await result.rerender();
+
+    // The meaningful assertion: no render ever has `isPending=true`.
+    // The cell update is visible (count=1), proving the write reached
+    // the component, but the transition tag was never set.
+    //
+    // Observed counts (2026-04-21):
+    //   strict mode: 4 renders at count=1 (strict double × layout notify)
+    //   loose mode:  2 renders at count=1 (initial + layout notify)
+    // Both with isPending=false throughout.
+    //
+    // If the scheduler ever starts to participate in transitions, this
+    // probe will need to be revised to assert a transition-tagged
+    // render appears in the sequence.
+    mode.match({
+      strict: () => {
+        events.expect(
+          "render:count=1,isPending=false",
+          "render:count=1,isPending=false",
+          "render:count=1,isPending=false",
+          "render:count=1,isPending=false",
+        );
+      },
+      loose: () => {
+        events.expect(
+          "render:count=1,isPending=false",
+          "render:count=1,isPending=false",
+        );
+      },
+    });
+  },
+);


### PR DESCRIPTION
test: transition probe documents Starbeam scheduler does not participate in React transitions

A recent survey of post-React-18 primitives (recon saved to
/memories/session/react-primitives-survey.md) noted that Starbeam's
current scheduler pokes `setState({})` from inside `useEffect` —
which runs AFTER `startTransition`'s sync call frame exits. React's
docs confirm only state updates scheduled *during* the sync call
frame are flagged as transitions.

This probe captures the observable consequence: writing a cell from
inside `startTransition(fn)` produces a re-render that is NOT
flagged as a transition. `isPending` from `useTransition()` never
becomes true during the update.

Observed (2026-04-21):
- Strict mode: 4 renders at count=1 after the cell write, all with
  isPending=false.
- Loose mode: 2 renders, all with isPending=false.

Neither outcome asserts correctness. This is a factual record of
current behavior. Whether Starbeam users expect cell writes inside
`startTransition` to participate in the transition is a design
question, open for the next ergonomics conversation.

If the scheduler ever starts to participate in transitions, this
probe will fail — a signal to update the documented expectation,
not a regression.