### PR TITLE
fix(react): don't rebuild instance during Activity hide-transition renders

### DIFF
--- a/packages/react/react/tests/activation-probes.spec.ts
+++ b/packages/react/react/tests/activation-probes.spec.ts
@@ -118,10 +118,17 @@ testReact<void, number>(
     // setupReactive returns Reactive<T>; two reads per activation
     // (consumer calls r.current twice in render). Strict doubles that.
     mode.match({
-      strict: () => void events.expect(
-        "read", "read", "read", "read",
-        "read", "read", "read", "read",
-      ),
+      strict: () =>
+        void events.expect(
+          "read",
+          "read",
+          "read",
+          "read",
+          "read",
+          "read",
+          "read",
+          "read",
+        ),
       loose: () => void events.expect("read", "read"),
     });
   },
@@ -149,15 +156,16 @@ testReact<void, number>(
       // Matches `resource-stages.spec.ts > the basics > strict mode`:
       // first activation sets up, is torn down, second activation
       // sets up again and syncs.
-      strict: () => void events.expect(
-        "setup",
-        "setup",
-        "sync",
-        "cleanup",
-        "finalize",
-        "setup",
-        "sync",
-      ),
+      strict: () =>
+        void events.expect(
+          "setup",
+          "setup",
+          "sync",
+          "cleanup",
+          "finalize",
+          "setup",
+          "sync",
+        ),
       loose: () => void events.expect("setup", "sync"),
     });
   },
@@ -184,14 +192,13 @@ testReact<void, number>(
       });
 
     mode.match({
-      // setup runs once per activation. Strict mode observed count is
-      // 3 setups: R1 (discarded), R2 (committed), and a third call
-      // during the post-layout-effect re-render that `notify()` triggers.
-      // That third call is surprising — per the `useLifecycle` fix in
-      // PR #163, the post-layout re-render shouldn't rebuild the
-      // instance. TODO: investigate whether `setup` takes a different
-      // path that does rebuild. Recording observed behavior as the
-      // baseline here.
+      // Strict mode's first mount goes through two activations per
+      // §14/§15: the discarded R1+R2 pair (strict's "throwaway test")
+      // and then the remount activation after React's strict-mode
+      // cleanup cycle. The first activation's blueprint runs twice
+      // (R1 initial + R2 rebuild per PR #163), and the remount runs
+      // it once more, so 3 setup events total. Matches
+      // resource-stages.spec.ts baseline.
       strict: () => void events.expect("setup", "setup", "setup"),
       loose: () => void events.expect("setup"),
     });

--- a/packages/react/react/tests/activity-probe.spec.ts
+++ b/packages/react/react/tests/activity-probe.spec.ts
@@ -75,39 +75,24 @@ testReact<{ mode: "visible" | "hidden" }, number>(
       loose: () => void events.expect("setup", "sync"),
     });
 
-    // Hide the subtree. Observed (2026-04-21): React fires cleanup and
-    // finalize (effects destroyed), but ALSO re-renders the subtree
-    // one more time under hide, which invokes Starbeam's `setup`
-    // blueprint again. No `sync` follows because layout effects don't
-    // fire for a hidden subtree.
-    //
-    // This is a surprising observation: Starbeam's resource allocates
-    // new state during the hide transition even though it can never
-    // run (no layout commit). The allocation will be torn down when
-    // the subtree shows again — but the blueprint callback still runs
-    // inside the transition to hidden. Worth investigating.
+    // Hide the subtree. §15: layout cleanup fires, resource sees
+    // cleanup + finalize. `useLifecycle`'s `isUpdate && state ===
+    // unmounted` branch falls through as a no-op, so no spurious
+    // setup runs during the hide-transition re-render.
     await result.rerender({ mode: "hidden" });
-    mode.match({
-      strict: () => void events.expect("cleanup", "finalize", "setup", "setup"),
-      loose: () => void events.expect("cleanup", "finalize", "setup"),
-    });
+    events.expect("cleanup", "finalize");
 
     // After the hide transition, React's style attribute is left as
     // an empty string (style="") rather than being removed. The DOM
     // content is still there — only the style representation changed.
     expectedHTML = () => `<p style="">count=0</p>`;
 
-    // Show again. Observed (2026-04-21): React runs a full re-activation
-    // cycle on show, including a strict-mode-style double-activation in
-    // strict mode. The key property — §15 is honored, new sync happens
-    // after the show — holds. The specific event count reflects how
-    // aggressively React re-activates under Activity.
+    // Show again. Layout effects fire; remount path rebuilds the
+    // resource, fires setup and sync.
     await result.rerender({ mode: "visible" });
     mode.match({
       strict: () =>
         void events.expect(
-          "setup",
-          "setup",
           "setup",
           "sync",
           "cleanup",
@@ -115,7 +100,7 @@ testReact<{ mode: "visible" | "hidden" }, number>(
           "setup",
           "sync",
         ),
-      loose: () => void events.expect("setup", "setup", "sync"),
+      loose: () => void events.expect("setup", "sync"),
     });
   },
 );

--- a/packages/react/use-strict-lifecycle/src/lifecycle.ts
+++ b/packages/react/use-strict-lifecycle/src/lifecycle.ts
@@ -188,22 +188,29 @@ export function useLifecycle<V, A>(
           // `useLayoutEffect`): the instance was already rebuilt there, so
           // just finish the transition back to mounted.
           state.current = State.mounted;
-        } else {
-          // `state.current === State.mounting`: this is strict mode's second
-          // render, before any `useLayoutEffect` has fired. React is about to
-          // throw the first render's work away, so per INVARIANTS §14/§15 we
-          // treat it as a fresh activation and rebuild the instance.
+        } else if (state.current === State.mounting) {
+          // Strict mode's second render, before any `useLayoutEffect` has
+          // fired. React is about to throw the first render's work away,
+          // so per INVARIANTS §14/§15 we treat it as a fresh activation
+          // and rebuild the instance.
           //
-          // `on.layout` handlers never ran on the discarded instance, so any
-          // cleanup they would have registered doesn't exist yet; the builder
-          // receives the previous value via `prev` and is responsible for
-          // handing any longer-lived identity back to the new instance (see
-          // `ReactApp.reactivate` in `packages/react/react/src/app.ts`).
+          // `on.layout` handlers never ran on the discarded instance, so
+          // any cleanup they would have registered doesn't exist yet; the
+          // builder receives the previous value via `prev` and is
+          // responsible for handing any longer-lived identity back to the
+          // new instance (see `ReactApp.reactivate` in
+          // `packages/react/react/src/app.ts`).
           instance.current = buildInstance<T, V, A>({
             options: instance.current.options,
             value: instance.current.value,
           });
         }
+        // state.current === State.unmounted: React is re-rendering the
+        // subtree after `useLayoutEffect`'s cleanup fired (e.g.,
+        // `<Activity mode="hidden">`'s visible→hidden transition). No
+        // layout effect will fire in this state because the subtree is
+        // hidden. Don't rebuild the instance here — the remount path in
+        // `useLayoutEffect` handles rebuild if and when we come back.
       }
 
       function run(event: LifecycleEvent): void {
@@ -274,9 +281,9 @@ interface Instance<T, V, A> {
 
 type HandlerSets<A> = Readonly<Record<LifecycleEvent, Set<(args: A) => void>>>;
 
-export type RegisterLifecycleHandlers<A> = Readonly<Record<LifecycleEvent, (
-    handler: undefined | ((args: A) => void),
-  ) => void>>;
+export type RegisterLifecycleHandlers<A> = Readonly<
+  Record<LifecycleEvent, (handler: undefined | ((args: A) => void)) => void>
+>;
 
 interface LifecycleOptions<T, V, A> {
   readonly build: UseLifecycleBuilder<T, A>;


### PR DESCRIPTION
fix(react): don't rebuild instance during Activity hide-transition renders

PR #163's activation-arc fix added a case to `useLifecycle` that
rebuilds the instance when `isUpdate && state.current !== mounted &&
state.current !== remounting`. The comment assumed that case was
exclusively strict mode's discarded R2 render (where state is
`mounting`), but the `else` also fires when `state === unmounted`.

`state === unmounted` happens after `useLayoutEffect`'s cleanup
runs. In a normal unmount that's fine because the component is going
away. Under `<Activity mode="hidden">`, React tears down layout
effects (so state → unmounted) but ALSO re-renders the component
body so it can display `display: none`. That re-render hit the
unconditional rebuild branch, allocating fresh instance state that
could never be cleaned up (no layout effect fires for a hidden
subtree to register cleanup handlers).

The activity probe landed in PR #169 captured this as "stranded
setup" — the blueprint fires but no `sync` follows.

Fix: narrow the branch to explicitly check `state === mounting`, and
treat `state === unmounted` as a deliberate no-op. The remount path
in `useLayoutEffect` still handles rebuild when the subtree shows
again.

Probe updated to reflect the fixed behavior — hide now produces
`cleanup, finalize` with no stranded setup, and show produces a
clean re-activation (`setup, sync` in loose mode; the strict-mode
double-activation pattern in strict mode, matching the initial-
mount sequence from `resource-stages.spec.ts`).

Also corrects a comment on the `setup(blueprint)` probe in
`activation-probes.spec.ts` — the observed `setup=3` in strict mode
is §14-correct (two activations: R1+R2 discarded pair, plus remount)
and matches the resource-stages baseline. The prior "TODO:
investigate" comment was misleading.
