### PR TITLE
chore(react): delete two dead-code paths (duplicate useReactive + broken useDeps)

### DIFF
--- a/packages/react/react/index.ts
+++ b/packages/react/react/index.ts
@@ -3,4 +3,4 @@ import "./src/debug/warnings.js";
 export { type ReactApp, Starbeam, useStarbeamApp } from "./src/app.js";
 export { useSetup } from "./src/hooks/setup.js";
 export { useReactive, useResource, useService } from "./src/hooks/use.js";
-export { useDeps, useProp } from "./src/utils.js";
+export { useProp } from "./src/utils.js";

--- a/packages/react/react/src/utils.ts
+++ b/packages/react/react/src/utils.ts
@@ -4,31 +4,6 @@ import { UNINITIALIZED } from "@starbeam/shared";
 import { Cell } from "@starbeam/universal";
 import { useRef, useState } from "react";
 
-export interface Deps {
-  consume: () => void;
-  debug: () => Reactive<unknown>[];
-}
-
-/**
- * Convert a React hooks dependency list into a reactive
- */
-export function useDeps<T extends unknown[] | undefined>(
-  deps: T,
-  description?: string | Description | undefined,
-): Deps | undefined {
-  const desc = DEBUG?.Desc("cell", description, "useDeps");
-
-  if (deps?.length) {
-    const dependencies = deps.map((dep, i) => useProp(dep, desc?.index(i)));
-    return {
-      consume: () => {
-        dependencies.forEach((dep) => dep.read());
-      },
-      debug: () => dependencies,
-    };
-  }
-}
-
 export function useProp<T>(
   variable: T,
   description?: string | Description,


### PR DESCRIPTION
Two independent cleanups landed on one branch.

## 1. Delete duplicate `useReactive` in `hooks/setup.ts`

`useReactive` was defined twice:
- `src/hooks/setup.ts:75` (this one — the duplicate)
- `src/hooks/use.ts:29` (the canonical one re-exported from the package)

\`index.ts\` only re-exports \`useReactive\` from \`./src/hooks/use.js\`. No caller inside \`@starbeam/react\` or elsewhere in the monorepo imports \`useReactive\` from \`./setup.js\`. The copy in \`setup.ts\` is dead code.

Removes the duplicate definition plus its now-unused \`unsafeTrackedElsewhere\` import and \`ReactiveBlueprint\` type import.

## 2. Delete broken \`useDeps\` export

\`useDeps\` was publicly exported from \`@starbeam/react\`, had zero tests, zero internal callers, and contained two pre-existing Rules-of-React violations:

1. **Conditional hook call**: \`useProp(...)\` inside \`if (deps?.length)\`.
2. **Variable-count hook calls**: \`deps.map((dep, i) => useProp(dep, ...))\` — the number of \`useProp\` calls equals \`deps.length\`.

Both ESLint's \`react-hooks/rules-of-hooks\` rule and React Compiler's static analysis would flag these; they weren't caught because no test exercised \`useDeps\`.

The hook's purpose (bridge a React deps array into Starbeam reactives) is already covered by calling \`useProp(value)\` directly per element. \`useDeps\`'s \`{consume, debug}\` return shape adds little over a plain array of reactives and sacrificed correctness for brevity. Delete rather than fix.

The companion \`useProp\` is untouched.

## Verification

69/69 react tests pass. Lint + types clean. No regressions across the full workspace (pnpm ci:specs + ci:prod + build + build-verify + lint + types all green in pre-push).