### PR TITLE
Update release-plan

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -1,68 +1,49 @@
-name: Release Plan Review
+name: Plan Release
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
       - master
-  pull_request:
+  pull_request_target: # This workflow has permissions on the repo, do NOT run code from PRs in this workflow. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
     types:
       - labeled
+      - unlabeled
 
 concurrency:
   group: plan-release # only the latest one of these should ever be running
   cancel-in-progress: true
 
 jobs:
-  check-plan:
-    name: "Check Release Plan"
+  should-run-release-plan-prepare:
+    name: Should we run release-plan prepare?
     runs-on: ubuntu-latest
     outputs:
-      command: ${{ steps.check-release.outputs.command }}
-
+      should-prepare: ${{ steps.should-prepare.outputs.should-prepare }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: release-plan/actions/should-prepare-release@v1
         with:
-          fetch-depth: 0
           ref: "main"
-      # This will only cause the `check-plan` job to have a "command" of `release`
-      # when the .release-plan.json file was changed on the last commit.
-      - id: check-release
-        run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
+        id: should-prepare
 
-  prepare_release_notes:
-    name: Prepare Release Notes
+  create-prepare-release-pr:
+    name: Create Prepare Release PR
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: check-plan
+    needs: should-run-release-plan-prepare
     permissions:
       contents: write
+      issues: read
       pull-requests: write
-    outputs:
-      explanation: ${{ steps.explanation.outputs.text }}
-    # only run on push event if plan wasn't updated (don't create a release plan when we're releasing)
-    # only run on labeled event if the PR has already been merged
-    if: (github.event_name == 'push' && needs.check-plan.outputs.command != 'release') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
-
+    if: needs.should-run-release-plan-prepare.outputs.should-prepare == 'true'
     steps:
-      - uses: actions/checkout@v4
-        # We need to download lots of history so that
-        # lerna-changelog can discover what's changed since the last release
+      - uses: release-plan/actions/prepare@v1
+        name: Run release-plan prepare
         with:
-          fetch-depth: 0
-      - uses: wyvox/action-setup-pnpm@v3
-
-      - name: "Generate Explanation and Prep Changelogs"
-        id: explanation
-        run: |
-          set -x
-
-          pnpm release-plan prepare
-
-          echo 'text<<EOF' >> $GITHUB_OUTPUT
-          jq .description .release-plan.json -r >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+          ref: "main"
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+        id: explanation
 
       - uses: actions/create-github-app-token@v2
         id: release-plan-token
@@ -71,6 +52,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_PLAN_APP_PRIVATE_KEY }}
 
       - uses: peter-evans/create-pull-request@v8
+        name: Create Prepare Release PR
         with:
           # Pull requests created with the default GITHUB_TOKEN don't
           # trigger push/pull_request workflows, which means the
@@ -78,13 +60,11 @@ jobs:
           # GitHub App token triggers CI and can produce verified bot-
           # signed commits when `sign-commits` is enabled.
           token: ${{ steps.release-plan-token.outputs.token }}
-          commit-message: "Prepare Release using 'release-plan'"
-          # main requires signed commits. create-pull-request signs as
-          # the GitHub App's bot when using a GitHub App token.
-          sign-commits: true
+          commit-message: "Prepare Release ${{ steps.explanation.outputs.new-version }} using 'release-plan'"
           labels: "internal"
+          sign-commits: true
           branch: release-preview
-          title: Prepare Release
+          title: Prepare Release ${{ steps.explanation.outputs.new-version }}
           body: |
             This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,5 @@
-# For every push to the master branch, this checks if the release-plan was
-# updated and if it was it will publish stable npm packages based on the
-# release plan
+# For every push to the primary branch with .release-plan.json modified,
+# runs release-plan.
 
 name: Publish Stable
 
@@ -10,48 +9,32 @@ on:
     branches:
       - main
       - master
+    paths:
+      - '.release-plan.json'
 
 concurrency:
   group: publish-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  check-plan:
-    name: "Check Release Plan"
-    runs-on: ubuntu-latest
-    outputs:
-      command: ${{ steps.check-release.outputs.command }}
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: 'main'
-      # This will only cause the `check-plan` job to have a result of `success`
-      # when the .release-plan.json file was changed on the last commit. This
-      # plus the fact that this action only runs on main will be enough of a guard
-      - id: check-release
-        run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
-
   publish:
     name: "NPM Publish"
     runs-on: ubuntu-latest
-    needs: check-plan
-    if: needs.check-plan.outputs.command == 'release'
     permissions:
       contents: write
-      pull-requests: write   
+      id-token: write
+      attestations: write
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: wyvox/action-setup-pnpm@v3
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
-          # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
-          node-registry-url: 'https://registry.npmjs.org'
-      
-      - name: npm publish
-        run: pnpm release-plan publish
-      
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Publish to NPM
+        run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,24 +1,24 @@
 # Release Process
 
-Releases in this repo are mostly automated using [release-plan](https://github.com/embroider-build/release-plan/). Once you label all your PRs correctly (see below) you will have an automatically generated PR that updates your CHANGELOG.md file and a `.release-plan.json` that is used prepare the release once the PR is merged.
+Releases in this repo are mostly automated using [release-plan](https://github.com/embroider-build/release-plan/). Once you label all your PRs correctly (see below) you will have an automatically generated PR that updates your CHANGELOG.md file and a `.release-plan.json` that is used to prepare the release once the PR is merged.
 
 ## Preparation
 
-Since the majority of the actual release process is automated, the remaining tasks before releasing are: 
+Since the majority of the actual release process is automated, the remaining tasks before releasing are:
 
--  correctly labeling **all** pull requests that have been merged since the last release
--  updating pull request titles so they make sense to our users
+- correctly labeling **all** pull requests that have been merged since the last release
+- updating pull request titles so they make sense to our users
 
 Some great information on why this is important can be found at [keepachangelog.com](https://keepachangelog.com/en/1.1.0/), but the overall
 guiding principle here is that changelogs are for humans, not machines.
 
 When reviewing merged PR's the labels to be used are:
 
-* breaking - Used when the PR is considered a breaking change.
-* enhancement - Used when the PR adds a new feature or enhancement.
-* bug - Used when the PR fixes a bug included in a previous release.
-* documentation - Used when the PR adds or updates documentation.
-* internal - Internal changes or things that don't fit in any other category.
+- breaking - Used when the PR is considered a breaking change.
+- enhancement - Used when the PR adds a new feature or enhancement.
+- bug - Used when the PR fixes a bug included in a previous release.
+- documentation - Used when the PR adds or updates documentation.
+- internal - Internal changes or things that don't fit in any other category.
 
 **Note:** `release-plan` requires that **all** PRs are labeled. If a PR doesn't fit in a category it's fine to label it as `internal`
 


### PR DESCRIPTION
with OIDC and all the newish stuff that's happened with NPM in the last year, we need to update release-plan's workflows so that releasing remains smooth / painless (just merge the preview PR)