### PR TITLE
ci(release): use GitHub App token for release-preview PRs

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -5,7 +5,7 @@ on:
       - main
       - master
   pull_request:
-    types: 
+    types:
       - labeled
 
 concurrency:
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: 'main'
+          ref: "main"
       # This will only cause the `check-plan` job to have a "command" of `release`
       # when the .release-plan.json file was changed on the last commit.
       - id: check-release
@@ -36,7 +36,7 @@ jobs:
     needs: check-plan
     permissions:
       contents: write
-      pull-requests: write   
+      pull-requests: write
     outputs:
       explanation: ${{ steps.explanation.outputs.text }}
     # only run on push event if plan wasn't updated (don't create a release plan when we're releasing)
@@ -50,24 +50,38 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wyvox/action-setup-pnpm@v3
-      
+
       - name: "Generate Explanation and Prep Changelogs"
         id: explanation
         run: |
           set -x
-          
+
           pnpm release-plan prepare
-          
+
           echo 'text<<EOF' >> $GITHUB_OUTPUT
           jq .description .release-plan.json -r >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: peter-evans/create-pull-request@v5
+      - uses: actions/create-github-app-token@v2
+        id: release-plan-token
         with:
+          app-id: ${{ secrets.RELEASE_PLAN_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLAN_APP_PRIVATE_KEY }}
+
+      - uses: peter-evans/create-pull-request@v8
+        with:
+          # Pull requests created with the default GITHUB_TOKEN don't
+          # trigger push/pull_request workflows, which means the
+          # release-preview PR can't satisfy main's required checks. A
+          # GitHub App token triggers CI and can produce verified bot-
+          # signed commits when `sign-commits` is enabled.
+          token: ${{ steps.release-plan-token.outputs.token }}
           commit-message: "Prepare Release using 'release-plan'"
-          author: "github-actions[bot] <github-actions-bot@users.noreply.github.com>"
+          # main requires signed commits. create-pull-request signs as
+          # the GitHub App's bot when using a GitHub App token.
+          sign-commits: true
           labels: "internal"
           branch: release-preview
           title: Prepare Release


### PR DESCRIPTION
Fix the release-preview PR path under the new `main` ruleset.

## Problem

`main` now requires:

- signed commits
- required checks (`Build`, `Tests`, `Tests (production)`, `Typecheck`, `Lint`)
- PR-based, linear history

Release preview PRs created by `peter-evans/create-pull-request` with the default `GITHUB_TOKEN` don't trigger `push` / `pull_request` workflows, so the generated `release-preview` PR never gets the required checks. The current release-preview PR (#146) confirms this: 0 checks, no workflow runs for `release-preview`, and merge state `BLOCKED`.

A plain PAT would trigger CI, but `create-pull-request` cannot bot-sign commits with a PAT. The action's docs say `sign-commits: true` works with `GITHUB_TOKEN` or GitHub App tokens.

## Fix

Generate a GitHub App installation token with `actions/create-github-app-token@v2`, then pass that token to `peter-evans/create-pull-request@v8` with `sign-commits: true`.

This should produce a normal branch push (so CI runs) and verified bot-signed commits (so the ruleset accepts the release-preview PR).

## Required secrets

- `RELEASE_PLAN_APP_ID`
- `RELEASE_PLAN_APP_PRIVATE_KEY`

The GitHub App needs at least:

- Contents: read/write
- Pull requests: read/write

Add Workflows: read/write too if release-preview PRs may ever include workflow file changes.

## Verification

- YAML parses locally.
- `actions/create-github-app-token@v2` and `peter-evans/create-pull-request@v8` tags exist.
- Pre-push hook passed: build, build-verify, lint, specs, specs-prod, types.

## Relation to #174

This is the focused prerequisite for #174's release-plan workflow update. It does not address npm trusted publishing / OIDC; that still needs separate npm-side confirmation for all published packages.
