### PR TITLE
test(pack): verify public package artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - run: pnpm build 
       - name: "Ensure Certain dependencies don't end up in the production bundles"
         run: node ./workspace/scripts/build-verify.js 
+      - name: "Verify public package artifacts"
+        run: pnpm test:workspace:pack
 
   test:
     name: "Tests"

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "prepack": "pnpm run build",
     "sort-deps": "node workspace/scripts/sort-package-json-deps.mjs",
     "test:workspace:lint": "turbo run lint --output-logs errors-only --log-prefix none",
+    "test:workspace:pack": "node workspace/scripts/verify-packed-public-packages.js",
     "test:workspace:prod": "STARBEAM_TEST_PROD=1 vitest --pool forks --run",
     "test:workspace:specs": "vitest --pool forks --run",
     "test:workspace:types": "turbo run typecheck --output-logs errors-only --log-prefix none",

--- a/packages/preact/preact-utils/package.json
+++ b/packages/preact/preact-utils/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/preact/preact/package.json
+++ b/packages/preact/preact/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/react/react/package.json
+++ b/packages/react/react/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/react/use-strict-lifecycle/package.json
+++ b/packages/react/use-strict-lifecycle/package.json
@@ -12,9 +12,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/universal/collections/package.json
+++ b/packages/universal/collections/package.json
@@ -12,9 +12,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/universal/core-utils/package.json
+++ b/packages/universal/core-utils/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/universal/core/package.json
+++ b/packages/universal/core/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/universal/debug/package.json
+++ b/packages/universal/debug/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/universal/interfaces/package.json
+++ b/packages/universal/interfaces/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/universal/modifier/package.json
+++ b/packages/universal/modifier/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/universal/reactive/package.json
+++ b/packages/universal/reactive/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/universal/renderer/package.json
+++ b/packages/universal/renderer/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/universal/resource/package.json
+++ b/packages/universal/resource/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@starbeam/resource",
+  "type": "module",
   "version": "0.0.0",
   "main": "index.ts",
   "types": "index.ts",
@@ -10,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/universal/runtime/package.json
+++ b/packages/universal/runtime/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/universal/service/package.json
+++ b/packages/universal/service/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@starbeam/service",
+  "type": "module",
   "version": "0.0.0",
   "main": "index.ts",
   "types": "index.ts",
@@ -10,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/universal/shared/package.json
+++ b/packages/universal/shared/package.json
@@ -12,9 +12,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/universal/tags/package.json
+++ b/packages/universal/tags/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/universal/universal/package.json
+++ b/packages/universal/universal/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/universal/verify/package.json
+++ b/packages/universal/verify/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/vue/vue/package.json
+++ b/packages/vue/vue/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/x/store/package.json
+++ b/packages/x/store/package.json
@@ -12,9 +12,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/packages/x/vanilla/package.json
+++ b/packages/x/vanilla/package.json
@@ -12,9 +12,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/workspace/@domtree/any/package.json
+++ b/workspace/@domtree/any/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/workspace/@domtree/browser/package.json
+++ b/workspace/@domtree/browser/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/workspace/@domtree/flavors/package.json
+++ b/workspace/@domtree/flavors/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/workspace/@domtree/interface/package.json
+++ b/workspace/@domtree/interface/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/workspace/@domtree/minimal/package.json
+++ b/workspace/@domtree/minimal/package.json
@@ -11,9 +11,9 @@
     "exports": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
-    "main": "dist/index.cjs",
+    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/workspace/scripts/verify-packed-public-packages.js
+++ b/workspace/scripts/verify-packed-public-packages.js
@@ -22,7 +22,18 @@ const packageJsonPaths = await globby("**/package.json", {
 
 const packages = await Promise.all(
   packageJsonPaths.map(async (path) => {
-    let manifest = JSON.parse(await readFile(path, "utf8"));
+    let manifest;
+
+    try {
+      manifest = JSON.parse(await readFile(path, "utf8"));
+    } catch (error) {
+      throw new Error(
+        `Failed to read or parse package.json at ${relative(root, path)}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      );
+    }
 
     return {
       dir: dirname(path),

--- a/workspace/scripts/verify-packed-public-packages.js
+++ b/workspace/scripts/verify-packed-public-packages.js
@@ -1,0 +1,181 @@
+import { existsSync, readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { globby } from "globby";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(currentDir, "../..");
+
+const packageJsonPaths = await globby("**/package.json", {
+  cwd: root,
+  absolute: true,
+  ignore: [
+    "**/.git/**",
+    "**/.yalc/**",
+    "**/coverage/**",
+    "**/dist/**",
+    "**/node_modules/**",
+  ],
+});
+
+const packages = await Promise.all(
+  packageJsonPaths.map(async (path) => {
+    let manifest = JSON.parse(await readFile(path, "utf8"));
+
+    return {
+      dir: dirname(path),
+      manifest,
+      path,
+    };
+  }),
+);
+
+const workspacePackages = packages.filter(({ manifest }) => manifest.name);
+const publicPackages = workspacePackages.filter(
+  ({ manifest }) => manifest.publishConfig && manifest.private !== true,
+);
+const privatePackageNames = new Set(
+  workspacePackages
+    .filter(({ manifest }) => manifest.private === true)
+    .map(({ manifest }) => manifest.name),
+);
+
+let errors = [];
+
+for (let pkg of publicPackages) {
+  validateManifest(pkg);
+  validateArtifacts(pkg);
+}
+
+if (errors.length > 0) {
+  for (let error of errors) {
+    console.error(`${error.package}: ${error.message}`);
+
+    if (error.file) {
+      console.error(`  file: ${relative(root, error.file)}`);
+    }
+  }
+
+  throw new Error("Public package artifact verification failed");
+}
+
+console.info(`Verified ${publicPackages.length} publishable packages.`);
+
+function validateManifest(pkg) {
+  let { manifest } = pkg;
+
+  for (let field of [
+    "dependencies",
+    "peerDependencies",
+    "optionalDependencies",
+  ]) {
+    let deps = manifest[field] ?? {};
+
+    for (let dep of Object.keys(deps)) {
+      if (privatePackageNames.has(dep)) {
+        fail(
+          pkg,
+          `published ${field} references private package ${dep}`,
+          pkg.path,
+        );
+      }
+    }
+  }
+
+  if (!manifest.publishConfig?.exports) {
+    fail(pkg, "publishConfig.exports is missing", pkg.path);
+  }
+
+  if (hasRuntimeEntrypoint(pkg) && !manifest.publishConfig?.main) {
+    fail(pkg, "publishConfig.main is missing", pkg.path);
+  }
+
+  if (!manifest.publishConfig?.types) {
+    fail(pkg, "publishConfig.types is missing", pkg.path);
+  }
+}
+
+function validateArtifacts(pkg) {
+  let files = new Set();
+  let { publishConfig } = pkg.manifest;
+
+  addPublishedFile(files, pkg, publishConfig?.main);
+  addPublishedFile(files, pkg, publishConfig?.types);
+  collectExportFiles(files, pkg, publishConfig?.exports);
+
+  for (let file of files) {
+    if (!existsSync(file)) {
+      // Several packages currently publish types from the root tsc output and
+      // type-only packages have no built JS. This verifier still checks every
+      // artifact that exists today, and later surface-reduction PRs can tighten
+      // missing-artifact checks package by package.
+      continue;
+    }
+
+    let content = readFileSync(file, "utf8");
+
+    for (let name of privatePackageNames) {
+      if (referencesPackage(content, name)) {
+        fail(
+          pkg,
+          `published artifact references private package ${name}`,
+          file,
+        );
+      }
+    }
+  }
+}
+
+function collectExportFiles(files, pkg, value) {
+  if (typeof value === "string") {
+    addPublishedFile(files, pkg, value);
+  } else if (Array.isArray(value)) {
+    for (let item of value) {
+      collectExportFiles(files, pkg, item);
+    }
+  } else if (value && typeof value === "object") {
+    for (let item of Object.values(value)) {
+      collectExportFiles(files, pkg, item);
+    }
+  }
+}
+
+function addPublishedFile(files, pkg, file) {
+  if (typeof file === "string" && file.startsWith("./")) {
+    files.add(resolve(pkg.dir, file));
+  }
+}
+
+function hasRuntimeEntrypoint(pkg) {
+  let { publishConfig } = pkg.manifest;
+
+  if (publishConfig?.main) {
+    return true;
+  }
+
+  return hasRuntimeExport(publishConfig?.exports);
+}
+
+function hasRuntimeExport(value) {
+  if (typeof value === "string") {
+    return /\.(?:c|m)?js$/.test(value);
+  } else if (Array.isArray(value)) {
+    return value.some(hasRuntimeExport);
+  } else if (value && typeof value === "object") {
+    return Object.entries(value).some(
+      ([key, item]) => key !== "types" && hasRuntimeExport(item),
+    );
+  } else {
+    return false;
+  }
+}
+
+function referencesPackage(content, name) {
+  return content.includes(`"${name}"`) || content.includes(`'${name}'`);
+}
+
+function fail(pkg, message, file) {
+  errors.push({ package: pkg.manifest.name, message, file });
+}

--- a/workspace/scripts/verify-packed-public-packages.js
+++ b/workspace/scripts/verify-packed-public-packages.js
@@ -88,6 +88,14 @@ function validateManifest(pkg) {
     fail(pkg, "publishConfig.exports is missing", pkg.path);
   }
 
+  if (hasRuntimeEntrypoint(pkg) && manifest.type !== "module") {
+    fail(pkg, "runtime package is missing type: module", pkg.path);
+  }
+
+  if (referencesCjs(manifest.publishConfig)) {
+    fail(pkg, "publishConfig references a CJS artifact", pkg.path);
+  }
+
   if (hasRuntimeEntrypoint(pkg) && !manifest.publishConfig?.main) {
     fail(pkg, "publishConfig.main is missing", pkg.path);
   }
@@ -174,6 +182,10 @@ function hasRuntimeExport(value) {
 
 function referencesPackage(content, name) {
   return content.includes(`"${name}"`) || content.includes(`'${name}'`);
+}
+
+function referencesCjs(value) {
+  return JSON.stringify(value).includes(".cjs");
 }
 
 function fail(pkg, message, file) {

--- a/workspace/scripts/verify-packed-public-packages.js
+++ b/workspace/scripts/verify-packed-public-packages.js
@@ -151,7 +151,7 @@ function collectExportFiles(files, pkg, value) {
 }
 
 function addPublishedFile(files, pkg, file) {
-  if (typeof file === "string" && file.startsWith("./")) {
+  if (isPackageRelativePath(file)) {
     files.add(resolve(pkg.dir, file));
   }
 }
@@ -186,6 +186,15 @@ function referencesPackage(content, name) {
 
 function referencesCjs(value) {
   return JSON.stringify(value).includes(".cjs");
+}
+
+function isPackageRelativePath(value) {
+  return (
+    typeof value === "string" &&
+    !value.startsWith("/") &&
+    !value.startsWith("node:") &&
+    !URL.canParse(value)
+  );
 }
 
 function fail(pkg, message, file) {


### PR DESCRIPTION
## Summary

This PR adds a release-surface safety check before we reshape packages for the next 0.9 release.

- Add a public package artifact verifier for publishable workspace packages.
- Fail when public manifests or existing published artifacts reference private workspace packages.
- Move public package metadata to ESM-only entrypoints (`type: module`, `exports`, `dist/index.js`).
- Enforce that public runtime packages do not advertise CJS artifacts.
- Run the verifier in CI after the production bundle guard.

## Validation

- `pnpm test:workspace:pack`
- `pnpm test:workspace:types`
- `pnpm test:workspace:lint`
- `pnpm build`
- `node workspace/scripts/build-verify.js`
