### PR TITLE
Mark vite-env private

### DIFF
--- a/@types/vite-env/package.json
+++ b/@types/vite-env/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "vite-env",
   "version": "1.0.0",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary
- mark the local vite-env type-support package private so it is not published

## Validation
- pnpm --filter vite-env test:types
- pnpm --filter vite-env test:lint
- pnpm --filter @starbeam/runtime test:types
- pnpm --filter @starbeam-workspace/test-utils test:types
- pnpm test:workspace:pack
- pnpm test:workspace:types
- pnpm test:workspace:lint