### PR TITLE
Configure pre-1.0 breaking releases as minors

### DIFF
--- a/packages/preact/preact-utils/package.json
+++ b/packages/preact/preact-utils/package.json
@@ -41,5 +41,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/preact/preact/package.json
+++ b/packages/preact/preact/package.json
@@ -58,5 +58,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/react/react/package.json
+++ b/packages/react/react/package.json
@@ -60,5 +60,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/react/use-strict-lifecycle/package.json
+++ b/packages/react/use-strict-lifecycle/package.json
@@ -47,5 +47,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/universal/collections/package.json
+++ b/packages/universal/collections/package.json
@@ -50,5 +50,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/universal/core-utils/package.json
+++ b/packages/universal/core-utils/package.json
@@ -29,5 +29,10 @@
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"
+  },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
   }
 }

--- a/packages/universal/core/package.json
+++ b/packages/universal/core/package.json
@@ -37,5 +37,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/universal/debug/package.json
+++ b/packages/universal/debug/package.json
@@ -56,5 +56,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/universal/interfaces/package.json
+++ b/packages/universal/interfaces/package.json
@@ -31,5 +31,10 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*"
+  },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
   }
 }

--- a/packages/universal/modifier/package.json
+++ b/packages/universal/modifier/package.json
@@ -44,5 +44,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/universal/reactive/package.json
+++ b/packages/universal/reactive/package.json
@@ -42,5 +42,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/universal/renderer/package.json
+++ b/packages/universal/renderer/package.json
@@ -43,5 +43,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/universal/resource/package.json
+++ b/packages/universal/resource/package.json
@@ -44,5 +44,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/universal/runtime/package.json
+++ b/packages/universal/runtime/package.json
@@ -45,5 +45,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/universal/service/package.json
+++ b/packages/universal/service/package.json
@@ -44,5 +44,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/universal/tags/package.json
+++ b/packages/universal/tags/package.json
@@ -40,5 +40,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/universal/universal/package.json
+++ b/packages/universal/universal/package.json
@@ -47,5 +47,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/universal/verify/package.json
+++ b/packages/universal/verify/package.json
@@ -38,5 +38,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/vue/vue/package.json
+++ b/packages/vue/vue/package.json
@@ -56,5 +56,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }

--- a/packages/x/store/package.json
+++ b/packages/x/store/package.json
@@ -36,5 +36,10 @@
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"
+  },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
   }
 }

--- a/packages/x/vanilla/package.json
+++ b/packages/x/vanilla/package.json
@@ -38,5 +38,10 @@
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"
+  },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
   }
 }

--- a/workspace/@domtree/any/package.json
+++ b/workspace/@domtree/any/package.json
@@ -31,5 +31,10 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*"
+  },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
   }
 }

--- a/workspace/@domtree/browser/package.json
+++ b/workspace/@domtree/browser/package.json
@@ -29,5 +29,10 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*"
+  },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
   }
 }

--- a/workspace/@domtree/flavors/package.json
+++ b/workspace/@domtree/flavors/package.json
@@ -31,5 +31,10 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*"
+  },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
   }
 }

--- a/workspace/@domtree/interface/package.json
+++ b/workspace/@domtree/interface/package.json
@@ -26,5 +26,10 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*"
+  },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
   }
 }

--- a/workspace/@domtree/minimal/package.json
+++ b/workspace/@domtree/minimal/package.json
@@ -29,5 +29,10 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*"
+  },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Configure public pre-1.0 packages so release-plan maps major impacts to minor version bumps.
- Preserve normal semver behavior for stable packages like `@starbeam/shared`.
- Keep breaking changelog semantics without treating the next release as 1.0 readiness.

## Validation

- Synthetic release-plan probe: `@starbeam/react` breaking => `0.8.9` to `0.9.0`
- Synthetic release-plan probe: `@domtree/any` breaking => `0.9.3` to `0.10.0`
- Synthetic release-plan probe: `@starbeam/shared` breaking => `1.3.7` to `2.0.0`
- `pnpm test:workspace:pack`
- `pnpm test:workspace:types`
- `pnpm test:workspace:lint`
