### PR TITLE
Configure shared breaking releases as minors

### DIFF
--- a/packages/universal/shared/package.json
+++ b/packages/universal/shared/package.json
@@ -36,5 +36,10 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md"
-  ]
+  ],
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "minor"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Configure `@starbeam/shared` so release-plan maps major impacts to minor version bumps.
- Preserve `@starbeam/shared` as the cross-version compatibility substrate rather than allowing broad historical `breaking` labels to force `2.0.0`.

## Validation

- Synthetic release-plan probe: `@starbeam/shared` breaking => `1.3.7` to `1.4.0`
- `pnpm test:workspace:pack`
- `pnpm --filter @starbeam/shared test:types`
- `pnpm --filter @starbeam/shared test:lint`
- `pnpm test:workspace:types`
- `pnpm test:workspace:lint`
