### PR TITLE
Inline preact-utils internals into preact

### DIFF
--- a/packages/preact/preact-utils/package.json
+++ b/packages/preact/preact-utils/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@starbeam/preact-utils",
   "type": "module",
   "version": "0.8.9",
@@ -7,17 +8,8 @@
   "exports": {
     "default": "./index.ts"
   },
-  "publishConfig": {
-    "exports": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
-  },
   "starbeam": {
-    "type": "library:public"
+    "type": "library:private"
   },
   "scripts": {
     "build": "rollup -c",
@@ -35,16 +27,5 @@
   },
   "peerDependencies": {
     "preact": ">=10"
-  },
-  "files": [
-    "dist",
-    "README.md",
-    "CHANGELOG.md",
-    "LICENSE.md"
-  ],
-  "release-plan": {
-    "semverIncrementAs": {
-      "major": "minor"
-    }
   }
 }

--- a/packages/preact/preact/package.json
+++ b/packages/preact/preact/package.json
@@ -35,7 +35,6 @@
     "@starbeam/core-utils": "workspace:^",
     "@starbeam/debug": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
-    "@starbeam/preact-utils": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/renderer": "workspace:^",
     "@starbeam/resource": "workspace:^",

--- a/packages/preact/preact/src/frame.ts
+++ b/packages/preact/preact/src/frame.ts
@@ -1,6 +1,5 @@
 import { getLast } from "@starbeam/core-utils";
 import type { Description, FormulaTag } from "@starbeam/interfaces";
-import type { InternalComponent } from "@starbeam/preact-utils";
 import type {
   FinalizedFormula,
   InitializingTrackingFrame,
@@ -10,6 +9,8 @@ import type { Unsubscribe } from "@starbeam/runtime";
 import { render, RUNTIME } from "@starbeam/runtime";
 import { initializeFormulaTag } from "@starbeam/tags";
 import { expected, isPresent, verify } from "@starbeam/verify";
+
+import type { InternalComponent } from "./preact-internals/internals/component.js";
 
 export class ComponentFrame {
   static readonly #frames = new WeakMap<InternalComponent, ComponentFrame>();

--- a/packages/preact/preact/src/options.ts
+++ b/packages/preact/preact/src/options.ts
@@ -1,14 +1,12 @@
-import type {
-  InternalComponent,
-  InternalElement,
-} from "@starbeam/preact-utils";
-import { Plugin } from "@starbeam/preact-utils";
 import { DEBUG, isReactive } from "@starbeam/reactive";
 import { CONTEXT } from "@starbeam/runtime";
 import { finalize } from "@starbeam/shared";
 import type { ComponentType } from "preact";
 
 import { ComponentFrame } from "./frame.js";
+import type { InternalComponent } from "./preact-internals/internals/component.js";
+import type { InternalElement } from "./preact-internals/internals/elements.js";
+import { Plugin } from "./preact-internals/plugin.js";
 
 export const STARBEAM = Symbol("STARBEAM");
 

--- a/packages/preact/preact/src/preact-internals/inspect.ts
+++ b/packages/preact/preact/src/preact-internals/inspect.ts
@@ -1,0 +1,46 @@
+export type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JSONValue[]
+  | { [key: string]: JSONValue };
+
+interface DisplayStructOptions {
+  readonly description: JSONValue;
+}
+
+export function DisplayStruct(
+  name: string,
+  fields: Record<PropertyKey, unknown>,
+  options?: DisplayStructOptions,
+): object {
+  let displayName = name;
+
+  if (options?.description) {
+    displayName = `${displayName} [${
+      typeof options.description === "string"
+        ? options.description
+        : JSON.stringify(options.description)
+    }]`;
+  }
+
+  const constructor = class {};
+  Object.defineProperty(constructor, "name", { value: displayName });
+  const object = new constructor();
+
+  for (const [key, value] of entries(fields)) {
+    Object.defineProperty(object, key, {
+      value,
+      enumerable: true,
+    });
+  }
+
+  return object;
+}
+
+type Entries<R extends object> = { [P in keyof R]: [P, R[P]] }[keyof R];
+
+function entries<R extends object>(object: R): Entries<R>[] {
+  return Object.entries(object) as Entries<R>[];
+}

--- a/packages/preact/preact/src/preact-internals/inspect.ts
+++ b/packages/preact/preact/src/preact-internals/inspect.ts
@@ -17,7 +17,7 @@ export function DisplayStruct(
 ): object {
   let displayName = name;
 
-  if (options?.description) {
+  if (options && options.description !== undefined) {
     displayName = `${displayName} [${
       typeof options.description === "string"
         ? options.description

--- a/packages/preact/preact/src/preact-internals/interfaces.ts
+++ b/packages/preact/preact/src/preact-internals/interfaces.ts
@@ -1,8 +1,11 @@
 import type { ComponentChild, Options } from "preact";
 
 import type { InternalPreactComponent } from "./internals/component.js";
+import type { InternalPreactElement } from "./internals/elements.js";
 import type { InternalPreactVNode } from "./internals/vnode.js";
 import type { HOOK_NAMES } from "./plugin.js";
+
+export type { InternalPreactElement } from "./internals/elements.js";
 
 export interface RawPreactOptions extends Options {
   _hook?: Hook<
@@ -56,20 +59,6 @@ export const DIFF = "_diff";
 export const RENDER = "_render";
 export const CATCH_ERROR = "_catchError";
 export const ROOT = "_root";
-
-export interface InternalPreactElement extends HTMLElement {
-  /** children */
-  __k?: InternalPreactVNode | null;
-  /** Event listeners to support event delegation */
-  l?: Record<string, (e: Event) => void>;
-
-  // Preact uses this attribute to detect SVG nodes
-  ownerSVGElement?: SVGElement | null;
-
-  // style: HTMLElement["style"]; // From HTMLElement
-
-  data?: string | number; // From Text node
-}
 
 export interface InternalEffect {
   _sources: object | undefined;

--- a/packages/preact/preact/src/preact-internals/interfaces.ts
+++ b/packages/preact/preact/src/preact-internals/interfaces.ts
@@ -1,0 +1,93 @@
+import type { ComponentChild, Options } from "preact";
+
+import type { InternalPreactComponent } from "./internals/component.js";
+import type { InternalPreactVNode } from "./internals/vnode.js";
+import type { HOOK_NAMES } from "./plugin.js";
+
+export interface RawPreactOptions extends Options {
+  _hook?: Hook<
+    [component: InternalPreactComponent, index: number, type: number]
+  >;
+  __h?: Hook<[component: InternalPreactComponent, index: number, type: number]>;
+
+  _catchError?: CatchErrorHook;
+  __e?: CatchErrorHook;
+
+  _root?: RootHook;
+  __?: RootHook;
+
+  _diff?: Hook;
+  __b?: Hook;
+  _render?: Hook;
+  __r?: Hook;
+
+  _commit?: Hook;
+  __c?: Hook;
+}
+
+export type MangledHookNames = (typeof HOOK_NAMES)[keyof typeof HOOK_NAMES];
+export type PrivateHookNames = keyof typeof HOOK_NAMES;
+
+type Hook<Args extends unknown[] = [vnode: InternalPreactVNode]> = (
+  ...args: Args
+) => void;
+
+type RootHook = Hook<[child: ComponentChild, parent: InternalPreactElement]>;
+
+type CatchErrorHook = Hook<
+  [
+    error: Error,
+    vnode: InternalPreactVNode,
+    oldVNode: InternalPreactVNode,
+    errorInfo: Record<PropertyKey, unknown>,
+  ]
+>;
+
+export const PREACT_HOOK_NAMES = {
+  _hook: "__h",
+  _diff: "__b",
+  _render: "__r",
+  _catchError: "__e",
+  _root: "__",
+} as const;
+
+export const HOOK = "_hook";
+export const DIFF = "_diff";
+export const RENDER = "_render";
+export const CATCH_ERROR = "_catchError";
+export const ROOT = "_root";
+
+export interface InternalPreactElement extends HTMLElement {
+  /** children */
+  __k?: InternalPreactVNode | null;
+  /** Event listeners to support event delegation */
+  l?: Record<string, (e: Event) => void>;
+
+  // Preact uses this attribute to detect SVG nodes
+  ownerSVGElement?: SVGElement | null;
+
+  // style: HTMLElement["style"]; // From HTMLElement
+
+  data?: string | number; // From Text node
+}
+
+export interface InternalEffect {
+  _sources: object | undefined;
+  _start: () => () => void;
+  _callback: () => void;
+  _dispose: () => void;
+}
+
+export interface InternalSource {
+  fileName: string;
+  lineNumber: number;
+}
+
+/*
+  eslint-disable-next-line @typescript-eslint/no-explicit-any --
+  this is the most general type of function and is at least
+  a little bit better than `Function`. We can keep refining
+  it if we come up with better ideas, but this lint is intended
+  to absorb many other lints.
+*/
+export type AnyFn = (...args: any[]) => any;

--- a/packages/preact/preact/src/preact-internals/internals.ts
+++ b/packages/preact/preact/src/preact-internals/internals.ts
@@ -1,0 +1,44 @@
+import type { ComponentChild, Options } from "preact";
+
+import type {
+  MangledHookNames,
+  PrivateHookNames,
+  RawPreactOptions,
+} from "./interfaces.js";
+import type { InternalPreactVNode } from "./internals/vnode.js";
+
+export interface HookName {
+  dev: string;
+  prod: string;
+}
+
+export type PreactOptionName = keyof Options | PrivateHookNames;
+export type MangledPreactOptionName = keyof Options | MangledHookNames;
+
+type Req<T> = {
+  [P in keyof T]-?: T[P] extends infer U | undefined ? U : T[P];
+};
+
+export type PreactHook<T extends PreactOptionName> = Req<RawPreactOptions>[T];
+
+type Primitive = string | number | bigint | boolean | null | undefined;
+
+export function isProbablyVNode(
+  child: ComponentChild,
+): child is InternalPreactVNode {
+  const candidate = child as
+    | InternalPreactVNode
+    | Record<PropertyKey, unknown>
+    | Primitive;
+
+  if (candidate && typeof candidate === "object") {
+    const type = typeof candidate.type;
+    return (
+      (type === "string" || type === "function") &&
+      candidate.__k !== undefined &&
+      candidate.__c !== undefined
+    );
+  } else {
+    return false;
+  }
+}

--- a/packages/preact/preact/src/preact-internals/internals/component.ts
+++ b/packages/preact/preact/src/preact-internals/internals/component.ts
@@ -1,0 +1,167 @@
+import { objectHasKeys } from "@starbeam/core-utils";
+import type { Component, ComponentType } from "preact";
+
+import { DisplayStruct } from "../inspect.js";
+import type { InternalEffect, InternalPreactElement } from "../interfaces.js";
+import type { InternalPreactVNode } from "./vnode.js";
+import { InternalVNode } from "./vnode.js";
+
+const COMPONENTS = new WeakMap<InternalPreactComponent, InternalComponent>();
+const INITIAL_ID = 0;
+
+interface Handlers {
+  prePaint: Set<() => void>;
+  postPaint: Set<() => void>;
+}
+
+export class InternalComponent {
+  readonly #component: InternalPreactComponent;
+  readonly id: number;
+
+  static #nextId = INITIAL_ID;
+
+  static is(value: unknown): value is InternalComponent {
+    return !!(
+      value &&
+      typeof value === "object" &&
+      value instanceof InternalComponent
+    );
+  }
+
+  static from(
+    component: InternalPreactComponent | InternalComponent | null | undefined,
+  ): InternalComponent | null | undefined {
+    if (InternalComponent.is(component)) {
+      return component;
+    } else if (component) {
+      return InternalComponent.of(component);
+    } else {
+      return component;
+    }
+  }
+
+  static of(component: InternalPreactComponent): InternalComponent {
+    let wrapper = COMPONENTS.get(component);
+
+    if (!wrapper) {
+      wrapper = new InternalComponent(component);
+      COMPONENTS.set(component, wrapper);
+    }
+
+    return wrapper;
+  }
+
+  readonly #handlers: Handlers = {
+    prePaint: new Set(),
+    postPaint: new Set(),
+  };
+
+  private constructor(component: InternalPreactComponent) {
+    this.#component = component;
+    this.id = InternalComponent.#nextId++;
+  }
+
+  readonly on = {
+    idle: (fn: () => void): void => void this.#handlers.postPaint.add(fn),
+    layout: (fn: () => void): void => void this.#handlers.prePaint.add(fn),
+  };
+
+  run(phase: keyof Handlers): void {
+    this.#handlers[phase].forEach((fn) => void fn());
+  }
+
+  get lifetime(): InternalPreactComponent {
+    return this.#component;
+  }
+
+  get fn(): ComponentType<unknown> | string {
+    return this.vnode.type as ComponentType<unknown> | string;
+  }
+
+  get props(): InternalPreactComponent["props"] {
+    return this.#component.props;
+  }
+
+  get state(): InternalPreactComponent["state"] {
+    return this.#component.state;
+  }
+
+  get context(): Record<PropertyKey, unknown> {
+    const context = this.#component.context as unknown;
+
+    if (typeof context !== "object" || context === null) {
+      throw Error(
+        `UNEXPECTED: Expected context to be an object, got ${
+          context === null ? "null" : typeof context
+        }`,
+      );
+    }
+
+    return context as Record<PropertyKey, unknown>;
+  }
+
+  set context(value: unknown) {
+    this.#component.context = value;
+  }
+
+  get vnode(): InternalVNode {
+    return InternalVNode.of(this.#component[KEYS._vnode]);
+  }
+
+  get parentDOM(): InternalPreactElement | undefined | null {
+    return this.#component[KEYS._parentDom];
+  }
+
+  get updater(): InternalEffect | undefined {
+    return this.#component[KEYS["signals._updater"]];
+  }
+
+  get updateFlags(): number {
+    return this.#component[KEYS["signals._updateFlags"]];
+  }
+
+  [Symbol.for("nodejs.util.inspect.custom")](): object {
+    const propsFields: Partial<{ props: unknown }> = {};
+    const stateFields: Partial<{ state: unknown }> = {};
+
+    if (objectHasKeys(this.#component.props)) {
+      propsFields.props = this.#component.props;
+    }
+
+    if (objectHasKeys(this.#component.state)) {
+      stateFields.state = this.#component.state;
+    }
+
+    return DisplayStruct(
+      "InternalComponent",
+      {
+        vnode: this.vnode,
+        context: this.context,
+        ...propsFields,
+        ...stateFields,
+      },
+      { description: String(this.id) },
+    );
+  }
+
+  notify = (): void => void this.#component.forceUpdate();
+}
+
+const KEYS = {
+  _vnode: "__v",
+  _parentDom: "__P",
+  _parent: "__",
+  "signals._updater": "__$u",
+  "signals._updateFlags": "__$f",
+} as const;
+
+export interface InternalPreactComponent extends Component<unknown, unknown> {
+  /** the vnode */
+  __v: InternalPreactVNode;
+  /** the parent DOM */
+  __P?: InternalPreactElement | null;
+  __?: InternalPreactComponent;
+  __$u?: InternalEffect;
+  __$f: number;
+  __c?: boolean;
+}

--- a/packages/preact/preact/src/preact-internals/internals/elements.ts
+++ b/packages/preact/preact/src/preact-internals/internals/elements.ts
@@ -1,0 +1,84 @@
+import { DisplayStruct } from "../inspect.js";
+import type { InternalPreactVNode } from "./vnode.js";
+import { InternalVNode } from "./vnode.js";
+
+const INITIAL_ID = 0;
+const ELEMENTS = new WeakMap<InternalPreactElement, InternalElement>();
+
+export class InternalElement {
+  static #nextId = INITIAL_ID;
+
+  static of(element: InternalPreactElement): InternalElement {
+    let internalElement = ELEMENTS.get(element);
+
+    if (!internalElement) {
+      internalElement = new InternalElement(element);
+      ELEMENTS.set(element, internalElement);
+    }
+
+    return internalElement;
+  }
+
+  readonly #id: number;
+  readonly #element: InternalPreactElement;
+
+  private constructor(element: InternalPreactElement) {
+    this.#id = InternalElement.#nextId++;
+    this.#element = element;
+  }
+
+  [Symbol.for("nodejs.util.inspect.custom")](): object {
+    const optionalFields: {
+      listeners?: PreactEventListeners;
+      children?: InternalVNode;
+    } = {};
+
+    const listeners = this.listeners;
+    if (listeners) {
+      optionalFields.listeners = listeners;
+    }
+
+    const children = this.children;
+    if (children) {
+      optionalFields.children = children;
+    }
+
+    return DisplayStruct(
+      "InternalElement",
+      {
+        element: `${this.#element.tagName.toLowerCase()}`,
+        ...optionalFields,
+      },
+      { description: `#${this.#id}` },
+    );
+  }
+
+  get children(): InternalVNode | null | undefined {
+    return InternalVNode.from(this.#element[PREACT_ELEMENT_KEYS._children]);
+  }
+
+  get listeners(): PreactEventListeners | undefined {
+    return this.#element[PREACT_ELEMENT_KEYS._listeners];
+  }
+}
+
+const PREACT_ELEMENT_KEYS = {
+  _children: "__k",
+  _listeners: "l",
+} as const;
+
+type PreactEventListeners = Record<string, (e: Event) => void>;
+
+export interface InternalPreactElement extends HTMLElement {
+  /** children */
+  __k?: InternalPreactVNode | null;
+  /** Event listeners to support event delegation */
+  l?: PreactEventListeners;
+
+  // Preact uses this attribute to detect SVG nodes
+  ownerSVGElement?: SVGElement | null;
+
+  // style: HTMLElement["style"]; // From HTMLElement
+
+  data?: string | number; // From Text node
+}

--- a/packages/preact/preact/src/preact-internals/internals/hooks.ts
+++ b/packages/preact/preact/src/preact-internals/internals/hooks.ts
@@ -1,0 +1,45 @@
+// Hook types are indexed starting at 1 in preact internals, so slot 0 is
+// intentionally empty.
+const HOOK_NAMES = [
+  // eslint-disable-next-line no-sparse-arrays -- intentional: slot 0 unused
+  ,
+  "useState",
+  "useReducer",
+  "useEffect",
+  "useLayoutEffect",
+  "useRef",
+  "useImperativeHandle",
+  "useMemo",
+  "useCallback",
+  "useContext",
+  "useErrorBoundary",
+  "useDebugvalue",
+] as const;
+
+type HookName = NonNullable<(typeof HOOK_NAMES)[number]>;
+
+export class HookType {
+  readonly #type: number;
+
+  static of(type: number): HookType {
+    return new HookType(type);
+  }
+
+  private constructor(type: number) {
+    this.#type = type;
+  }
+
+  /**
+   * This is not currently used in the Starbeam codebase, because
+   * the Starbeam codebase doesn't use the `hook` option.
+   *
+   * However, it is part of the complete enumeration of Preact
+   * features and will be important once this library is announced
+   * for general use.
+   *
+   * @public
+   */
+  is(name: HookName): boolean {
+    return HOOK_NAMES[this.#type] === name;
+  }
+}

--- a/packages/preact/preact/src/preact-internals/internals/vnode.ts
+++ b/packages/preact/preact/src/preact-internals/internals/vnode.ts
@@ -1,0 +1,312 @@
+import type {
+  ComponentChild,
+  ComponentChildren,
+  ComponentType,
+  VNode,
+} from "preact";
+import { Fragment } from "preact";
+
+import { DisplayStruct } from "../inspect.js";
+import type { InternalPreactElement, InternalSource } from "../interfaces.js";
+import { isProbablyVNode } from "../internals.js";
+import type { InternalPreactComponent } from "./component.js";
+import { InternalComponent } from "./component.js";
+
+const BUILTINS = new Set<ComponentType>([Fragment]);
+
+const INITIAL_ID = 0;
+
+export class InternalVNode {
+  readonly #delete = {
+    parent: (): void => {
+      delete this.#vnode[KEYS._parent];
+    },
+
+    depth: (): void => {
+      delete this.#vnode[KEYS._depth];
+    },
+  } as const;
+
+  readonly id: number;
+  readonly #vnode: InternalPreactVNode;
+
+  static #nextId = INITIAL_ID;
+
+  static is(value: unknown): value is InternalVNode {
+    return !!(
+      value &&
+      typeof value === "object" &&
+      value instanceof InternalVNode
+    );
+  }
+
+  static of(this: void, vnode: InternalPreactVNode): InternalVNode {
+    return new InternalVNode(vnode);
+  }
+
+  static from(node: InternalVNode | InternalPreactVNode | VNode): InternalVNode;
+  static from(node: IntoInternalVNode): InternalVNode | null | undefined;
+  static from(node: IntoInternalVNode): InternalVNode | null | undefined {
+    if (InternalVNode.is(node)) {
+      return node;
+    } else if (node) {
+      return new InternalVNode(node as InternalPreactVNode);
+    } else {
+      return node;
+    }
+  }
+
+  static asPreact(
+    vnode: InternalVNode | InternalPreactVNode | VNode,
+  ): InternalPreactVNode;
+  static asPreact(
+    vnode: IntoInternalVNode,
+  ): InternalPreactVNode | null | undefined;
+  static asPreact(
+    vnode: IntoInternalVNode,
+  ): InternalPreactVNode | null | undefined {
+    if (InternalVNode.is(vnode)) {
+      return vnode.#vnode;
+    } else {
+      return vnode as InternalPreactVNode;
+    }
+  }
+
+  private constructor(vnode: InternalPreactVNode) {
+    this.#vnode = vnode;
+    this.id = InternalVNode.#nextId++;
+  }
+
+  get raw(): InternalPreactVNode {
+    return this.#vnode;
+  }
+
+  get type(): VNode["type"] {
+    return this.#vnode.type;
+  }
+
+  get props(): VNode["props"] {
+    return this.#vnode.props;
+  }
+
+  get source(): InternalSource | null | undefined {
+    return this.#vnode[KEYS.__source];
+  }
+
+  set source(value: InternalSource | null | undefined) {
+    this.#vnode[KEYS.__source] = value;
+  }
+
+  get self(): unknown {
+    return this.#vnode[KEYS.__self];
+  }
+
+  set self(value: unknown) {
+    this.#vnode[KEYS.__self] = value;
+  }
+
+  get children(): WrappedComponentChildren {
+    const children = this.#vnode.props.children;
+
+    return mapChildren(children, wrapVNodeChild);
+  }
+
+  get dom(): Element | Text | undefined {
+    return this.#vnode[KEYS._dom];
+  }
+
+  get owner(): InternalVNode | null | undefined {
+    return InternalVNode.from(this.#vnode[KEYS._owner]);
+  }
+
+  set owner(vnode: IntoInternalVNode) {
+    this.#vnode[KEYS._owner] = InternalVNode.asPreact(vnode);
+  }
+
+  get component(): InternalComponent | null | undefined {
+    const component = this.#vnode[KEYS._component];
+    return component ? InternalComponent.of(component) : component;
+  }
+
+  get parent(): InternalVNode | null | undefined {
+    return InternalVNode.from(this.#vnode[KEYS._parent]);
+  }
+
+  get vnodeChildren(): InternalVNode[] | undefined {
+    const children = this.#vnode[KEYS._children];
+
+    if (children) {
+      return children.map(InternalVNode.of);
+    } else {
+      return undefined;
+    }
+  }
+
+  get signalProps(): Record<string, unknown> | null | undefined {
+    return this.#vnode[KEYS["signals._signalProps"]];
+  }
+
+  get delete(): { readonly parent: () => void; readonly depth: () => void } {
+    return this.#delete;
+  }
+
+  [Symbol.for("nodejs.util.inspect.custom")](): object {
+    let type: unknown;
+    const internalType = this.#vnode.type;
+
+    const childrenFields: Partial<{ vnodes: unknown; children: unknown }> = {};
+
+    if (this.vnodeChildren) {
+      childrenFields.vnodes = this.vnodeChildren.map((vnode) => vnode.id);
+    }
+
+    if (this.props.children) {
+      childrenFields.children = mapChildren(this.props.children, (c) => {
+        switch (typeof c) {
+          case "string":
+          case "number":
+            return c;
+          default:
+            if (isProbablyVNode(c)) {
+              return InternalVNode.of(c);
+            } else {
+              return c;
+            }
+        }
+      });
+    }
+
+    if (internalType === Fragment) {
+      type = "{Fragment}";
+    } else if (typeof internalType === "string") {
+      type = `<${internalType}>`;
+    } else {
+      type = internalType;
+    }
+
+    return DisplayStruct(
+      `InternalVNode`,
+      {
+        type,
+        ...childrenFields,
+      },
+      { description: this.id },
+    );
+  }
+
+  processChildren(process: (prev: ComponentChild) => ComponentChild): boolean {
+    const props = this.#vnode.props;
+    const children = props.children;
+
+    let updated = false;
+
+    if (children) {
+      if (Array.isArray(children)) {
+        const out: ComponentChild[] = [];
+
+        for (const child of children) {
+          const processed = process(child as ComponentChild);
+          out.push(processed);
+          updated ||= processed !== child;
+        }
+
+        props.children = out;
+      } else {
+        props.children = process(children);
+        updated = props.children !== children;
+      }
+    }
+
+    return updated;
+  }
+}
+
+export type IntoInternalVNode =
+  | InternalVNode
+  | InternalPreactVNode
+  | VNode
+  | null
+  | undefined;
+
+const KEYS = {
+  __source: "__source",
+  __self: "__self",
+  _parentDom: "__P",
+  _owner: "__o",
+  _children: "__k",
+  _component: "__c",
+  _parent: "__",
+  _dom: "__e",
+  _depth: "__b",
+  "signals._signalProps": "__np",
+} as const;
+
+export interface InternalPreactVNode<P = unknown> extends preact.VNode<P> {
+  __source?: InternalSource | null | undefined;
+  __self?: unknown;
+
+  /** The parent DOM */
+  __P?: InternalPreactElement | null | undefined;
+  /** The component's owner */
+  __o?: InternalPreactVNode | null | undefined;
+  /** The component's children */
+  __k: InternalPreactVNode[] | null;
+  /** The component instance for this VNode */
+  __c?: InternalPreactComponent | null | undefined;
+  /** The parent VNode */
+  __?: InternalPreactVNode | undefined;
+  /** The DOM node for this VNode */
+  __e?: Element | Text | undefined;
+  /** The depth of the vnode */
+  __b?: number | null | undefined;
+  /**
+   * Props that had Signal values before diffing (used after diffing to
+   * subscribe)
+   */
+  __np?: Record<string, unknown> | null | undefined;
+}
+
+export function isUserspaceComponent(
+  vnode: InternalPreactVNode | VNode,
+): vnode is InternalPreactVNode & { __c: InternalPreactComponent } {
+  return (
+    typeof vnode.type === "function" &&
+    !BUILTINS.has(vnode.type) &&
+    hasVNodeComponent(vnode as InternalPreactVNode)
+  );
+}
+
+function hasVNodeComponent(vnode: InternalPreactVNode): boolean {
+  return !!vnode.__c;
+}
+
+export function getVNodeComponent<N extends InternalPreactVNode>(
+  vnode: N,
+): N["__c"] {
+  return vnode.__c;
+}
+
+function mapChildren<T>(
+  children: ComponentChildren,
+  mapper: (child: ComponentChild) => T,
+): T | T[] {
+  if (Array.isArray(children)) {
+    return children.map(mapper);
+  } else {
+    return mapper(children);
+  }
+}
+
+type WrappedComponentChildren = WrappedComponentChild | WrappedComponentChild[];
+
+type WrappedComponentChild =
+  | Exclude<ComponentChild, VNode | InternalPreactVNode>
+  | InternalVNode;
+
+function wrapVNodeChild(child: ComponentChild): WrappedComponentChild {
+  if (isProbablyVNode(child)) {
+    return InternalVNode.of(child);
+  } else {
+    return child;
+  }
+}

--- a/packages/preact/preact/src/preact-internals/plugin.ts
+++ b/packages/preact/preact/src/preact-internals/plugin.ts
@@ -1,0 +1,344 @@
+import type { Options } from "preact";
+
+import type { AnyFn, RawPreactOptions } from "./interfaces.js";
+import type {
+  MangledPreactOptionName,
+  PreactHook,
+  PreactOptionName,
+} from "./internals.js";
+import { isProbablyVNode } from "./internals.js";
+import { InternalComponent } from "./internals/component.js";
+import { InternalElement } from "./internals/elements.js";
+import { HookType } from "./internals/hooks.js";
+import {
+  getVNodeComponent,
+  InternalVNode,
+  isUserspaceComponent,
+} from "./internals/vnode.js";
+
+export function Plugin(
+  updater: (callback: AugmentPreact) => void,
+): (options: RawPreactOptions) => void {
+  return (options) => {
+    updater(new AugmentPreact(options));
+  };
+}
+
+export class AugmentPreact {
+  readonly component: AugmentPreactAsComponent;
+  readonly #original: RawPreactOptions;
+
+  constructor(original: RawPreactOptions) {
+    this.#original = original;
+    this.component = new AugmentPreactAsComponent(original);
+  }
+
+  root(hook: (vnode: InternalVNode, parent: InternalElement) => void): void {
+    createHook(this.#original, "_root", (vnode, parent) => {
+      if (isProbablyVNode(vnode)) {
+        hook(InternalVNode.from(vnode), InternalElement.of(parent));
+      }
+    });
+  }
+
+  unroot(hook: (parent: InternalElement) => void): void {
+    createHook(this.#original, "_root", (vnode, parent) => {
+      if (vnode === null) {
+        hook(InternalElement.of(parent));
+      }
+    });
+  }
+
+  /**
+   * Whenever a vnode is created, this hook gives you an opportunity to rewrite
+   * the vnode before it's otherwise used by Preact.
+   */
+  vnode(hook: (vnode: InternalVNode, handler: Handler) => void): void {
+    createHook(this.#original, "vnode", (vnode, handler) => {
+      hook(InternalVNode.from(vnode), handler);
+    });
+  }
+
+  /**
+   * This plugin hook is called whenever a Hook is created.
+   */
+  hook(
+    hook: (
+      options: {
+        component: InternalComponent;
+        index: number;
+        type: HookType;
+      },
+      handler: Handler,
+    ) => void,
+  ): void {
+    createHook(this.#original, "_hook", (component, index, type, handler) => {
+      hook(
+        {
+          component: InternalComponent.of(component),
+          index,
+          type: HookType.of(type),
+        },
+        handler,
+      );
+    });
+  }
+
+  /**
+   * This plugin hook is called before a vnode is rendered. If you need to wrap
+   * the call to the vnode's render function, this is where you can start the
+   * wrapping.
+   *
+   * For example, Starbeam uses this hook to start a tracking frame.
+   */
+  willRender(hook: (vnode: InternalVNode, handler: Handler) => void): void {
+    createHook(this.#original, "_render", (vnode, handler) => {
+      hook(InternalVNode.of(vnode), handler);
+    });
+  }
+
+  diff(hook: (vnode: InternalVNode, handler: Handler) => void): void {
+    createHook(this.#original, "_diff", (vnode, handler) => {
+      hook(InternalVNode.of(vnode), handler);
+    });
+  }
+
+  /**
+   * This plugin hook is called after a vnode is rendered and diffed, but
+   * before anything else happens. If you started wrapping rendering in
+   * `render`, you should end it here.
+   */
+  didRender(hook: (vnode: InternalVNode, handler: Handler) => void): void {
+    createHook(this.#original, "diffed", (vnode, handler) => {
+      hook(InternalVNode.from(vnode), handler);
+    });
+  }
+
+  /**
+   * This plugin hook is called whenever a vnode is unmounted from the DOM.
+   *
+   * If you set something up in `render` or `diffed` that needs to be cleaned
+   * up, this is the place to do it.
+   */
+  unmount(hook: (vnode: InternalVNode, handler: Handler) => void): void {
+    createHook(this.#original, "unmount", (vnode, handler) => {
+      hook(InternalVNode.from(vnode), handler);
+    });
+  }
+
+  catchError(
+    hook: (
+      options: {
+        error: unknown;
+        vnode: InternalVNode;
+        oldVNode: InternalVNode;
+        errorInfo: Record<PropertyKey, unknown>;
+      },
+      handler: Handler,
+    ) => void,
+  ): void {
+    createHook(
+      this.#original,
+      "_catchError",
+      (error, vnode, oldVNode, errorInfo, handler) => {
+        hook(
+          {
+            error,
+            vnode: InternalVNode.of(vnode),
+            oldVNode: InternalVNode.of(oldVNode),
+            errorInfo,
+          },
+          handler,
+        );
+      },
+    );
+  }
+}
+
+function createHook<
+  K extends PreactOptionName,
+  V extends AnyFn = PreactHook<K>,
+>(
+  originalOptions: RawPreactOptions,
+  hookName: K,
+  hook: (...args: [...args: Parameters<V>, handler: Handler]) => void,
+): void {
+  const [originalFn, mangled] = getOriginal(originalOptions, hookName);
+
+  originalOptions[mangled] = ((...args: HookParams<K>) => {
+    const handler = AugmentHandler.create(
+      hookName,
+      originalFn && (() => originalFn(...args)),
+    );
+
+    hook(...args, handler);
+
+    AugmentHandler.finish(handler);
+  }) as AnyFn;
+}
+
+function getOriginal(
+  original: RawPreactOptions,
+  name: PreactOptionName,
+): [
+  fn: ((...args: unknown[]) => unknown) | undefined,
+  mangled: MangledPreactOptionName,
+] {
+  const mangled = getHookName(name);
+
+  return [original[mangled] as AnyFn, mangled];
+}
+
+export const HOOK_NAMES = {
+  _hook: "__h",
+  _diff: "__b",
+  _commit: "__c",
+  _render: "__r",
+  _catchError: "__e",
+  _root: "__",
+} as const;
+
+type HookNames = typeof HOOK_NAMES;
+type HookName = keyof HookNames;
+type MangledHookName = HookNames[HookName];
+
+function getHookName(name: PreactOptionName): MangledHookName | keyof Options {
+  if (name in HOOK_NAMES) {
+    return HOOK_NAMES[name as HookName];
+  } else if (name.startsWith("_")) {
+    throw Error(`Unknown hook name: ${name}`);
+  } else {
+    return name as keyof Options;
+  }
+}
+
+type HookParams<K extends PreactOptionName> = RawPreactOptions[K] extends AnyFn
+  ? Parameters<RawPreactOptions[K]>
+  : never;
+
+interface Handler {
+  original: () => void;
+  override: () => void;
+}
+
+const NOOP = (): void => {
+  /* noop */
+};
+
+class Noop implements Handler {
+  original = NOOP;
+  override = NOOP;
+
+  constructor(readonly name: string) {}
+}
+
+export const HOOK_SUPER = {
+  _diff: "after",
+  _render: "before",
+  diffed: "before",
+  _commit: "after",
+  unmount: "before",
+} as const;
+
+class AugmentHandler<F extends AnyFn> implements Handler {
+  static create<F extends AnyFn>(
+    name: string,
+    original: F | undefined,
+  ): AugmentHandler<F> | Noop {
+    if (original === undefined) {
+      return new Noop(name);
+    }
+    const handler = new AugmentHandler(name, original);
+
+    if (
+      name in HOOK_SUPER &&
+      (HOOK_SUPER as Record<string, string>)[name] === "before"
+    ) {
+      handler.original();
+    }
+
+    return handler;
+  }
+
+  static finish(handler: AugmentHandler<AnyFn> | Noop): void {
+    if (handler instanceof AugmentHandler) {
+      if (!handler.#handled) {
+        handler.original();
+      }
+    }
+  }
+
+  #handled = false;
+  readonly #original: F;
+
+  private constructor(_name: string, original: F) {
+    this.#original = original;
+  }
+
+  original(): void {
+    this.#original();
+    this.#handled = true;
+  }
+
+  override(): void {
+    this.#handled = true;
+  }
+}
+
+export class AugmentPreactAsComponent {
+  readonly #original: RawPreactOptions;
+
+  constructor(original: RawPreactOptions) {
+    this.#original = original;
+  }
+
+  willRender(hook: (vnode: InternalComponent, handler: Handler) => void): void {
+    createHook(this.#original, "_render", (vnode, handler) => {
+      if (isUserspaceComponent(vnode)) {
+        hook(InternalComponent.of(getVNodeComponent(vnode)), handler);
+      }
+    });
+  }
+
+  diff(hook: (vnode: InternalComponent, handler: Handler) => void): void {
+    createHook(this.#original, "_diff", (vnode, handler) => {
+      if (isUserspaceComponent(vnode)) {
+        hook(InternalComponent.of(getVNodeComponent(vnode)), handler);
+      }
+    });
+  }
+
+  afterPaint(hook: (vnode: InternalComponent, handler: Handler) => void): void {
+    createHook(this.#original, "diffed", (vnode, handler) => {
+      if (isUserspaceComponent(vnode)) {
+        hook(InternalComponent.of(getVNodeComponent(vnode)), handler);
+      }
+    });
+  }
+
+  beforePaint(
+    hook: (vnode: InternalComponent, handler: Handler) => void,
+  ): void {
+    createHook(this.#original, "diffed", (vnode, handler) => {
+      if (isUserspaceComponent(vnode)) {
+        hook(InternalComponent.of(getVNodeComponent(vnode)), handler);
+      }
+    });
+  }
+
+  didRender(hook: (vnode: InternalComponent, handler: Handler) => void): void {
+    createHook(this.#original, "_commit", (vnode, handler) => {
+      if (isUserspaceComponent(vnode)) {
+        hook(InternalComponent.of(getVNodeComponent(vnode)), handler);
+      }
+    });
+  }
+
+  unmount(hook: (vnode: InternalComponent, handler: Handler) => void): void {
+    createHook(this.#original, "unmount", (vnode, handler) => {
+      if (isUserspaceComponent(vnode)) {
+        hook(InternalComponent.of(getVNodeComponent(vnode)), handler);
+      }
+    });
+  }
+}

--- a/packages/preact/preact/src/renderer.ts
+++ b/packages/preact/preact/src/renderer.ts
@@ -1,4 +1,3 @@
-import type { InternalComponent } from "@starbeam/preact-utils";
 import type {
   ComponentScheduler,
   Handler,
@@ -13,6 +12,7 @@ import {
 } from "preact/hooks";
 
 import { getCurrentComponent } from "./options.js";
+import type { InternalComponent } from "./preact-internals/internals/component.js";
 
 export const MANAGER = {
   getComponent: () => getCurrentComponent(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,9 +167,6 @@ importers:
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../../universal/interfaces
-      '@starbeam/preact-utils':
-        specifier: workspace:^
-        version: link:../preact-utils
       '@starbeam/reactive':
         specifier: workspace:^
         version: link:../../universal/reactive


### PR DESCRIPTION
## Summary

- Move the Preact private-shape utilities into `@starbeam/preact` internals.
- Remove the public `@starbeam/preact` dependency on `@starbeam/preact-utils`.
- Mark `@starbeam/preact-utils` private and remove its publish metadata.

## Validation

- `pnpm --filter @starbeam/preact build`
- `pnpm --filter @starbeam/preact test:types`
- `pnpm exec vitest --pool forks --run packages/preact/preact/tests`
- `pnpm --filter @starbeam/preact test:lint`
- `pnpm test:workspace:pack` => `Verified 26 publishable packages.`
- `pnpm test:workspace:types`
- `pnpm test:workspace:lint`
- `grep -R "@starbeam/preact-utils" packages/preact/preact/dist dist/types/packages/preact/preact packages/preact/preact/package.json || true`
