### PR TITLE
Tighten release surface verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - run: pnpm build 
       - name: "Ensure Certain dependencies don't end up in the production bundles"
         run: node ./workspace/scripts/build-verify.js 
+      - name: "Verify public package artifacts"
+        run: pnpm test:workspace:pack
 
   test:
     name: "Tests"
@@ -66,10 +68,6 @@ jobs:
       # (which means we'll have a lot of extra errors
       #  if something core doesn't pass type checking)
       - run: ./node_modules/.bin/turbo run test:types --continue 
-      - name: "Build package artifacts"
-        run: pnpm build
-      - name: "Verify public package artifacts"
-        run: pnpm test:workspace:pack
 
   lint:
     name: "Lint"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: package-dist
+          path: .
       - name: "Restore package artifacts"
         run: tar -xzf package-dist.tgz
       - name: "Verify public package artifacts"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
       - run: pnpm build 
       - name: "Ensure Certain dependencies don't end up in the production bundles"
         run: node ./workspace/scripts/build-verify.js 
-      - name: "Verify public package artifacts"
-        run: pnpm test:workspace:pack
 
   test:
     name: "Tests"
@@ -68,6 +66,8 @@ jobs:
       # (which means we'll have a lot of extra errors
       #  if something core doesn't pass type checking)
       - run: ./node_modules/.bin/turbo run test:types --continue 
+      - name: "Verify public package artifacts"
+        run: pnpm test:workspace:pack
 
   lint:
     name: "Lint"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
   typecheck:
     name: "Typecheck"
     runs-on: "ubuntu-latest"
-    needs: ["install_dependencies"]
+    needs: ["install_dependencies", "build"]
     steps:
       - uses: wyvox/action@v1
         with:
@@ -66,6 +66,8 @@ jobs:
       # (which means we'll have a lot of extra errors
       #  if something core doesn't pass type checking)
       - run: ./node_modules/.bin/turbo run test:types --continue 
+      - name: "Build package artifacts"
+        run: pnpm build
       - name: "Verify public package artifacts"
         run: pnpm test:workspace:pack
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
-      - run: pnpm build 
+      - run: pnpm build
       - name: "Ensure Certain dependencies don't end up in the production bundles"
-        run: node ./workspace/scripts/build-verify.js 
-      - name: "Verify public package artifacts"
-        run: pnpm test:workspace:pack
+        run: node ./workspace/scripts/build-verify.js
+      - name: "Archive package artifacts"
+        run: find packages -path '*/dist' -type d -prune -print | tar -czf package-dist.tgz -T -
+      - uses: actions/upload-artifact@v4
+        with:
+          name: package-dist
+          path: package-dist.tgz
+          retention-days: 1
 
   test:
     name: "Tests"
@@ -63,11 +68,18 @@ jobs:
       - uses: wyvox/action@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      # --continue will keep running test:types 
+      # --continue will keep running test:types
       # even if dependencies of packages have failed
       # (which means we'll have a lot of extra errors
       #  if something core doesn't pass type checking)
-      - run: ./node_modules/.bin/turbo run test:types --continue 
+      - run: ./node_modules/.bin/turbo run test:types --continue
+      - uses: actions/download-artifact@v4
+        with:
+          name: package-dist
+      - name: "Restore package artifacts"
+        run: tar -xzf package-dist.tgz
+      - name: "Verify public package artifacts"
+        run: pnpm test:workspace:pack
 
   lint:
     name: "Lint"
@@ -77,5 +89,4 @@ jobs:
       - uses: wyvox/action@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./node_modules/.bin/turbo run test:lint --continue 
-
+      - run: ./node_modules/.bin/turbo run test:lint --continue

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,5 +25,7 @@ pre-push:
       run: pnpm ci:prod
     types:
       run: pnpm test:workspace:types
+    pack:
+      run: pnpm test:workspace:pack
     lint:
       run: pnpm test:workspace:lint

--- a/packages/universal/interfaces/package.json
+++ b/packages/universal/interfaces/package.json
@@ -9,11 +9,8 @@
   },
   "publishConfig": {
     "exports": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
+      "types": "./dist/index.d.ts"
     },
-    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/workspace/@domtree/any/package.json
+++ b/workspace/@domtree/any/package.json
@@ -9,11 +9,8 @@
   },
   "publishConfig": {
     "exports": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
+      "types": "./dist/index.d.ts"
     },
-    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/workspace/@domtree/browser/package.json
+++ b/workspace/@domtree/browser/package.json
@@ -9,11 +9,8 @@
   },
   "publishConfig": {
     "exports": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
+      "types": "./dist/index.d.ts"
     },
-    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/workspace/@domtree/flavors/package.json
+++ b/workspace/@domtree/flavors/package.json
@@ -9,11 +9,8 @@
   },
   "publishConfig": {
     "exports": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
+      "types": "./dist/index.d.ts"
     },
-    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/workspace/@domtree/interface/package.json
+++ b/workspace/@domtree/interface/package.json
@@ -9,11 +9,8 @@
   },
   "publishConfig": {
     "exports": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
+      "types": "./dist/index.d.ts"
     },
-    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/workspace/@domtree/minimal/package.json
+++ b/workspace/@domtree/minimal/package.json
@@ -9,11 +9,8 @@
   },
   "publishConfig": {
     "exports": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
+      "types": "./dist/index.d.ts"
     },
-    "main": "dist/index.js",
     "types": "dist/index.d.ts"
   },
   "starbeam": {

--- a/workspace/scripts/verify-packed-public-packages.js
+++ b/workspace/scripts/verify-packed-public-packages.js
@@ -1,12 +1,13 @@
 import { existsSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { dirname, relative, resolve } from "node:path";
+import { basename, dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { globby } from "globby";
+import { globby, globbySync } from "globby";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const root = resolve(currentDir, "../..");
+const rootTypesDir = resolve(root, "dist/types");
 
 const packageJsonPaths = await globby("**/package.json", {
   cwd: root,
@@ -117,53 +118,216 @@ function validateManifest(pkg) {
 }
 
 function validateArtifacts(pkg) {
-  let files = new Set();
+  let artifacts = new Map();
   let { publishConfig } = pkg.manifest;
+  let scannedFiles = new Set();
 
-  addPublishedFile(files, pkg, publishConfig?.main);
-  addPublishedFile(files, pkg, publishConfig?.types);
-  collectExportFiles(files, pkg, publishConfig?.exports);
+  addPublishedArtifact(artifacts, pkg, publishConfig?.main, "js");
+  addPublishedArtifact(artifacts, pkg, publishConfig?.types, "types");
+  collectExportArtifacts(artifacts, pkg, publishConfig?.exports);
 
-  for (let file of files) {
-    if (!existsSync(file)) {
-      // Several packages currently publish types from the root tsc output and
-      // type-only packages have no built JS. This verifier still checks every
-      // artifact that exists today, and later surface-reduction PRs can tighten
-      // missing-artifact checks package by package.
+  for (let artifact of artifacts.values()) {
+    let file = resolvePublishedArtifact(pkg, artifact);
+
+    if (!file) {
       continue;
     }
 
-    let content = readFileSync(file, "utf8");
+    scanFileForPrivateReferences(pkg, file, scannedFiles);
+  }
 
-    for (let name of privatePackageNames) {
-      if (referencesPackage(content, name)) {
-        fail(
-          pkg,
-          `published artifact references private package ${name}`,
-          file,
-        );
-      }
+  for (let file of findPackageDistJavaScript(pkg)) {
+    scanFileForPrivateReferences(pkg, file, scannedFiles);
+  }
+
+  for (let file of findRootDeclarations(pkg)) {
+    scanFileForPrivateReferences(pkg, file, scannedFiles);
+    validateDeclarationMap(pkg, file);
+  }
+}
+
+function resolvePublishedArtifact(pkg, artifact) {
+  if (existsSync(artifact.file)) {
+    return artifact.file;
+  }
+
+  if (artifact.kind === "types") {
+    let rootDeclaration = rootDeclarationForPackageArtifact(pkg, artifact.file);
+
+    if (rootDeclaration && existsSync(rootDeclaration)) {
+      return rootDeclaration;
+    }
+
+    fail(
+      pkg,
+      `declared types artifact is missing: ${artifact.specifier}`,
+      artifact.file,
+    );
+  } else if (artifact.kind === "js" && buildsJavaScript(pkg)) {
+    fail(
+      pkg,
+      `declared JS artifact is missing: ${artifact.specifier}`,
+      artifact.file,
+    );
+  }
+
+  return undefined;
+}
+
+function scanFileForPrivateReferences(pkg, file, scannedFiles) {
+  if (scannedFiles.has(file) || !existsSync(file)) {
+    return;
+  }
+
+  scannedFiles.add(file);
+
+  let content = readFileSync(file, "utf8");
+
+  for (let name of privatePackageNames) {
+    if (referencesPackage(content, name)) {
+      fail(pkg, `published artifact references private package ${name}`, file);
     }
   }
 }
 
-function collectExportFiles(files, pkg, value) {
+function collectExportArtifacts(artifacts, pkg, value, kindHint) {
   if (typeof value === "string") {
-    addPublishedFile(files, pkg, value);
+    addPublishedArtifact(artifacts, pkg, value, kindHint);
   } else if (Array.isArray(value)) {
     for (let item of value) {
-      collectExportFiles(files, pkg, item);
+      collectExportArtifacts(artifacts, pkg, item, kindHint);
     }
   } else if (value && typeof value === "object") {
-    for (let item of Object.values(value)) {
-      collectExportFiles(files, pkg, item);
+    for (let [key, item] of Object.entries(value)) {
+      collectExportArtifacts(
+        artifacts,
+        pkg,
+        item,
+        key === "types" ? "types" : kindHint,
+      );
     }
   }
 }
 
-function addPublishedFile(files, pkg, file) {
-  if (isPackageRelativePath(file)) {
-    files.add(resolve(pkg.dir, file));
+function addPublishedArtifact(artifacts, pkg, specifier, kindHint) {
+  if (isPackageRelativePath(specifier)) {
+    let file = resolve(pkg.dir, specifier);
+    let kind = kindHint ?? artifactKind(specifier);
+
+    artifacts.set(`${kind}:${file}`, { file, kind, specifier });
+  }
+}
+
+function artifactKind(file) {
+  if (isDeclarationFile(file)) {
+    return "types";
+  } else if (/\.(?:c|m)?js$/.test(file)) {
+    return "js";
+  } else {
+    return "other";
+  }
+}
+
+function rootDeclarationForPackageArtifact(pkg, file) {
+  let packageRelativePath = relative(pkg.dir, file);
+
+  if (!packageRelativePath.startsWith("dist/")) {
+    return undefined;
+  }
+
+  return resolve(
+    rootTypesDir,
+    relative(root, pkg.dir),
+    packageRelativePath.slice("dist/".length),
+  );
+}
+
+function findPackageDistJavaScript(pkg) {
+  return globbySync("dist/**/*.js", {
+    cwd: pkg.dir,
+    absolute: true,
+    onlyFiles: true,
+  });
+}
+
+function findRootDeclarations(pkg) {
+  let declarationsRoot = resolve(rootTypesDir, relative(root, pkg.dir));
+
+  if (!existsSync(declarationsRoot)) {
+    return [];
+  }
+
+  return globbySync(["**/*.d.ts", "**/*.d.mts", "**/*.d.cts"], {
+    cwd: declarationsRoot,
+    absolute: true,
+    onlyFiles: true,
+  }).filter((file) => shouldScanRootDeclaration(declarationsRoot, file));
+}
+
+function shouldScanRootDeclaration(declarationsRoot, file) {
+  let relativePath = relative(declarationsRoot, file);
+  let segments = relativePath.split(/[\\/]/u);
+  let fileName = basename(file);
+  let ignoredSegments = new Set([
+    "__tests__",
+    "bench",
+    "benches",
+    "spec",
+    "specs",
+    "test",
+    "tests",
+  ]);
+
+  if (segments.slice(0, -1).some((segment) => ignoredSegments.has(segment))) {
+    return false;
+  }
+
+  return !(
+    fileName.startsWith("_test") ||
+    fileName.startsWith("rollup.config.d.") ||
+    /\.(?:spec|test)\.d\.[cm]?ts$/u.test(fileName)
+  );
+}
+
+function validateDeclarationMap(pkg, declarationFile) {
+  let mapFile = `${declarationFile}.map`;
+
+  if (!existsSync(mapFile)) {
+    return;
+  }
+
+  let map;
+
+  try {
+    map = JSON.parse(readFileSync(mapFile, "utf8"));
+  } catch (error) {
+    fail(
+      pkg,
+      `declaration map could not be parsed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      mapFile,
+    );
+
+    return;
+  }
+
+  let sourceRoot = typeof map.sourceRoot === "string" ? map.sourceRoot : "";
+
+  for (let source of map.sources ?? []) {
+    if (typeof source !== "string" || URL.canParse(source)) {
+      continue;
+    }
+
+    let sourcePath = resolve(dirname(mapFile), sourceRoot, source);
+
+    if (!existsSync(sourcePath)) {
+      fail(
+        pkg,
+        `declaration map references missing source ${source}`,
+        mapFile,
+      );
+    }
   }
 }
 
@@ -175,6 +339,10 @@ function hasRuntimeEntrypoint(pkg) {
   }
 
   return hasRuntimeExport(publishConfig?.exports);
+}
+
+function buildsJavaScript(pkg) {
+  return pkg.manifest.scripts?.build === "rollup -c";
 }
 
 function hasRuntimeExport(value) {
@@ -192,7 +360,9 @@ function hasRuntimeExport(value) {
 }
 
 function referencesPackage(content, name) {
-  return content.includes(`"${name}"`) || content.includes(`'${name}'`);
+  return new RegExp(`["']${escapeRegExp(name)}(?:/[^"']*)?["']`, "u").test(
+    content,
+  );
 }
 
 function referencesCjs(value) {
@@ -206,6 +376,14 @@ function isPackageRelativePath(value) {
     !value.startsWith("node:") &&
     !URL.canParse(value)
   );
+}
+
+function isDeclarationFile(file) {
+  return /\.d\.[cm]?ts$/u.test(file);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 function fail(pkg, message, file) {

--- a/workspace/scripts/verify-packed-public-packages.js
+++ b/workspace/scripts/verify-packed-public-packages.js
@@ -229,7 +229,7 @@ function artifactKind(file) {
 }
 
 function rootDeclarationForPackageArtifact(pkg, file) {
-  let packageRelativePath = relative(pkg.dir, file);
+  let packageRelativePath = posixPath(relative(pkg.dir, file));
 
   if (!packageRelativePath.startsWith("dist/")) {
     return undefined;
@@ -322,11 +322,7 @@ function validateDeclarationMap(pkg, declarationFile) {
     let sourcePath = resolve(dirname(mapFile), sourceRoot, source);
 
     if (!existsSync(sourcePath)) {
-      fail(
-        pkg,
-        `declaration map references missing source ${source}`,
-        mapFile,
-      );
+      fail(pkg, `declaration map references missing source ${source}`, mapFile);
     }
   }
 }
@@ -384,6 +380,10 @@ function isDeclarationFile(file) {
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function posixPath(path) {
+  return path.replace(/\\/gu, "/");
 }
 
 function fail(pkg, message, file) {

--- a/workspace/scripts/verify-packed-public-packages.js
+++ b/workspace/scripts/verify-packed-public-packages.js
@@ -108,6 +108,10 @@ function validateManifest(pkg) {
     fail(pkg, "publishConfig references a CJS artifact", pkg.path);
   }
 
+  if (isTypeOnlyPackage(pkg) && hasRuntimeEntrypoint(pkg)) {
+    fail(pkg, "type-only package declares a runtime artifact", pkg.path);
+  }
+
   if (hasRuntimeEntrypoint(pkg) && !manifest.publishConfig?.main) {
     fail(pkg, "publishConfig.main is missing", pkg.path);
   }
@@ -163,7 +167,7 @@ function resolvePublishedArtifact(pkg, artifact) {
       `declared types artifact is missing: ${artifact.specifier}`,
       artifact.file,
     );
-  } else if (artifact.kind === "js" && buildsJavaScript(pkg)) {
+  } else if (artifact.kind === "js") {
     fail(
       pkg,
       `declared JS artifact is missing: ${artifact.specifier}`,
@@ -337,8 +341,8 @@ function hasRuntimeEntrypoint(pkg) {
   return hasRuntimeExport(publishConfig?.exports);
 }
 
-function buildsJavaScript(pkg) {
-  return pkg.manifest.scripts?.build === "rollup -c";
+function isTypeOnlyPackage(pkg) {
+  return pkg.manifest.starbeam?.type === "library:interfaces";
 }
 
 function hasRuntimeExport(value) {


### PR DESCRIPTION
## Summary

- Resolve declared package types from root `dist/types` output when package-local declarations are absent.
- Scan generated root declarations and existing package-local `dist/**/*.js` artifacts for private package references.
- Validate scanned declaration maps point at existing sources, while skipping test/bench/spec/rollup-config declarations.
- Require declared JS artifacts only for public packages that currently build JS with `rollup -c`.

## Validation

- `pnpm build`
- `pnpm test:workspace:types`
- `pnpm test:workspace:pack`
- `node workspace/scripts/verify-packed-public-packages.js`
- `pnpm test:workspace:lint`
- pre-commit: `pnpm test:workspace:lint`, `pnpm test:workspace:types`

## Notes

- Cleaned stale ignored declaration-map outputs for deleted React sources before rerunning the verifier; no generated `dist` files are included in the commit.
- Left untracked docs out of this PR.
