### PR TITLE
Make verify an internal package

### DIFF
--- a/packages/preact/preact-testing-utils/package.json
+++ b/packages/preact/preact-testing-utils/package.json
@@ -21,13 +21,13 @@
     "test:types": "tsc -b"
   },
   "dependencies": {
-    "@starbeam/verify": "workspace:^",
     "@starbeam-workspace/test-utils": "workspace:^",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/preact": "^3.2.4",
     "htm": "^3.1.1"
   },
   "devDependencies": {
+    "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "preact-render-to-string": "^6.6.7",
     "rollup": "^4.60.1"

--- a/packages/preact/preact/package.json
+++ b/packages/preact/preact/package.json
@@ -42,10 +42,10 @@
     "@starbeam/service": "workspace:^",
     "@starbeam/shared": "workspace:^",
     "@starbeam/tags": "workspace:^",
-    "@starbeam/universal": "workspace:^",
-    "@starbeam/verify": "workspace:^"
+    "@starbeam/universal": "workspace:^"
   },
   "devDependencies": {
+    "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"
   },

--- a/packages/react/react/package.json
+++ b/packages/react/react/package.json
@@ -41,10 +41,10 @@
     "@starbeam/shared": "workspace:^",
     "@starbeam/universal": "workspace:^",
     "@starbeam/use-strict-lifecycle": "workspace:^",
-    "@starbeam/verify": "workspace:^",
     "scheduler": "^0.27.0"
   },
   "devDependencies": {
+    "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "@types/node": "^22.19.17",
     "@types/react": "^19.2.14",

--- a/packages/react/test-utils/package.json
+++ b/packages/react/test-utils/package.json
@@ -28,10 +28,10 @@
     "@starbeam/debug": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
-    "@starbeam/verify": "workspace:^",
     "@starbeam-workspace/test-utils": "workspace:^"
   },
   "devDependencies": {
+    "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",

--- a/packages/universal/collections/package.json
+++ b/packages/universal/collections/package.json
@@ -38,10 +38,10 @@
     "@starbeam/shared": "workspace:^",
     "@starbeam/tags": "workspace:^",
     "@starbeam/universal": "workspace:^",
-    "@starbeam/verify": "workspace:^",
     "@swc/helpers": "^0.5.21"
   },
   "devDependencies": {
+    "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"
   },

--- a/packages/universal/debug/package.json
+++ b/packages/universal/debug/package.json
@@ -41,12 +41,12 @@
     "@starbeam/reactive": "workspace:^",
     "@starbeam/shared": "workspace:^",
     "@starbeam/tags": "workspace:^",
-    "@starbeam/verify": "workspace:^",
     "buffer": "^6.0.3",
     "inspect-utils": "^1.0.1",
     "stacktracey": "^2.2.0"
   },
   "devDependencies": {
+    "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "@types/node": "^22.19.17",
     "rollup": "^4.60.1"

--- a/packages/universal/modifier/package.json
+++ b/packages/universal/modifier/package.json
@@ -31,11 +31,11 @@
     "@starbeam/reactive": "workspace:^",
     "@starbeam/shared": "workspace:^",
     "@starbeam/tags": "workspace:^",
-    "@starbeam/universal": "workspace:^",
-    "@starbeam/verify": "workspace:^"
+    "@starbeam/universal": "workspace:^"
   },
   "devDependencies": {
     "@domtree/flavors": "workspace:^",
+    "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"
   },

--- a/packages/universal/reactive/package.json
+++ b/packages/universal/reactive/package.json
@@ -30,10 +30,10 @@
     "@starbeam/core-utils": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/shared": "workspace:^",
-    "@starbeam/tags": "workspace:^",
-    "@starbeam/verify": "workspace:^"
+    "@starbeam/tags": "workspace:^"
   },
   "devDependencies": {
+    "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"
   },

--- a/packages/universal/resource/package.json
+++ b/packages/universal/resource/package.json
@@ -32,10 +32,10 @@
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/runtime": "workspace:^",
-    "@starbeam/shared": "workspace:^",
-    "@starbeam/verify": "workspace:^"
+    "@starbeam/shared": "workspace:^"
   },
   "devDependencies": {
+    "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"
   },

--- a/packages/universal/runtime/package.json
+++ b/packages/universal/runtime/package.json
@@ -32,10 +32,10 @@
     "@starbeam/reactive": "workspace:^",
     "@starbeam/shared": "workspace:^",
     "@starbeam/tags": "workspace:^",
-    "@starbeam/verify": "workspace:^",
     "inspect-utils": "^1.0.1"
   },
   "devDependencies": {
+    "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1",
     "vite-env": "workspace:^"

--- a/packages/universal/universal/package.json
+++ b/packages/universal/universal/package.json
@@ -35,10 +35,10 @@
     "@starbeam/runtime": "workspace:^",
     "@starbeam/shared": "workspace:^",
     "@starbeam/tags": "workspace:^",
-    "@starbeam/verify": "workspace:^",
     "inspect-utils": "^1.0.1"
   },
   "devDependencies": {
+    "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"
   },

--- a/packages/universal/verify/package.json
+++ b/packages/universal/verify/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@starbeam/verify",
   "type": "module",
   "version": "0.8.9",
@@ -7,21 +8,11 @@
   "exports": {
     "default": "./index.ts"
   },
-  "publishConfig": {
-    "exports": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
-  },
   "starbeam": {
-    "type": "library:public"
+    "type": "library:internal"
   },
   "scripts": {
     "build": "rollup -c",
-    "prepack": "pnpm build",
     "test:lint": "eslint . --max-warnings 0",
     "test:specs": "vitest --run --pool forks",
     "test:types": "tsc -b"
@@ -32,16 +23,5 @@
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"
-  },
-  "files": [
-    "dist",
-    "README.md",
-    "CHANGELOG.md",
-    "LICENSE.md"
-  ],
-  "release-plan": {
-    "semverIncrementAs": {
-      "major": "minor"
-    }
   }
 }

--- a/packages/universal/verify/tests/package.json
+++ b/packages/universal/verify/tests/package.json
@@ -22,8 +22,8 @@
     "test:lint": "eslint . --max-warnings 0",
     "test:types": "tsc -b"
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "@starbeam/verify": "workspace:^"
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/vue/vue-testing-utils/package.json
+++ b/packages/vue/vue-testing-utils/package.json
@@ -23,12 +23,12 @@
   "dependencies": {
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/shared": "workspace:^",
-    "@starbeam/verify": "workspace:^",
     "@starbeam-workspace/test-utils": "workspace:^",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/vue": "^8.1.0"
   },
   "devDependencies": {
+    "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "@vue/shared": "^3.5.32",
     "rollup": "^4.60.1"

--- a/packages/vue/vue/package.json
+++ b/packages/vue/vue/package.json
@@ -41,10 +41,10 @@
     "@starbeam/service": "workspace:^",
     "@starbeam/shared": "workspace:^",
     "@starbeam/tags": "workspace:^",
-    "@starbeam/universal": "workspace:^",
-    "@starbeam/verify": "workspace:^"
+    "@starbeam/universal": "workspace:^"
   },
   "devDependencies": {
+    "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"
   },

--- a/packages/x/store/tests/package.json
+++ b/packages/x/store/tests/package.json
@@ -14,8 +14,9 @@
   "dependencies": {
     "@faker-js/faker": "^10.4.0",
     "@starbeam/universal": "workspace:^",
-    "@starbeam/verify": "workspace:^",
     "@starbeamx/store": "workspace:^"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@starbeam/verify": "workspace:^"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,9 +191,6 @@ importers:
       '@starbeam/universal':
         specifier: workspace:^
         version: link:../../universal/universal
-      '@starbeam/verify':
-        specifier: workspace:^
-        version: link:../../universal/verify
       preact:
         specifier: 10.29.1
         version: 10.29.1
@@ -201,6 +198,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../../universal/verify
       rollup:
         specifier: ^4.60.1
         version: 4.60.1
@@ -210,9 +210,6 @@ importers:
       '@starbeam-workspace/test-utils':
         specifier: workspace:^
         version: link:../../../workspace/test-utils
-      '@starbeam/verify':
-        specifier: workspace:^
-        version: link:../../universal/verify
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -229,6 +226,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../../universal/verify
       preact-render-to-string:
         specifier: ^6.6.7
         version: 6.6.7(preact@10.29.1)
@@ -413,9 +413,6 @@ importers:
       '@starbeam/use-strict-lifecycle':
         specifier: workspace:^
         version: link:../use-strict-lifecycle
-      '@starbeam/verify':
-        specifier: workspace:^
-        version: link:../../universal/verify
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -429,6 +426,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../../universal/verify
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -495,9 +495,6 @@ importers:
       '@starbeam/shared':
         specifier: workspace:^
         version: link:../../universal/shared
-      '@starbeam/verify':
-        specifier: workspace:^
-        version: link:../../universal/verify
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -511,6 +508,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../../universal/verify
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -597,9 +597,6 @@ importers:
       '@starbeam/universal':
         specifier: workspace:^
         version: link:../universal
-      '@starbeam/verify':
-        specifier: workspace:^
-        version: link:../verify
       '@swc/helpers':
         specifier: ^0.5.21
         version: 0.5.21
@@ -607,6 +604,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../verify
       rollup:
         specifier: ^4.60.1
         version: 4.60.1
@@ -668,9 +668,6 @@ importers:
       '@starbeam/tags':
         specifier: workspace:^
         version: link:../tags
-      '@starbeam/verify':
-        specifier: workspace:^
-        version: link:../verify
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -684,6 +681,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../verify
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -733,9 +733,6 @@ importers:
       '@starbeam/universal':
         specifier: workspace:^
         version: link:../universal
-      '@starbeam/verify':
-        specifier: workspace:^
-        version: link:../verify
     devDependencies:
       '@domtree/flavors':
         specifier: workspace:^
@@ -743,6 +740,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../verify
       rollup:
         specifier: ^4.60.1
         version: 4.60.1
@@ -761,13 +761,13 @@ importers:
       '@starbeam/tags':
         specifier: workspace:^
         version: link:../tags
-      '@starbeam/verify':
-        specifier: workspace:^
-        version: link:../verify
     devDependencies:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../verify
       rollup:
         specifier: ^4.60.1
         version: 4.60.1
@@ -850,13 +850,13 @@ importers:
       '@starbeam/shared':
         specifier: workspace:^
         version: link:../shared
-      '@starbeam/verify':
-        specifier: workspace:^
-        version: link:../verify
     devDependencies:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../verify
       rollup:
         specifier: ^4.60.1
         version: 4.60.1
@@ -908,9 +908,6 @@ importers:
       '@starbeam/tags':
         specifier: workspace:^
         version: link:../tags
-      '@starbeam/verify':
-        specifier: workspace:^
-        version: link:../verify
       inspect-utils:
         specifier: ^1.0.1
         version: 1.0.1
@@ -918,6 +915,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../verify
       rollup:
         specifier: ^4.60.1
         version: 4.60.1
@@ -1085,9 +1085,6 @@ importers:
       '@starbeam/tags':
         specifier: workspace:^
         version: link:../tags
-      '@starbeam/verify':
-        specifier: workspace:^
-        version: link:../verify
       inspect-utils:
         specifier: ^1.0.1
         version: 1.0.1
@@ -1095,6 +1092,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../verify
       rollup:
         specifier: ^4.60.1
         version: 4.60.1
@@ -1135,7 +1135,7 @@ importers:
         version: 4.60.1
 
   packages/universal/verify/tests:
-    dependencies:
+    devDependencies:
       '@starbeam/verify':
         specifier: workspace:^
         version: link:..
@@ -1175,9 +1175,6 @@ importers:
       '@starbeam/universal':
         specifier: workspace:^
         version: link:../../universal/universal
-      '@starbeam/verify':
-        specifier: workspace:^
-        version: link:../../universal/verify
       vue:
         specifier: 3.5.32
         version: 3.5.32(typescript@6.0.3)
@@ -1185,6 +1182,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../../universal/verify
       rollup:
         specifier: ^4.60.1
         version: 4.60.1
@@ -1200,9 +1200,6 @@ importers:
       '@starbeam/shared':
         specifier: workspace:^
         version: link:../../universal/shared
-      '@starbeam/verify':
-        specifier: workspace:^
-        version: link:../../universal/verify
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -1216,6 +1213,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../../universal/verify
       '@vue/shared':
         specifier: ^3.5.32
         version: 3.5.32
@@ -1369,12 +1369,13 @@ importers:
       '@starbeam/universal':
         specifier: workspace:^
         version: link:../../../universal/universal
-      '@starbeam/verify':
-        specifier: workspace:^
-        version: link:../../../universal/verify
       '@starbeamx/store':
         specifier: workspace:^
         version: link:..
+    devDependencies:
+      '@starbeam/verify':
+        specifier: workspace:^
+        version: link:../../../universal/verify
 
   packages/x/vanilla:
     dependencies:

--- a/workspace/dev-compile/src/rollup/plugins/external.ts
+++ b/workspace/dev-compile/src/rollup/plugins/external.ts
@@ -195,9 +195,10 @@ import type { RollupPlugin } from "../utils.js";
  *
  * ## Development and Peer Dependencies
  *
- * Since development dependencies are not intended to be used at runtime, they
- * should never be imported from runtime code, and therefore should never be
- * included in the build.
+ * Development dependencies are normally build/test-only and should not be
+ * imported from runtime code. The exception is an internal implementation
+ * package that is always bundled into the published artifact instead of being
+ * left as a runtime dependency.
  *
  * Since peer dependencies are intended to be supplied by a dependent package
  * (i.e. the package including the package you are building), they are always
@@ -235,8 +236,12 @@ function external(pkg: PackageInfo, mode: 'development' | 'production' | undefin
       return INLINE;
     }
 
+    if (id === "@starbeam/verify" || id.startsWith("@starbeam/verify/")) {
+      return INLINE;
+    }
+
     if (mode === 'production') {
-      if (id.startsWith('@starbeam/debug') || id.startsWith('@starbeam/verify')) {
+      if (id.startsWith('@starbeam/debug')) {
         return INLINE;
       }
     }


### PR DESCRIPTION
## Summary

- Mark `@starbeam/verify` private/internal and remove publish metadata.
- Move public package references to `@starbeam/verify` out of runtime dependencies.
- Inline `@starbeam/verify` in built public artifacts in all modes.

## Why

`@starbeam/verify` is internal assertion/type-narrowing substrate. It does not have a positive direct-install package story, and the release-surface verifier now lets us enforce that it does not leak through public manifests or artifacts.

## Validation

- `pnpm install --lockfile-only`
- `pnpm build`
- `pnpm test:workspace:types`
- `pnpm test:workspace:pack` => `Verified 25 publishable packages.`
- `pnpm test:workspace:lint`
- `pnpm exec vitest --pool forks --run packages/universal/verify/tests packages/universal/debug/tests`
- `node ./workspace/scripts/build-verify.js`
- searched public JS artifacts, declarations, and runtime manifests for `@starbeam/verify` leaks
