### PR TITLE
Verify debug bootstrap artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - run: pnpm build
       - name: "Ensure Certain dependencies don't end up in the production bundles"
         run: node ./workspace/scripts/build-verify.js
+      - name: "Verify debug bootstrap artifacts"
+        run: pnpm test:workspace:debug-bootstrap
       - name: "Archive package artifacts"
         run: find packages -path '*/dist' -type d -prune -print | tar -czf package-dist.tgz -T -
       - uses: actions/upload-artifact@v4
@@ -72,7 +74,7 @@ jobs:
       # even if dependencies of packages have failed
       # (which means we'll have a lot of extra errors
       #  if something core doesn't pass type checking)
-      - run: ./node_modules/.bin/turbo run test:types --continue
+      - run: ./node_modules/.bin/turbo run test:types --continue --force
       - uses: actions/download-artifact@v4
         with:
           name: package-dist

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,6 +19,8 @@ pre-push:
       run: pnpm build
     build-verify:
       run: node ./workspace/scripts/build-verify.js
+    debug-bootstrap:
+      run: pnpm test:workspace:debug-bootstrap
     specs:
       run: pnpm ci:specs
     specs-prod:

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "lint:fix": "pnpm --filter '*' test:lint --fix",
     "prepack": "pnpm run build",
     "sort-deps": "node workspace/scripts/sort-package-json-deps.mjs",
+    "test:workspace:debug-bootstrap": "node workspace/scripts/verify-debug-bootstrap.js",
     "test:workspace:lint": "turbo run lint --output-logs errors-only --log-prefix none",
     "test:workspace:pack": "node workspace/scripts/verify-packed-public-packages.js",
     "test:workspace:prod": "STARBEAM_TEST_PROD=1 vitest --pool forks --run",

--- a/packages/universal/debug/index.ts
+++ b/packages/universal/debug/index.ts
@@ -1,5 +1,8 @@
-import "./src/setup.js";
+import { setupDebug } from "./src/setup.js";
+
+await setupDebug();
 
 export { default as DEBUG } from "./src/debug.js";
+export { setupDebug } from "./src/setup.js";
 export { debugReactive, logReactive } from "./src/tag.js";
 export { Tree } from "./src/tree.js";

--- a/packages/universal/debug/src/setup.ts
+++ b/packages/universal/debug/src/setup.ts
@@ -2,7 +2,17 @@ import { defineDebug } from "@starbeam/reactive";
 
 import debug from "./debug.js";
 
-if (import.meta.env.DEV) {
+let setup: Promise<void> | undefined;
+
+export async function setupDebug(): Promise<void> {
+  setup ??= setupDebugOnce();
+
+  return setup;
+}
+
+async function setupDebugOnce(): Promise<void> {
+  if (!import.meta.env.DEV) return;
+
   if (
     (globalThis.Buffer as BufferConstructor | undefined) === undefined &&
     typeof require === "function"

--- a/packages/universal/universal/index.ts
+++ b/packages/universal/universal/index.ts
@@ -1,4 +1,8 @@
-import "@starbeam/debug";
+import { setupDebug } from "@starbeam/debug";
+
+if (import.meta.env.DEV) {
+  await setupDebug();
+}
 
 export { DEBUG_RENDERER } from "./src/debug-renderer.js";
 export { FormulaList } from "./src/reactive-core/higher-level/formula-list.js";

--- a/packages/universal/universal/tests/debug-bootstrap.spec.ts
+++ b/packages/universal/universal/tests/debug-bootstrap.spec.ts
@@ -1,0 +1,11 @@
+import { DEBUG } from "@starbeam/universal";
+import { expect, test } from "vitest";
+
+test("source import bootstraps DEBUG in development", () => {
+  if (import.meta.env.DEV) {
+    expect(DEBUG?.Desc("cell")).not.toBe(undefined);
+    expect(DEBUG?.callerStack()).not.toBe(undefined);
+  } else {
+    expect(DEBUG).toBe(undefined);
+  }
+});

--- a/workspace/scripts/verify-debug-bootstrap.js
+++ b/workspace/scripts/verify-debug-bootstrap.js
@@ -1,0 +1,197 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(currentDir, "../..");
+
+const ARTIFACTS = new Map(
+  [
+    ["@starbeam/core-utils", "packages/universal/core-utils/dist/index"],
+    ["@starbeam/shared", "packages/universal/shared/dist/index"],
+    ["@starbeam/tags", "packages/universal/tags/dist/index"],
+    ["@starbeam/reactive", "packages/universal/reactive/dist/index"],
+    ["@starbeam/runtime", "packages/universal/runtime/dist/index"],
+    ["@starbeam/resource", "packages/universal/resource/dist/index"],
+    ["@starbeam/debug", "packages/universal/debug/dist/index"],
+    ["@starbeam/universal", "packages/universal/universal/dist/index"],
+  ].map(([specifier, path]) => [specifier, resolve(root, path)]),
+);
+
+const PNPM_RUNTIME_DEPENDENCIES = new Map([
+  [
+    "inspect-utils",
+    "../.pnpm/node_modules/inspect-utils/dist/index.development.js",
+  ],
+  ["stacktracey", "../.pnpm/node_modules/stacktracey/stacktracey.js"],
+]);
+
+const PUBLIC_UNIVERSAL_ARTIFACTS = [
+  "packages/universal/universal/dist/index.development.js",
+  "packages/universal/universal/dist/index.js",
+];
+
+await verifyDevelopmentArtifacts();
+await verifyProductionArtifacts();
+
+console.info(
+  "Verified debug bootstrap in development and production artifacts.",
+);
+
+async function verifyDevelopmentArtifacts() {
+  for (const mode of ["development"]) {
+    const universal = await importDevelopmentArtifact(
+      "@starbeam/universal",
+      mode,
+    );
+
+    assertDebugBootstrapped(
+      universal.DEBUG,
+      `${mode} @starbeam/universal artifact`,
+    );
+  }
+
+  for (const path of PUBLIC_UNIVERSAL_ARTIFACTS) {
+    const content = await readFile(resolve(root, path), "utf8");
+
+    assertIncludes(
+      content,
+      "setupDebug()",
+      `${path} must retain the debug bootstrap call`,
+    );
+  }
+}
+
+async function verifyProductionArtifacts() {
+  const universal = await importProductionArtifact("@starbeam/universal");
+
+  assertDebugNotBootstrapped(
+    universal.DEBUG,
+    "production @starbeam/universal artifact",
+  );
+
+  const productionArtifacts = [
+    "packages/universal/universal/dist/index.production.js",
+    "packages/universal/universal/dist/index.production.js.map",
+  ];
+
+  for (const path of productionArtifacts) {
+    const content = await readFile(resolve(root, path), "utf8");
+
+    for (const forbidden of [
+      "@starbeam/debug",
+      "@starbeam/verify",
+      "stacktracey",
+    ]) {
+      assertExcludes(
+        content,
+        forbidden,
+        `${path} must not include ${forbidden}`,
+      );
+    }
+  }
+}
+
+async function importDevelopmentArtifact(specifier, mode) {
+  return importRewrittenArtifacts(specifier, mode);
+}
+
+async function importProductionArtifact(specifier) {
+  return importRewrittenArtifacts(specifier, "production");
+}
+
+async function importRewrittenArtifacts(specifier, mode) {
+  const workspace = await mkdtemp(
+    join(root, "node_modules/.starbeam-debug-bootstrap."),
+  );
+
+  try {
+    const rewritten = new Map();
+
+    for (const [artifactSpecifier, artifact] of ARTIFACTS) {
+      const source = artifactPath(artifact, mode);
+      const target = join(workspace, artifactFile(artifactSpecifier));
+
+      rewritten.set(artifactSpecifier, target);
+      await writeFile(target, await rewriteImports(source, rewritten));
+    }
+
+    return await import(pathToFileURL(rewritten.get(specifier)).href);
+  } finally {
+    await rm(workspace, { force: true, recursive: true });
+  }
+}
+
+async function rewriteImports(source, rewritten) {
+  let content = await readFile(source, "utf8");
+
+  for (const [specifier, target] of rewritten) {
+    const replacement = `./${basename(target)}`;
+
+    content = content
+      .replaceAll(`from "${specifier}"`, `from "${replacement}"`)
+      .replaceAll(`from '${specifier}'`, `from '${replacement}'`)
+      .replaceAll(`import "${specifier}"`, `import "${replacement}"`)
+      .replaceAll(`import '${specifier}'`, `import '${replacement}'`);
+  }
+
+  for (const [specifier, replacement] of PNPM_RUNTIME_DEPENDENCIES) {
+    content = content
+      .replaceAll(`from "${specifier}"`, `from "${replacement}"`)
+      .replaceAll(`from '${specifier}'`, `from '${replacement}'`)
+      .replaceAll(`import "${specifier}"`, `import "${replacement}"`)
+      .replaceAll(`import '${specifier}'`, `import '${replacement}'`);
+  }
+
+  return content;
+}
+
+function artifactPath(base, mode) {
+  const suffix = mode === "default" ? "" : `.${mode}`;
+
+  return `${base}${suffix}.js`;
+}
+
+function artifactFile(specifier) {
+  return `${specifier.slice("@starbeam/".length)}.js`;
+}
+
+function assertDebugBootstrapped(debug, label) {
+  assert(
+    debug && typeof debug.Desc === "function",
+    `${label} should export bootstrapped DEBUG.Desc`,
+  );
+
+  const desc = debug.Desc("cell");
+
+  assert(desc !== undefined, `${label} DEBUG.Desc should create a description`);
+  assert(
+    desc.api?.name === "assertDebugBootstrapped",
+    `${label} DEBUG.Desc should infer the caller api, got ${JSON.stringify(
+      desc.api,
+    )}`,
+  );
+  assert(
+    typeof debug.callerStack === "function" &&
+      debug.callerStack() !== undefined,
+    `${label} DEBUG.callerStack should produce a call stack`,
+  );
+}
+
+function assertDebugNotBootstrapped(debug, label) {
+  assert(debug === undefined, `${label} should not bootstrap DEBUG`);
+}
+
+function assertIncludes(content, needle, message) {
+  assert(content.includes(needle), message);
+}
+
+function assertExcludes(content, needle, message) {
+  assert(!content.includes(needle), message);
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}


### PR DESCRIPTION
## Summary

- Add explicit `setupDebug()` bootstrap for `@starbeam/debug`.
- Make `@starbeam/universal` explicitly bootstrap debug in development so Rollup retains the call.
- Add source and built-artifact coverage for debug bootstrap behavior in development and production.
- Wire the artifact verifier into CI and pre-push.

## Why

The debug package has an architectural bootstrap role. Before deciding whether it should become private, we need durable coverage for the behavior it provides. This PR confirms the previous side-effect-only bootstrap could be dropped from built development artifacts and makes the bootstrap explicit.

## Validation

- `pnpm build`
- `pnpm test:workspace:debug-bootstrap`
- `pnpm test:workspace:pack` => `Verified 25 publishable packages.`
- `node workspace/scripts/build-verify.js`
- `pnpm test:workspace:types`
- `pnpm test:workspace:lint`
- `pnpm exec vitest --pool forks --run packages/universal/universal/tests/debug-bootstrap.spec.ts`
- `STARBEAM_TEST_PROD=1 pnpm exec vitest --pool forks --run packages/universal/universal/tests/debug-bootstrap.spec.ts`
