### PR TITLE
Make debug an internal package

### DIFF
--- a/packages/preact/preact/package.json
+++ b/packages/preact/preact/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@preact/signals": "^2.9.0",
     "@starbeam/core-utils": "workspace:^",
-    "@starbeam/debug": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/renderer": "workspace:^",

--- a/packages/react/react/package.json
+++ b/packages/react/react/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@starbeam/collections": "workspace:^",
     "@starbeam/core-utils": "workspace:^",
-    "@starbeam/debug": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/modifier": "workspace:^",
     "@starbeam/reactive": "workspace:^",

--- a/packages/react/test-utils/package.json
+++ b/packages/react/test-utils/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@starbeam/core-utils": "workspace:^",
-    "@starbeam/debug": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam-workspace/test-utils": "workspace:^"

--- a/packages/universal/collections/package.json
+++ b/packages/universal/collections/package.json
@@ -31,7 +31,6 @@
     "test:types": "tsc -b"
   },
   "dependencies": {
-    "@starbeam/debug": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/runtime": "workspace:^",

--- a/packages/universal/debug/package.json
+++ b/packages/universal/debug/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@starbeam/debug",
   "type": "module",
   "version": "0.8.9",
@@ -6,15 +7,6 @@
   "types": "index.ts",
   "exports": {
     "default": "./index.ts"
-  },
-  "publishConfig": {
-    "exports": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
   },
   "starbeam": {
     "inline": [
@@ -26,11 +18,10 @@
       "printable-characters",
       "chalk"
     ],
-    "type": "library:public"
+    "type": "library:internal"
   },
   "scripts": {
     "build": "rollup -c",
-    "prepack": "pnpm build",
     "test:lint": "eslint . --max-warnings 0",
     "test:specs": "vitest --run --pool forks",
     "test:types": "tsc -b"
@@ -50,16 +41,5 @@
     "@starbeam-dev/compile": "workspace:*",
     "@types/node": "^22.19.17",
     "rollup": "^4.60.1"
-  },
-  "files": [
-    "dist",
-    "README.md",
-    "CHANGELOG.md",
-    "LICENSE.md"
-  ],
-  "release-plan": {
-    "semverIncrementAs": {
-      "major": "minor"
-    }
   }
 }

--- a/packages/universal/modifier/package.json
+++ b/packages/universal/modifier/package.json
@@ -26,7 +26,6 @@
     "test:types": "tsc -b"
   },
   "dependencies": {
-    "@starbeam/debug": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/shared": "workspace:^",

--- a/packages/universal/resource/package.json
+++ b/packages/universal/resource/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@starbeam/core-utils": "workspace:^",
-    "@starbeam/debug": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/runtime": "workspace:^",

--- a/packages/universal/service/package.json
+++ b/packages/universal/service/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@starbeam/core-utils": "workspace:^",
-    "@starbeam/debug": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/resource": "workspace:^",

--- a/packages/universal/universal/package.json
+++ b/packages/universal/universal/package.json
@@ -17,6 +17,9 @@
     "types": "dist/index.d.ts"
   },
   "starbeam": {
+    "inline": [
+      "@starbeam/debug"
+    ],
     "type": "library:public"
   },
   "scripts": {
@@ -28,16 +31,17 @@
   },
   "dependencies": {
     "@starbeam/core-utils": "workspace:^",
-    "@starbeam/debug": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/resource": "workspace:^",
     "@starbeam/runtime": "workspace:^",
     "@starbeam/shared": "workspace:^",
     "@starbeam/tags": "workspace:^",
-    "inspect-utils": "^1.0.1"
+    "inspect-utils": "^1.0.1",
+    "stacktracey": "^2.2.0"
   },
   "devDependencies": {
+    "@starbeam/debug": "workspace:^",
     "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"

--- a/packages/universal/universal/rollup.config.mjs
+++ b/packages/universal/universal/rollup.config.mjs
@@ -1,3 +1,9 @@
 import { compile } from "@starbeam-dev/compile";
 
-export default compile(import.meta);
+export default compile(import.meta).map((config) => ({
+  ...config,
+  output: {
+    ...config.output,
+    sourcemapExcludeSources: true,
+  },
+}));

--- a/packages/vue/vue/package.json
+++ b/packages/vue/vue/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "@starbeam/core-utils": "workspace:^",
-    "@starbeam/debug": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/renderer": "workspace:^",

--- a/packages/x/headless-form/package.json
+++ b/packages/x/headless-form/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "@starbeam/collections": "workspace:^",
-    "@starbeam/debug": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^"
   },

--- a/packages/x/store/package.json
+++ b/packages/x/store/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@starbeam/collections": "workspace:^",
-    "@starbeam/debug": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^"
   },

--- a/packages/x/vanilla/package.json
+++ b/packages/x/vanilla/package.json
@@ -28,7 +28,6 @@
     "test:types": "tsc -b"
   },
   "dependencies": {
-    "@starbeam/debug": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/runtime": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,9 +161,6 @@ importers:
       '@starbeam/core-utils':
         specifier: workspace:^
         version: link:../../universal/core-utils
-      '@starbeam/debug':
-        specifier: workspace:^
-        version: link:../../universal/debug
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../../universal/interfaces
@@ -380,9 +377,6 @@ importers:
       '@starbeam/core-utils':
         specifier: workspace:^
         version: link:../../universal/core-utils
-      '@starbeam/debug':
-        specifier: workspace:^
-        version: link:../../universal/debug
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../../universal/interfaces
@@ -483,9 +477,6 @@ importers:
       '@starbeam/core-utils':
         specifier: workspace:^
         version: link:../../universal/core-utils
-      '@starbeam/debug':
-        specifier: workspace:^
-        version: link:../../universal/debug
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../../universal/interfaces
@@ -576,9 +567,6 @@ importers:
 
   packages/universal/collections:
     dependencies:
-      '@starbeam/debug':
-        specifier: workspace:^
-        version: link:../debug
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../interfaces
@@ -715,9 +703,6 @@ importers:
 
   packages/universal/modifier:
     dependencies:
-      '@starbeam/debug':
-        specifier: workspace:^
-        version: link:../debug
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../interfaces
@@ -835,9 +820,6 @@ importers:
       '@starbeam/core-utils':
         specifier: workspace:^
         version: link:../core-utils
-      '@starbeam/debug':
-        specifier: workspace:^
-        version: link:../debug
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../interfaces
@@ -951,9 +933,6 @@ importers:
       '@starbeam/core-utils':
         specifier: workspace:^
         version: link:../core-utils
-      '@starbeam/debug':
-        specifier: workspace:^
-        version: link:../debug
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../interfaces
@@ -1064,9 +1043,6 @@ importers:
       '@starbeam/core-utils':
         specifier: workspace:^
         version: link:../core-utils
-      '@starbeam/debug':
-        specifier: workspace:^
-        version: link:../debug
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../interfaces
@@ -1088,10 +1064,16 @@ importers:
       inspect-utils:
         specifier: ^1.0.1
         version: 1.0.1
+      stacktracey:
+        specifier: ^2.2.0
+        version: 2.2.0
     devDependencies:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/debug':
+        specifier: workspace:^
+        version: link:../debug
       '@starbeam/verify':
         specifier: workspace:^
         version: link:../verify
@@ -1145,9 +1127,6 @@ importers:
       '@starbeam/core-utils':
         specifier: workspace:^
         version: link:../../universal/core-utils
-      '@starbeam/debug':
-        specifier: workspace:^
-        version: link:../../universal/debug
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../../universal/interfaces
@@ -1322,9 +1301,6 @@ importers:
       '@starbeam/collections':
         specifier: workspace:^
         version: link:../../universal/collections
-      '@starbeam/debug':
-        specifier: workspace:^
-        version: link:../../universal/debug
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../../universal/interfaces
@@ -1344,9 +1320,6 @@ importers:
       '@starbeam/collections':
         specifier: workspace:^
         version: link:../../universal/collections
-      '@starbeam/debug':
-        specifier: workspace:^
-        version: link:../../universal/debug
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../../universal/interfaces
@@ -1379,9 +1352,6 @@ importers:
 
   packages/x/vanilla:
     dependencies:
-      '@starbeam/debug':
-        specifier: workspace:^
-        version: link:../../universal/debug
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../../universal/interfaces


### PR DESCRIPTION
## Summary

- Mark `@starbeam/debug` private/internal and remove its publish metadata.
- Move `@starbeam/universal` to own the public debug bootstrap boundary by inlining `@starbeam/debug` as a build-time input.
- Remove stale public runtime dependencies on `@starbeam/debug`.
- Keep production artifacts verified clean while preserving development `DEBUG` bootstrap behavior.

## Notes

`@starbeam/universal` intentionally keeps `@starbeam/debug` as a build-time/dev dependency and declares `stacktracey` for default/development artifacts after inlining the debug bootstrap. Production artifacts remain verified clean of `@starbeam/debug`, `@starbeam/verify`, and `stacktracey`.

## Validation

- `pnpm build`
- `node ./workspace/scripts/build-verify.js`
- `pnpm test:workspace:debug-bootstrap`
- `pnpm test:workspace:types`
- `pnpm test:workspace:pack` => `Verified 24 publishable packages.`
- `pnpm test:workspace:lint`
- public artifact/declaration/runtime manifest leak checks for `@starbeam/debug`
