### PR TITLE
Document package surface heuristics

### DIFF
--- a/.github/instructions/per-workflow.instructions.md
+++ b/.github/instructions/per-workflow.instructions.md
@@ -1,0 +1,51 @@
+---
+description: "Use when: planning or reviewing Starbeam work described as PER, Prepare/Execute/Review, or a hypothesis-driven implementation cycle."
+---
+
+# Starbeam PER Workflow
+
+PER means **Prepare / Execute / Review**.
+
+Use PER for non-trivial Starbeam changes where the risk is not just typing code, but choosing the right boundary, preserving behavior, and validating release-surface consequences.
+
+## Phases
+
+1. **Prepare**
+   - Gather evidence from the current codebase.
+   - State the hypothesis and the intended behavior.
+   - List falsifiable predictions.
+   - Identify high-consequence unknowns before editing.
+   - Produce a bounded execute plan and validation plan.
+
+2. **Execute**
+   - Make the smallest changes that test the Prepare hypothesis.
+   - Keep unrelated files out of the branch.
+   - Record any divergence from the prediction.
+   - Run the validation plan.
+
+3. **Review**
+   - Compare the outcome to Prepare's predictions.
+   - Call out mismatches and whether they matter.
+   - Decide whether the result is safe to push, needs a targeted execute loop, or needs a new Prepare phase.
+
+## Starbeam package-surface use
+
+For package-surface work, PER should explicitly check:
+
+- public manifest dependencies
+- default/development JavaScript artifacts
+- production JavaScript artifacts
+- generated declarations
+- declaration maps and source maps when private package names could leak
+- `pnpm test:workspace:pack`
+- relevant bootstrap or behavior tests, not only package metadata
+
+Production stripping alone is not enough. Published default/development artifacts and declarations are part of the release surface.
+
+## PR and docs language
+
+When using the acronym in docs or PR descriptions, spell it out on first use:
+
+> Prepare / Execute / Review (PER)
+
+After first use, `PER` is fine.

--- a/docs/PACKAGE-SURFACE-TRIAGE.md
+++ b/docs/PACKAGE-SURFACE-TRIAGE.md
@@ -1,0 +1,91 @@
+# Package Surface Triage
+
+This is the current working hypothesis for Starbeam's public npm surface. It
+uses the heuristics in [PACKAGE-SURFACE.md](./PACKAGE-SURFACE.md).
+
+The goal is not to classify packages by size. The goal is to recover the story
+behind each boundary: audience, architecture, reusable infrastructure,
+complete conceptual model, or intentional experiment.
+
+## Strong public hypotheses
+
+These packages currently have a positive public-package story.
+
+| Package                          | Hypothesis                     | Reason                                                                                     | Action                                                                                               |
+| -------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `@starbeam/react`                | Public                         | React adapter; distinct user audience.                                                     | Keep public. Reduce internal manifest deps.                                                          |
+| `@starbeam/preact`               | Public                         | Preact adapter; distinct user audience.                                                    | Keep public.                                                                                         |
+| `@starbeam/vue`                  | Public, if Vue is in 0.9 scope | Vue adapter; distinct user audience.                                                       | Confirm release scope.                                                                               |
+| `@starbeam/shared`               | Public                         | Architectural substrate for cross-copy and cross-version interoperability.                 | Keep public. Majors should require explicit intent.                                                  |
+| `@starbeam/collections`          | Public                         | Documented reactive collection package with direct value proposition.                      | Keep public. Remove support deps.                                                                    |
+| `@starbeam/resource`             | Public                         | Direct resource composition package with package-level docs.                               | Keep public if resources are standalone API.                                                         |
+| `@starbeam/use-strict-lifecycle` | Public reusable infrastructure | Solves a standalone React lifecycle problem under Strict Mode, remounts, and hidden trees. | Write README from THEORY; separate public lifecycle API from Starbeam-specific read-barrier helpers. |
+| `@starbeamx/store`               | Public experiment              | Usable reactive table/query/group/aggregate experiment.                                    | Keep as `@starbeamx`; align README with actual API.                                                  |
+| `@starbeamx/vanilla`             | Public experiment              | Minimal DOM renderer and reference implementation for Starbeam renderer authors.           | Keep as `@starbeamx`; add usage docs and round out tests.                                            |
+
+## Conceptual boundaries that need decisions
+
+These packages are not obviously wrong. They encode real architectural stories,
+but we need to decide which audiences are supported in 0.9 and whether the
+current package names are the right public surface.
+
+| Package                | Better hypothesis                                                              | Why we cared                                                                                                                                                                                                                   | Current conflict                                                                                                                                              | Suggested action                                                                                                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@starbeam/modifier`   | Internal element-attachment kernel; mandatory post-surface hardening candidate | Represents the ref/directive/modifier part of complete framework reactivity. The basic idea composes resources, element availability, and framework lifetimes. Historically backed React refs and universal element resources. | Current adapter APIs/docs are stale or removed; package only exposes `ElementPlaceholder`; React dependency appears stale. Cross-framework glue needs design. | Keep internal during the package-surface arc, then run a focused hardening PER sequence alongside renderer to see whether the ref/directive/modifier story can be made solid for 0.9. |
+| `@domtree/*`           | Internal DOM-type substrate; tied to modifier hardening                        | Type-level DOM flavor normalization: write DOM algorithms against minimal structural DOM while preserving browser/JSDOM/range types.                                                                                           | Original DOM renderer is gone; current active leak is mostly through `@starbeam/modifier` and stale manifests.                                                | Keep internal unless modifier/renderer hardening proves public authors need these types directly.                                                                                     |
+| `@starbeam/interfaces` | Decision needed / protocol surface                                             | Internal protocol type boundary for runtime/tags/reactive/debug without cycles.                                                                                                                                                | No README, special `library:interfaces`, stale-looking `src/protocol.ts`, stale `@domtree/any` manifest dependency, broad declaration leakage.                | Decide whether protocol types are public. Consider a better public `@starbeam/protocol` surface or re-export strategy.                                                                |
+| `@starbeam/tags`       | Decision needed                                                                | Validation/tag substrate extracted from runtime; core of demand-driven validation.                                                                                                                                             | Low-level implementor API, not normal app-user API.                                                                                                           | Bless as implementor API or hide behind `reactive`/`runtime`.                                                                                                                         |
+| `@starbeam/runtime`    | Decision needed                                                                | Runtime coordination, subscriptions, finalization scopes; intentionally split from reactive primitives.                                                                                                                        | README says stable for libraries but not app code; public exports are low-level.                                                                              | Decide whether runtime/library authors are supported. Refresh docs if public.                                                                                                         |
+| `@starbeam/renderer`   | Internal adapter kernel; mandatory post-surface hardening candidate            | Real shared adapter kernel for owner identity, setup values, resources, services, and scheduling. Preact fits best; Vue fits partially; React mostly uses the vocabulary but bypasses helpers for strict lifecycle semantics.  | Not yet a complete contributor-facing adapter contract. Current docs are stale, and there is no cross-adapter contract suite.                                 | Keep internal during the package-surface arc, then immediately run a focused hardening PER series to see whether it can become the adapter-author kit for 0.9.                        |
+| `@starbeam/service`    | Decision needed                                                                | App-scoped singleton resource machinery used by adapters/renderer.                                                                                                                                                             | README appears copied from resource docs; old universal docs say `service` belongs in `@starbeam/universal`, but current universal index does not export it.  | Decide if service is direct API, universal re-export, renderer-author API, or private adapter support.                                                                                |
+| `@starbeam/reactive`   | Public primitive surface, needs split                                          | Primitive reactive values are documented and useful to library authors.                                                                                                                                                        | Exports include runtime wiring/debug/tracking-frame substrate, not just public primitives.                                                                    | Keep public for primitives. Move/hide runtime wiring and tracking internals behind internal or future author-facing surfaces.                                                         |
+| `@starbeam/universal`  | Main public umbrella candidate                                                 | Best current framework-agnostic entrypoint over cells, formulas, resources, and common integration concepts.                                                                                                                   | Leaks low-level package names in JS and declarations; service docs conflict with exports.                                                                     | Make it the public umbrella over private substrates. Re-export service if public; stop exposing raw runtime/protocol pieces as the story.                                             |
+| `@starbeam/core`       | Compatibility decision                                                         | Deprecated alias over `@starbeam/universal`.                                                                                                                                                                                   | Root badge still points at it, but code is only a warning + re-export.                                                                                        | Decide old-import compatibility policy for 0.9.                                                                                                                                       |
+
+## Private candidates
+
+These packages currently lack a strong direct public story, though some need
+engineering work before they can become private.
+
+| Package                | Hypothesis        | Why                                                                                               | Main blockers                                                                             | Suggested PER                                                                                    |
+| ---------------------- | ----------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `@starbeam/verify`     | Private           | Internal assertion/type-narrowing support. A tidy API is not a public-package argument by itself. | Done: private/internal, inlined in public artifacts, no public runtime manifest leaks.    | Monitor verifier; no public surface unless a real audience appears.                              |
+| `@starbeam/debug`      | Private           | Dev/runtime support and bootstrap implementation, not a direct install target.                    | Done: private/internal; `@starbeam/universal` owns and verifies the public DEV bootstrap. | Keep `test:workspace:debug-bootstrap` green; revisit only if a public diagnostics story appears. |
+| `@starbeam/core-utils` | Private candidate | Generic JS utilities are not a Starbeam public goal by default.                                   | Very broad source, JS, and declaration usage.                                             | After debug/verify, inline or internalize utilities.                                             |
+
+## Possible new public surfaces
+
+Creating new packages is allowed if it makes the public story clearer.
+
+| Possible package                                         | Purpose                                                                                                                                 |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `@starbeam/universal` as umbrella                        | Main user/library surface over cells, formulas, resources, services, and common integration concepts.                                   |
+| `@starbeam/protocol`                                     | Future explicit protocol/type package if runtime/framework authors become a supported audience. Better name than `interfaces`.          |
+| `@starbeam/reactivity` or clarified `@starbeam/reactive` | Public primitive reactive values, separated from runtime wiring and tracking-frame internals if needed.                                 |
+| `@starbeam/renderer`                                     | Future adapter-author surface if the current internal kernel is hardened with docs, extension points, and cross-adapter contract tests. |
+
+## Suggested Prepare / Execute / Review (PER) order
+
+PER means Prepare / Execute / Review: prepare a falsifiable plan, execute the
+bounded change, then review the result against the prediction.
+
+1. ~~Tighten release-surface verification so generated declarations and default
+   JS cannot hide private-package leaks.~~ Done.
+2. ~~`@starbeam/verify` and `@starbeam/debug` strategy.~~ Done: both are
+   private/internal, with debug bootstrap covered through `@starbeam/universal`.
+3. `@starbeam/core-utils` cleanup.
+4. Modifier/domtree hardening PER sequence alongside renderer. Goal: determine
+   whether ref/directive/modifier integration can become a solid 0.9 story
+   across framework adapters.
+5. Low-level surface consolidation: make `@starbeam/universal` the umbrella,
+   split public `@starbeam/reactive` primitives from runtime wiring, place
+   service intentionally, and target interfaces/tags/runtime as internal unless
+   a future protocol package is needed.
+6. Audience decision matrix for app users, library authors, framework
+   contributors, and runtime/protocol implementors.
+7. Renderer hardening PER series immediately after this package-surface arc.
+   Goal: determine whether the internal kernel can become the adapter-author
+   kit for 0.9.
+8. Public-consumption polish for `@starbeam/use-strict-lifecycle` and
+   `@starbeamx/*`.
+9. `@starbeam/core` compatibility alias policy.

--- a/docs/PACKAGE-SURFACE.md
+++ b/docs/PACKAGE-SURFACE.md
@@ -1,0 +1,129 @@
+# Package Surface Heuristics
+
+This document records how we decide whether a workspace package should be part
+of Starbeam's public npm surface.
+
+The default is not "publish it because it exists." A public package needs a
+positive reason to be installed directly.
+
+## Public package criteria
+
+A package should stay public only if it satisfies at least one of these
+criteria.
+
+### 1. Distinct audience
+
+The package serves a supported audience that is distinct from ordinary
+Starbeam users.
+
+Examples:
+
+- framework adapters such as `@starbeam/react`, `@starbeam/preact`, and
+  `@starbeam/vue`
+- framework-author or runtime-author APIs, if we decide that audience is
+  supported for the release
+
+### 2. Complete story
+
+The package represents one coherent piece of Starbeam's model, even if its
+current implementation is small.
+
+The question is not "how much code is in the package?" The question is whether
+the package maps to something we want users or implementors to understand as a
+separate concept.
+
+Examples:
+
+- element modifiers / refs / directives as the DOM-attachment part of
+  framework reactivity
+- resources as the lifecycle-aware composition primitive
+
+### 3. Reusable infrastructure
+
+The package provides infrastructure that is useful outside Starbeam and worth
+explaining as a package in its own right.
+
+This is not enough by itself. We should be able to say why publishing it serves
+Starbeam's goals.
+
+Examples of plausible candidates:
+
+- `@starbeam/use-strict-lifecycle`
+- Preact private-shape utilities, if we later decide to document and support
+  them for other Preact tooling authors
+
+### 4. Architectural necessity
+
+The architecture depends on the package having a separate npm identity.
+
+Example:
+
+- `@starbeam/shared`, which lets multiple Starbeam copies interoperate,
+  including across major versions
+
+### 5. Intentional experiments
+
+The package is explicitly an experiment that people can try directly. These
+packages should be framed as usable but not fully stable before 1.0.
+
+Example:
+
+- `@starbeamx/*`
+
+## New public surfaces are allowed
+
+Privatizing an implementation package does not require deleting its public
+concept. Sometimes the right answer is to create a new public package that
+groups several private packages into a principled surface.
+
+For example, low-level protocol packages might become private implementation
+details behind a future public author-facing package.
+
+## Privatization checklist
+
+Before making a package private, verify all of the following.
+
+1. It is not an intended direct install target for this release.
+2. No public package manifest lists it in `dependencies`, `peerDependencies`,
+   or `optionalDependencies`.
+3. Public declaration files do not import from it or expose its types.
+4. Published JavaScript does not import it as an external package.
+5. Any useful boundary remains internally, instead of smearing implementation
+   details through consumers.
+6. `pnpm test:workspace:pack` enforces the result.
+
+Production stripping is not enough. The release surface is about published
+manifests, default/development JavaScript, and declarations as well as
+production bundles.
+
+When a private package provides development-only behavior, preserve the public
+behavior through a public package boundary before making the implementation
+private. For example, `@starbeam/debug` is internal, but `@starbeam/universal`
+still owns the public development-mode `DEBUG` bootstrap and verifies it in
+development and production artifacts.
+
+## Classification states
+
+Use these states while triaging packages.
+
+- **Public:** should appear in npm release plans.
+- **Private:** workspace implementation detail; should not publish.
+- **Candidate:** likely private, but needs engineering work to remove manifest,
+  JavaScript, or declaration leaks.
+- **Decision needed:** package has a plausible public story, but we have not
+  decided whether to support that audience/API in this release.
+- **Public experiment:** intentionally publishable experiment; usable directly,
+  but not presented as fully stable before 1.0.
+
+## Current working examples
+
+- `vite-env` is private local type/test support.
+- `@starbeam/preact-utils` is private for the current release arc, while its
+  internal boundary remains inside `@starbeam/preact` for possible future
+  extraction.
+- `@starbeam/shared` is public for architectural reasons.
+- `@starbeam/verify` is private internal assertion/type-narrowing support. A
+  tidy helper API is not a public-package argument by itself.
+- `@starbeam/debug` is private development/runtime support. Its load-bearing
+  behavior is the `@starbeam/universal` debug bootstrap, which is kept as public
+  behavior and covered by artifact tests.


### PR DESCRIPTION
## Summary

- Document the heuristics for deciding whether a workspace package belongs in Starbeam's public npm surface.
- Add a working triage matrix for current public, private, and decision-needed package boundaries.
- Capture the lessons from the recent `vite-env`, `preact-utils`, `verify`, and `debug` privatization work.

## Validation

- `pnpm test:workspace:pack` => `Verified 24 publishable packages.`
- pre-commit lint/types via lefthook
