### PR TITLE
Make core-utils internal

### DIFF
--- a/packages/preact/preact/package.json
+++ b/packages/preact/preact/package.json
@@ -21,6 +21,9 @@
       "index": "./index.ts",
       "setup": "./src/setup.ts"
     },
+    "inline": [
+      "@starbeam/core-utils"
+    ],
     "type": "library:public"
   },
   "scripts": {
@@ -32,7 +35,6 @@
   },
   "dependencies": {
     "@preact/signals": "^2.9.0",
-    "@starbeam/core-utils": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/renderer": "workspace:^",
@@ -44,6 +46,7 @@
     "@starbeam/universal": "workspace:^"
   },
   "devDependencies": {
+    "@starbeam/core-utils": "workspace:^",
     "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"

--- a/packages/react/react/package.json
+++ b/packages/react/react/package.json
@@ -17,6 +17,9 @@
     "types": "dist/index.d.ts"
   },
   "starbeam": {
+    "inline": [
+      "@starbeam/core-utils"
+    ],
     "source": "tsx",
     "type": "library:public"
   },
@@ -29,7 +32,6 @@
   },
   "dependencies": {
     "@starbeam/collections": "workspace:^",
-    "@starbeam/core-utils": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/modifier": "workspace:^",
     "@starbeam/reactive": "workspace:^",
@@ -43,6 +45,7 @@
     "scheduler": "^0.27.0"
   },
   "devDependencies": {
+    "@starbeam/core-utils": "workspace:^",
     "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "@types/node": "^22.19.17",

--- a/packages/universal/core-utils/package.json
+++ b/packages/universal/core-utils/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@starbeam/core-utils",
   "type": "module",
   "version": "0.8.9",
@@ -7,21 +8,11 @@
   "exports": {
     "default": "./index.ts"
   },
-  "publishConfig": {
-    "exports": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
-  },
   "starbeam": {
-    "type": "library:public"
+    "type": "library:internal"
   },
   "scripts": {
     "build": "rollup -c",
-    "prepack": "pnpm build",
     "test:lint": "eslint . --max-warnings 0",
     "test:specs": "vitest --run --pool forks",
     "test:types": "tsc -b"
@@ -29,10 +20,5 @@
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"
-  },
-  "release-plan": {
-    "semverIncrementAs": {
-      "major": "minor"
-    }
   }
 }

--- a/packages/universal/interfaces/src/debug/debug-runtime.ts
+++ b/packages/universal/interfaces/src/debug/debug-runtime.ts
@@ -1,27 +1,27 @@
-import type { PresentArray } from "@starbeam/core-utils";
-
 import type { CellTag } from "../tag.js";
 import type { Tagged } from "../tagged.js";
 import type { CallerStackFn, CallStack } from "./call-stack.js";
 import type { DescFn, DescriptionDetails } from "./description.js";
 
+type PresentArray<T> = readonly [T, ...T[]] | [T, ...T[]];
+
 export type DescribeOptions =
   | {
-    id: boolean | undefined;
-  }
+      id: boolean | undefined;
+    }
   | undefined;
 
 export interface DebugRuntime {
   getUserFacing: <D extends DescriptionDetails | undefined>(
-    description: D
+    description: D,
   ) => D;
   describe: (
     description: DescriptionDetails,
-    options?: DescribeOptions
+    options?: DescribeOptions,
   ) => string;
   describeTagged: (tagged: Tagged, options?: DescribeOptions) => string;
   readonly untrackedReadBarrier: (
-    barrier: (tag: CellTag, stack: CallStack | undefined) => void | never
+    barrier: (tag: CellTag, stack: CallStack | undefined) => void | never,
   ) => void;
   readonly callerStack: CallerStackFn;
 
@@ -41,13 +41,13 @@ export interface DebugRuntime {
   markEntryPoint: (
     options?:
       | {
-        caller?: CallStack | undefined;
-        description?: EntryPointDescriptionArg | string | undefined;
-        force?: boolean | undefined;
-      }
+          caller?: CallStack | undefined;
+          description?: EntryPointDescriptionArg | string | undefined;
+          force?: boolean | undefined;
+        }
       | EntryPointDescriptionArg
       | EntryPoint
-      | string
+      | string,
   ) => void;
   getEntryPoint: () => EntryPoint | undefined;
 
@@ -68,36 +68,36 @@ export interface EntryPointDescription {
 export type EntryPointDescriptionArg =
   | ["label", string]
   | [
-    operation: "reactive:read" | "reactive:write" | "reactive:call",
-    entity: DescriptionDetails | string | undefined,
-    api?: PropertyKey
-  ]
+      operation: "reactive:read" | "reactive:write" | "reactive:call",
+      entity: DescriptionDetails | string | undefined,
+      api?: PropertyKey,
+    ]
   | [
-    operation:
-    | "object:get"
-    | "object:set"
-    | "object:has"
-    | "object:call"
-    | "object:define"
-    | "object:delete"
-    | "object:meta:get",
-    entity: DescriptionDetails | string | undefined,
-    target: PropertyKey
-  ]
+      operation:
+        | "object:get"
+        | "object:set"
+        | "object:has"
+        | "object:call"
+        | "object:define"
+        | "object:delete"
+        | "object:meta:get",
+      entity: DescriptionDetails | string | undefined,
+      target: PropertyKey,
+    ]
   | [
-    operation: "object:meta:keys",
-    entity: DescriptionDetails | string | undefined
-  ]
+      operation: "object:meta:keys",
+      entity: DescriptionDetails | string | undefined,
+    ]
   | [
-    operation: "function:call",
-    entity: DescriptionDetails | string | undefined
-  ]
+      operation: "function:call",
+      entity: DescriptionDetails | string | undefined,
+    ]
   | [
-    operation:
-    | "collection:has"
-    | "collection:get"
-    | "collection:insert"
-    | "collection:delete",
-    entity: DescriptionDetails | string | undefined,
-    key: unknown
-  ];
+      operation:
+        | "collection:has"
+        | "collection:get"
+        | "collection:insert"
+        | "collection:delete",
+      entity: DescriptionDetails | string | undefined,
+      key: unknown,
+    ];

--- a/packages/universal/reactive/package.json
+++ b/packages/universal/reactive/package.json
@@ -17,6 +17,9 @@
     "types": "dist/index.d.ts"
   },
   "starbeam": {
+    "inline": [
+      "@starbeam/core-utils"
+    ],
     "type": "library:public"
   },
   "scripts": {
@@ -27,12 +30,12 @@
     "test:types": "tsc -b"
   },
   "dependencies": {
-    "@starbeam/core-utils": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/shared": "workspace:^",
     "@starbeam/tags": "workspace:^"
   },
   "devDependencies": {
+    "@starbeam/core-utils": "workspace:^",
     "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"

--- a/packages/universal/resource/package.json
+++ b/packages/universal/resource/package.json
@@ -17,6 +17,9 @@
     "types": "dist/index.d.ts"
   },
   "starbeam": {
+    "inline": [
+      "@starbeam/core-utils"
+    ],
     "type": "library:public"
   },
   "scripts": {
@@ -27,13 +30,13 @@
     "test:types": "tsc -b"
   },
   "dependencies": {
-    "@starbeam/core-utils": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/runtime": "workspace:^",
     "@starbeam/shared": "workspace:^"
   },
   "devDependencies": {
+    "@starbeam/core-utils": "workspace:^",
     "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"

--- a/packages/universal/runtime/package.json
+++ b/packages/universal/runtime/package.json
@@ -17,6 +17,9 @@
     "types": "dist/index.d.ts"
   },
   "starbeam": {
+    "inline": [
+      "@starbeam/core-utils"
+    ],
     "type": "library:public"
   },
   "scripts": {
@@ -27,7 +30,6 @@
     "test:types": "tsc -b"
   },
   "dependencies": {
-    "@starbeam/core-utils": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/shared": "workspace:^",
@@ -35,6 +37,7 @@
     "inspect-utils": "^1.0.1"
   },
   "devDependencies": {
+    "@starbeam/core-utils": "workspace:^",
     "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1",

--- a/packages/universal/service/package.json
+++ b/packages/universal/service/package.json
@@ -17,6 +17,9 @@
     "types": "dist/index.d.ts"
   },
   "starbeam": {
+    "inline": [
+      "@starbeam/core-utils"
+    ],
     "type": "library:public"
   },
   "scripts": {
@@ -27,7 +30,6 @@
     "test:types": "tsc -b"
   },
   "dependencies": {
-    "@starbeam/core-utils": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/resource": "workspace:^",
@@ -35,6 +37,7 @@
     "@starbeam/shared": "workspace:^"
   },
   "devDependencies": {
+    "@starbeam/core-utils": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"
   },

--- a/packages/universal/tags/package.json
+++ b/packages/universal/tags/package.json
@@ -17,6 +17,9 @@
     "types": "dist/index.d.ts"
   },
   "starbeam": {
+    "inline": [
+      "@starbeam/core-utils"
+    ],
     "type": "library:public"
   },
   "scripts": {
@@ -26,12 +29,12 @@
     "test:types": "tsc -b"
   },
   "dependencies": {
-    "@starbeam/core-utils": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/shared": "workspace:^",
     "inspect-utils": "^1.0.1"
   },
   "devDependencies": {
+    "@starbeam/core-utils": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"
   },

--- a/packages/universal/universal/package.json
+++ b/packages/universal/universal/package.json
@@ -18,6 +18,7 @@
   },
   "starbeam": {
     "inline": [
+      "@starbeam/core-utils",
       "@starbeam/debug"
     ],
     "type": "library:public"
@@ -30,7 +31,6 @@
     "test:types": "tsc -b"
   },
   "dependencies": {
-    "@starbeam/core-utils": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/resource": "workspace:^",
@@ -41,6 +41,7 @@
     "stacktracey": "^2.2.0"
   },
   "devDependencies": {
+    "@starbeam/core-utils": "workspace:^",
     "@starbeam/debug": "workspace:^",
     "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",

--- a/packages/universal/verify/package.json
+++ b/packages/universal/verify/package.json
@@ -17,9 +17,6 @@
     "test:specs": "vitest --run --pool forks",
     "test:types": "tsc -b"
   },
-  "dependencies": {
-    "@starbeam/core-utils": "workspace:^"
-  },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"

--- a/packages/universal/verify/src/assertions/basic.ts
+++ b/packages/universal/verify/src/assertions/basic.ts
@@ -1,8 +1,15 @@
-import { isPresentArray } from "@starbeam/core-utils";
-
 import { alwaysTrue, expected, toKind } from "../verify.js";
 import { format } from "./describe.js";
 import type { FixedArray, ReadonlyFixedArray } from "./type-utils.js";
+
+type PresentArrayFor<T extends unknown[] | readonly unknown[] | undefined> =
+  T extends (infer Item)[]
+    ? [Item, ...Item[]]
+    : T extends readonly (infer Item)[]
+      ? readonly [Item, ...Item[]]
+      : never;
+
+const EMPTY_LENGTH = 0;
 
 export function isPresent<T>(value: T): value is Exclude<T, null | undefined> {
   return value !== null && value !== undefined;
@@ -92,13 +99,11 @@ export function hasLength<L extends number>(length: L): HasLength<L> {
   return alwaysTrue as HasLength<L>;
 }
 
-export const hasItems = isPresentArray;
-
-// export function hasItems<T>(
-//   value: readonly T[]
-// ): value is [T, ...(readonly T[])] {
-//   return value.length > 0;
-// }
+export function hasItems<T extends unknown[] | readonly unknown[] | undefined>(
+  value: T,
+): value is T & PresentArrayFor<T> {
+  return Boolean(value && value.length > EMPTY_LENGTH);
+}
 
 export function isNullable<In, Out extends In>(
   verifier: (value: In) => value is Out,
@@ -140,7 +145,6 @@ export function isNullable<In, Out extends In>(
   return alwaysTrue;
 }
 
-
 if (import.meta.env.DEV) {
   expected.associate(isPresent, expected.toBe("present"));
   expected.associate(hasItems, expected.toHave(`at least one item`));
@@ -156,5 +160,4 @@ if (import.meta.env.DEV) {
       .toBe("an object")
       .butGot((value) => (value === null ? "null" : typeof value)),
   );
-
 }

--- a/packages/vue/vue/package.json
+++ b/packages/vue/vue/package.json
@@ -21,6 +21,9 @@
       "index": "./index.ts",
       "setup": "./src/setup.ts"
     },
+    "inline": [
+      "@starbeam/core-utils"
+    ],
     "type": "library:public"
   },
   "scripts": {
@@ -31,7 +34,6 @@
     "test:types": "tsc -b"
   },
   "dependencies": {
-    "@starbeam/core-utils": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/renderer": "workspace:^",
@@ -43,6 +45,7 @@
     "@starbeam/universal": "workspace:^"
   },
   "devDependencies": {
+    "@starbeam/core-utils": "workspace:^",
     "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,9 +158,6 @@ importers:
       '@preact/signals':
         specifier: ^2.9.0
         version: 2.9.0(preact@10.29.1)
-      '@starbeam/core-utils':
-        specifier: workspace:^
-        version: link:../../universal/core-utils
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../../universal/interfaces
@@ -195,6 +192,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/core-utils':
+        specifier: workspace:^
+        version: link:../../universal/core-utils
       '@starbeam/verify':
         specifier: workspace:^
         version: link:../../universal/verify
@@ -374,9 +374,6 @@ importers:
       '@starbeam/collections':
         specifier: workspace:^
         version: link:../../universal/collections
-      '@starbeam/core-utils':
-        specifier: workspace:^
-        version: link:../../universal/core-utils
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../../universal/interfaces
@@ -420,6 +417,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/core-utils':
+        specifier: workspace:^
+        version: link:../../universal/core-utils
       '@starbeam/verify':
         specifier: workspace:^
         version: link:../../universal/verify
@@ -734,9 +734,6 @@ importers:
 
   packages/universal/reactive:
     dependencies:
-      '@starbeam/core-utils':
-        specifier: workspace:^
-        version: link:../core-utils
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../interfaces
@@ -750,6 +747,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/core-utils':
+        specifier: workspace:^
+        version: link:../core-utils
       '@starbeam/verify':
         specifier: workspace:^
         version: link:../verify
@@ -817,9 +817,6 @@ importers:
 
   packages/universal/resource:
     dependencies:
-      '@starbeam/core-utils':
-        specifier: workspace:^
-        version: link:../core-utils
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../interfaces
@@ -836,6 +833,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/core-utils':
+        specifier: workspace:^
+        version: link:../core-utils
       '@starbeam/verify':
         specifier: workspace:^
         version: link:../verify
@@ -875,9 +875,6 @@ importers:
 
   packages/universal/runtime:
     dependencies:
-      '@starbeam/core-utils':
-        specifier: workspace:^
-        version: link:../core-utils
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../interfaces
@@ -897,6 +894,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/core-utils':
+        specifier: workspace:^
+        version: link:../core-utils
       '@starbeam/verify':
         specifier: workspace:^
         version: link:../verify
@@ -930,9 +930,6 @@ importers:
 
   packages/universal/service:
     dependencies:
-      '@starbeam/core-utils':
-        specifier: workspace:^
-        version: link:../core-utils
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../interfaces
@@ -952,6 +949,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/core-utils':
+        specifier: workspace:^
+        version: link:../core-utils
       rollup:
         specifier: ^4.60.1
         version: 4.60.1
@@ -1018,9 +1018,6 @@ importers:
 
   packages/universal/tags:
     dependencies:
-      '@starbeam/core-utils':
-        specifier: workspace:^
-        version: link:../core-utils
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../interfaces
@@ -1034,15 +1031,15 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/core-utils':
+        specifier: workspace:^
+        version: link:../core-utils
       rollup:
         specifier: ^4.60.1
         version: 4.60.1
 
   packages/universal/universal:
     dependencies:
-      '@starbeam/core-utils':
-        specifier: workspace:^
-        version: link:../core-utils
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../interfaces
@@ -1071,6 +1068,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/core-utils':
+        specifier: workspace:^
+        version: link:../core-utils
       '@starbeam/debug':
         specifier: workspace:^
         version: link:../debug
@@ -1104,10 +1104,6 @@ importers:
         version: link:../../../../workspace/test-utils
 
   packages/universal/verify:
-    dependencies:
-      '@starbeam/core-utils':
-        specifier: workspace:^
-        version: link:../core-utils
     devDependencies:
       '@starbeam-dev/compile':
         specifier: workspace:*
@@ -1124,9 +1120,6 @@ importers:
 
   packages/vue/vue:
     dependencies:
-      '@starbeam/core-utils':
-        specifier: workspace:^
-        version: link:../../universal/core-utils
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../../universal/interfaces
@@ -1161,6 +1154,9 @@ importers:
       '@starbeam-dev/compile':
         specifier: workspace:*
         version: link:../../../workspace/dev-compile
+      '@starbeam/core-utils':
+        specifier: workspace:^
+        version: link:../../universal/core-utils
       '@starbeam/verify':
         specifier: workspace:^
         version: link:../../universal/verify

--- a/workspace/scripts/verify-debug-bootstrap.js
+++ b/workspace/scripts/verify-debug-bootstrap.js
@@ -7,7 +7,6 @@ const root = resolve(currentDir, "../..");
 
 const ARTIFACTS = new Map(
   [
-    ["@starbeam/core-utils", "packages/universal/core-utils/dist/index"],
     ["@starbeam/shared", "packages/universal/shared/dist/index"],
     ["@starbeam/tags", "packages/universal/tags/dist/index"],
     ["@starbeam/reactive", "packages/universal/reactive/dist/index"],


### PR DESCRIPTION
## Summary

- Mark `@starbeam/core-utils` private/internal and remove publish metadata.
- Inline `@starbeam/core-utils` into public package artifacts and remove public runtime manifest dependencies.
- Localize public declaration types that previously referenced `@starbeam/core-utils`.
- Keep `@starbeam/core-utils` as an internal source boundary for private/test packages.

## Validation

- `pnpm install --lockfile-only`
- `pnpm build`
- `node ./workspace/scripts/build-verify.js`
- `pnpm test:workspace:debug-bootstrap`
- `pnpm test:workspace:types`
- `pnpm test:workspace:pack` => `Verified 23 publishable packages.`
- `pnpm test:workspace:lint`
- public artifact/declaration/runtime manifest leak checks for `@starbeam/core-utils`
