### PR TITLE
Add renderer and modifier contract baselines

### DIFF
--- a/packages/react/react/package.json
+++ b/packages/react/react/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@starbeam/collections": "workspace:^",
     "@starbeam/interfaces": "workspace:^",
-    "@starbeam/modifier": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/renderer": "workspace:^",
     "@starbeam/resource": "workspace:^",

--- a/packages/universal/modifier/package.json
+++ b/packages/universal/modifier/package.json
@@ -23,6 +23,7 @@
     "build": "rollup -c",
     "prepack": "pnpm build",
     "test:lint": "eslint . --max-warnings 0",
+    "test:specs": "cd ../../../ && vitest --run --pool forks --project modifier",
     "test:types": "tsc -b"
   },
   "dependencies": {

--- a/packages/universal/modifier/tests/.npmrc
+++ b/packages/universal/modifier/tests/.npmrc
@@ -1,0 +1,1 @@
+link-workspace-packages=true

--- a/packages/universal/modifier/tests/element-placeholder.spec.ts
+++ b/packages/universal/modifier/tests/element-placeholder.spec.ts
@@ -1,0 +1,64 @@
+import { ElementPlaceholder } from "@starbeam/modifier";
+import { describe, expect, test } from "@starbeam-workspace/test-utils";
+
+type ElementConstructor<E extends Element> = abstract new <
+  Args extends unknown[],
+>(
+  ...args: Args
+) => E;
+
+class TestElement {
+  readonly tagName = "TEST";
+}
+
+class OtherElement {
+  readonly tagName = "OTHER";
+}
+
+const TEST_ELEMENT = TestElement as unknown as ElementConstructor<Element>;
+
+describe("ElementPlaceholder", () => {
+  test("current is null before initialization", () => {
+    const placeholder = ElementPlaceholder(TEST_ELEMENT, undefined);
+
+    expect(placeholder.current).toBeNull();
+  });
+
+  test("initialize accepts an instance of the constructor", () => {
+    const placeholder = ElementPlaceholder(TEST_ELEMENT, undefined);
+    const element = new TestElement() as Element;
+
+    placeholder.initialize(element);
+
+    expect(placeholder.current).toBe(element);
+  });
+
+  test("initialize rejects an instance of the wrong constructor", () => {
+    const placeholder = ElementPlaceholder(TEST_ELEMENT, undefined);
+    const element = new OtherElement();
+
+    if (import.meta.env.DEV) {
+      expect(() => {
+        placeholder.initialize(element as Element);
+      }).toThrowError("instance of TestElement");
+    } else {
+      placeholder.initialize(element as Element);
+    }
+
+    expect(placeholder.current).toBe(import.meta.env.DEV ? null : element);
+  });
+
+  test("initializing more than once throws after updating the current element", () => {
+    const placeholder = ElementPlaceholder(TEST_ELEMENT, undefined);
+    const first = new TestElement() as Element;
+    const second = new TestElement() as Element;
+
+    placeholder.initialize(first);
+
+    expect(() => {
+      placeholder.initialize(second);
+    }).toThrow(TypeError);
+
+    expect(placeholder.current).toBe(second);
+  });
+});

--- a/packages/universal/modifier/tests/package.json
+++ b/packages/universal/modifier/tests/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@starbeam-tests/renderer",
+  "name": "@starbeam-tests/modifier",
   "type": "module",
   "version": "1.0.0",
   "starbeam": {
@@ -12,10 +12,7 @@
     "test:types": "tsc -b"
   },
   "dependencies": {
-    "@starbeam/reactive": "workspace:^",
-    "@starbeam/renderer": "workspace:^",
-    "@starbeam/resource": "workspace:^",
-    "@starbeam/shared": "workspace:^",
+    "@starbeam/modifier": "workspace:^",
     "@starbeam-workspace/test-utils": "workspace:^"
   },
   "devDependencies": {}

--- a/packages/universal/modifier/tests/tsconfig.json
+++ b/packages/universal/modifier/tests/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../.config/tsconfig/tsconfig.shared.json",
+  "compilerOptions": {
+    "composite": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "types": ["../../../env.d.ts"],
+    "declaration": true,
+    "declarationDir": "../../../../dist/types",
+    "declarationMap": true,
+    "emitDeclarationOnly": true
+  },
+  "exclude": ["dist/**/*"]
+}

--- a/packages/universal/renderer/package.json
+++ b/packages/universal/renderer/package.json
@@ -23,7 +23,7 @@
     "build": "rollup -c",
     "prepack": "pnpm build",
     "test:lint": "eslint . --max-warnings 0",
-    "test:specs": "vitest --run --pool forks",
+    "test:specs": "cd ../../../ && vitest --run --pool forks --project renderer",
     "test:types": "tsc -b"
   },
   "dependencies": {

--- a/packages/universal/renderer/tests/smoke.spec.ts
+++ b/packages/universal/renderer/tests/smoke.spec.ts
@@ -1,36 +1,247 @@
-import { Cell } from "@starbeam/reactive";
-import type { RendererManager } from "@starbeam/renderer";
-import { managerSetupReactive } from "@starbeam/renderer";
-import { describe, expect, test } from "@starbeam-workspace/test-utils";
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+import { Cell, Marker } from "@starbeam/reactive";
+import type { Handler, RendererManager } from "@starbeam/renderer";
+import {
+  managerSetupReactive,
+  managerSetupResource,
+  managerSetupService,
+} from "@starbeam/renderer";
+import { Resource } from "@starbeam/resource";
+import { finalize } from "@starbeam/shared";
+import {
+  describe,
+  expect,
+  RecordedEvents,
+  test,
+} from "@starbeam-workspace/test-utils";
 
 const INITIAL = 0;
 
 describe("RendererManager", () => {
   test("smoke test", () => {
-    const manager: RendererManager<object> = {
-      getComponent: () => ({}),
-      setupValue: (_, create) => create(),
-      setupRef: (_, value) => ({ current: value }),
-      createNotifier: () => () => {},
-      createScheduler: () => ({
-        schedule: () => {},
-        onSchedule: () => {},
-      }),
-      on: {
-        idle: () => {
-          // do nothing
-        },
-        mounted: () => {
-          // do nothing
-        },
-        layout: () => {
-          // do nothing
-        },
-      },
-    } satisfies RendererManager<object>;
+    const manager = TestManager.create();
 
     const cell = Cell(INITIAL);
-    const reactive = managerSetupReactive(manager, () => cell);
+    const reactive = managerSetupReactive(manager, () => cell.current);
     expect(reactive.current).toBe(INITIAL);
   });
+
+  test("setupReactive reads reactive values", () => {
+    const manager = TestManager.create();
+    const cell = Cell(INITIAL);
+    const reactive = managerSetupReactive(manager, cell);
+
+    expect(reactive.current).toBe(INITIAL);
+
+    cell.current = 1;
+    expect(reactive.current).toBe(1);
+  });
+
+  test("setupReactive uses the latest blueprint ref", () => {
+    const manager = TestManager.create();
+    const first = Cell(1);
+    const second = Cell(2);
+
+    const reactive = managerSetupReactive(manager, () => first.current);
+    expect(reactive.current).toBe(1);
+
+    managerSetupReactive(manager, () => second.current);
+    expect(reactive.current).toBe(1);
+
+    first.current = 10;
+    expect(reactive.current).toBe(2);
+
+    second.current = 3;
+    expect(reactive.current).toBe(3);
+  });
+
+  test("setupResource defers sync and subscriptions until mounted", () => {
+    const manager = TestManager.create();
+    const events = new RecordedEvents();
+    const invalidate = Marker();
+
+    const Counter = Resource(({ on }) => {
+      events.record("resource:setup");
+      const count = Cell(0);
+
+      on.sync(() => {
+        events.record("resource:sync");
+        invalidate.read();
+      });
+
+      return {
+        get count() {
+          return count.current;
+        },
+      };
+    });
+
+    const counter = managerSetupResource(manager, Counter);
+    expect(counter.count).toBe(0);
+    events.expect("resource:setup");
+
+    invalidate.mark();
+    events.expect([]);
+    expect(manager.scheduledCount).toBe(0);
+
+    manager.mount();
+    events.expect("resource:sync");
+
+    invalidate.mark();
+    events.expect([]);
+    expect(manager.scheduledCount).toBe(1);
+
+    manager.flushScheduled();
+    events.expect("resource:sync");
+
+    invalidate.mark();
+    manager.flushScheduled();
+    events.expect("resource:sync");
+  });
+
+  test("setupResource unsubscribes from runtime invalidation when finalized", () => {
+    const manager = TestManager.create();
+    const events = new RecordedEvents();
+    const invalidate = Marker();
+
+    const Counter = Resource(({ on }) => {
+      events.record("resource:setup");
+
+      on.sync(() => {
+        events.record("resource:sync");
+        invalidate.read();
+      });
+
+      return {};
+    });
+
+    managerSetupResource(manager, Counter);
+    events.expect("resource:setup");
+
+    manager.mount();
+    events.expect("resource:sync");
+
+    finalize(manager.component);
+
+    invalidate.mark();
+    expect(manager.scheduledCount).toBe(0);
+
+    manager.flushScheduled();
+    events.expect([]);
+  });
+
+  test("setupService shares service instances for a stable app", () => {
+    const app = {};
+    const first = TestManager.create({ app });
+    const second = TestManager.create({ app });
+    let setups = 0;
+
+    const Counter = Resource(() => {
+      const count = Cell(++setups);
+
+      return {
+        get count() {
+          return count.current;
+        },
+        increment() {
+          count.current++;
+        },
+      };
+    });
+
+    const firstCounter = managerSetupService(first, Counter);
+    const secondCounter = managerSetupService(second, Counter);
+
+    expect(firstCounter).toBe(secondCounter);
+    expect(firstCounter.count).toBe(1);
+
+    secondCounter.increment();
+    expect(firstCounter.count).toBe(2);
+    expect(setups).toBe(1);
+  });
 });
+
+class TestManager implements RendererManager<object> {
+  static create(options: { app?: object } = {}): TestManager {
+    return new TestManager(options.app);
+  }
+
+  readonly component = {};
+  readonly #app: object | undefined;
+  readonly #values = new WeakMap<() => unknown, unknown>();
+  readonly #refs = new Map<object, { current: unknown }>();
+  readonly #mountedHandlers = new Set<Handler>();
+  readonly #idleHandlers = new Set<Handler>();
+  readonly #layoutHandlers = new Set<Handler>();
+  readonly #schedulerHandlers = new Set<Handler>();
+  #scheduledCount = 0;
+
+  private constructor(app: object | undefined) {
+    this.#app = app;
+  }
+
+  get scheduledCount(): number {
+    return this.#scheduledCount;
+  }
+
+  getComponent = (): object => this.component;
+  getApp = (): object | undefined => this.#app;
+
+  setupValue = <T>(_instance: object, create: () => T): T => {
+    if (this.#values.has(create)) {
+      return this.#values.get(create) as T;
+    }
+
+    const value = create();
+    this.#values.set(create, value);
+    return value;
+  };
+
+  setupRef = <T>(instance: object, value: T): { readonly current: T } => {
+    let ref = this.#refs.get(instance);
+
+    if (!ref) {
+      ref = { current: value };
+      this.#refs.set(instance, ref);
+    } else {
+      ref.current = value;
+    }
+
+    return ref as { readonly current: T };
+  };
+
+  createNotifier = (): (() => void) => () => {};
+
+  createScheduler = (): {
+    readonly onSchedule: (handler: Handler) => void;
+    readonly schedule: () => void;
+  } => ({
+    onSchedule: (handler) => void this.#schedulerHandlers.add(handler),
+    schedule: () => void this.#scheduledCount++,
+  });
+
+  on = {
+    mounted: (_instance: object, handler: Handler): void => {
+      this.#mountedHandlers.add(handler);
+    },
+    idle: (_instance: object, handler: Handler): void => {
+      this.#idleHandlers.add(handler);
+    },
+    layout: (_instance: object, handler: Handler): void => {
+      this.#layoutHandlers.add(handler);
+    },
+  };
+
+  mount(): void {
+    run(this.#mountedHandlers);
+  }
+
+  flushScheduled(): void {
+    this.#scheduledCount = 0;
+    run(this.#schedulerHandlers);
+  }
+}
+
+function run(handlers: Set<Handler>): void {
+  for (const handler of handlers) handler();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,9 +377,6 @@ importers:
       '@starbeam/interfaces':
         specifier: workspace:^
         version: link:../../universal/interfaces
-      '@starbeam/modifier':
-        specifier: workspace:^
-        version: link:../../universal/modifier
       '@starbeam/reactive':
         specifier: workspace:^
         version: link:../../universal/reactive
@@ -732,6 +729,15 @@ importers:
         specifier: ^4.60.1
         version: 4.60.1
 
+  packages/universal/modifier/tests:
+    dependencies:
+      '@starbeam-workspace/test-utils':
+        specifier: workspace:^
+        version: link:../../../../workspace/test-utils
+      '@starbeam/modifier':
+        specifier: workspace:^
+        version: link:..
+
   packages/universal/reactive:
     dependencies:
       '@starbeam/interfaces':
@@ -811,9 +817,18 @@ importers:
       '@starbeam-workspace/test-utils':
         specifier: workspace:^
         version: link:../../../../workspace/test-utils
+      '@starbeam/reactive':
+        specifier: workspace:^
+        version: link:../../reactive
       '@starbeam/renderer':
         specifier: workspace:^
         version: link:..
+      '@starbeam/resource':
+        specifier: workspace:^
+        version: link:../../resource
+      '@starbeam/shared':
+        specifier: workspace:^
+        version: link:../../shared
 
   packages/universal/resource:
     dependencies:


### PR DESCRIPTION
## Summary

- Add contract tests for the current `@starbeam/renderer` manager helpers.
- Add baseline tests for `@starbeam/modifier`'s existing `ElementPlaceholder` behavior.
- Add modifier test package wiring and package-level spec scripts.
- Remove stale `@starbeam/modifier` dependency from `@starbeam/react`.

## Notes

This is the first renderer/modifier hardening PR. It intentionally pins current behavior before changing package boundaries or designing new modifier/ref APIs.

## Validation

- `pnpm --filter @starbeam/renderer test:specs`
- `pnpm --filter @starbeam/modifier test:specs`
- `STARBEAM_TEST_PROD=1 pnpm exec vitest --run --pool forks --project modifier`
- `pnpm --filter @starbeam/modifier test:types`
- `pnpm test:workspace:types`
- `pnpm test:workspace:pack` => `Verified 23 publishable packages.`
- `pnpm test:workspace:lint`
