### PR TITLE
Make modifier package private

### DIFF
--- a/packages/universal/modifier/package.json
+++ b/packages/universal/modifier/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@starbeam/modifier",
   "type": "module",
   "version": "0.8.9",
@@ -7,21 +8,11 @@
   "exports": {
     "default": "./index.ts"
   },
-  "publishConfig": {
-    "exports": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
-  },
   "starbeam": {
-    "type": "library:public"
+    "type": "library:internal"
   },
   "scripts": {
     "build": "rollup -c",
-    "prepack": "pnpm build",
     "test:lint": "eslint . --max-warnings 0",
     "test:specs": "cd ../../../ && vitest --run --pool forks --project modifier",
     "test:types": "tsc -b"
@@ -38,16 +29,5 @@
     "@starbeam/verify": "workspace:^",
     "@starbeam-dev/compile": "workspace:*",
     "rollup": "^4.60.1"
-  },
-  "files": [
-    "dist",
-    "README.md",
-    "CHANGELOG.md",
-    "LICENSE.md"
-  ],
-  "release-plan": {
-    "semverIncrementAs": {
-      "major": "minor"
-    }
   }
 }


### PR DESCRIPTION
## Summary

- Mark `@starbeam/modifier` private/internal and remove publish metadata.
- Preserve the existing `ElementPlaceholder` implementation and contract tests.
- Keep `@domtree/*` unchanged for a separate package-boundary decision.

## Notes

This PR does not delete the modifier concept or design a new public modifier/ref API. It only removes the current single-export `@starbeam/modifier` package from the 0.9 public npm surface while keeping its behavior covered internally.

## Validation

- `pnpm --filter @starbeam/modifier test:specs`
- `STARBEAM_TEST_PROD=1 pnpm exec vitest --run --pool forks --project modifier`
- `pnpm --filter @starbeam/modifier test:types`
- `pnpm test:workspace:types`
- `pnpm test:workspace:pack` => `Verified 22 publishable packages.`
- `pnpm test:workspace:lint`
- public manifest/artifact/declaration leak checks for `@starbeam/modifier`
