### PR TITLE
Make domtree packages private

### DIFF
--- a/packages/universal/interfaces/package.json
+++ b/packages/universal/interfaces/package.json
@@ -23,7 +23,6 @@
     "test:types": "tsc -b"
   },
   "dependencies": {
-    "@domtree/any": "workspace:^",
     "@starbeam/shared": "workspace:^"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -687,9 +687,6 @@ importers:
 
   packages/universal/interfaces:
     dependencies:
-      '@domtree/any':
-        specifier: workspace:^
-        version: link:../../../workspace/@domtree/any
       '@starbeam/shared':
         specifier: workspace:^
         version: link:../shared

--- a/workspace/@domtree/any/package.json
+++ b/workspace/@domtree/any/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@domtree/any",
   "type": "module",
   "version": "0.9.3",
@@ -7,15 +8,8 @@
   "exports": {
     "default": "./index.ts"
   },
-  "publishConfig": {
-    "exports": {
-      "types": "./dist/index.d.ts"
-    },
-    "types": "dist/index.d.ts"
-  },
   "starbeam": {
-    "source": "ts",
-    "type": "library:interfaces"
+    "type": "library:internal"
   },
   "scripts": {
     "test:lint": "eslint . --max-warnings 0",
@@ -28,10 +22,5 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*"
-  },
-  "release-plan": {
-    "semverIncrementAs": {
-      "major": "minor"
-    }
   }
 }

--- a/workspace/@domtree/browser/package.json
+++ b/workspace/@domtree/browser/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@domtree/browser",
   "type": "module",
   "version": "0.9.3",
@@ -7,15 +8,8 @@
   "exports": {
     "default": "./index.ts"
   },
-  "publishConfig": {
-    "exports": {
-      "types": "./dist/index.d.ts"
-    },
-    "types": "dist/index.d.ts"
-  },
   "starbeam": {
-    "source": "ts",
-    "type": "library:interfaces"
+    "type": "library:internal"
   },
   "scripts": {
     "test:lint": "eslint . --max-warnings 0",
@@ -26,10 +20,5 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*"
-  },
-  "release-plan": {
-    "semverIncrementAs": {
-      "major": "minor"
-    }
   }
 }

--- a/workspace/@domtree/flavors/package.json
+++ b/workspace/@domtree/flavors/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@domtree/flavors",
   "type": "module",
   "version": "0.9.3",
@@ -7,15 +8,8 @@
   "exports": {
     "default": "./index.ts"
   },
-  "publishConfig": {
-    "exports": {
-      "types": "./dist/index.d.ts"
-    },
-    "types": "dist/index.d.ts"
-  },
   "starbeam": {
-    "source": "ts",
-    "type": "library:interfaces"
+    "type": "library:internal"
   },
   "scripts": {
     "test:lint": "eslint . --max-warnings 0",
@@ -28,10 +22,5 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*"
-  },
-  "release-plan": {
-    "semverIncrementAs": {
-      "major": "minor"
-    }
   }
 }

--- a/workspace/@domtree/interface/package.json
+++ b/workspace/@domtree/interface/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@domtree/interface",
   "type": "module",
   "version": "0.9.3",
@@ -7,15 +8,8 @@
   "exports": {
     "default": "./index.ts"
   },
-  "publishConfig": {
-    "exports": {
-      "types": "./dist/index.d.ts"
-    },
-    "types": "dist/index.d.ts"
-  },
   "starbeam": {
-    "source": "ts",
-    "type": "library:interfaces"
+    "type": "library:internal"
   },
   "scripts": {
     "test:lint": "eslint . --max-warnings 0",
@@ -23,10 +17,5 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*"
-  },
-  "release-plan": {
-    "semverIncrementAs": {
-      "major": "minor"
-    }
   }
 }

--- a/workspace/@domtree/minimal/package.json
+++ b/workspace/@domtree/minimal/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@domtree/minimal",
   "type": "module",
   "version": "0.9.3",
@@ -7,15 +8,8 @@
   "exports": {
     "default": "./index.ts"
   },
-  "publishConfig": {
-    "exports": {
-      "types": "./dist/index.d.ts"
-    },
-    "types": "dist/index.d.ts"
-  },
   "starbeam": {
-    "source": "ts",
-    "type": "library:interfaces"
+    "type": "library:internal"
   },
   "scripts": {
     "test:lint": "eslint . --max-warnings 0",
@@ -26,10 +20,5 @@
   },
   "devDependencies": {
     "@starbeam-dev/compile": "workspace:*"
-  },
-  "release-plan": {
-    "semverIncrementAs": {
-      "major": "minor"
-    }
   }
 }


### PR DESCRIPTION
## Summary

- make the five `@domtree/*` packages private/internal
- remove stale `@domtree/any` dependency from `@starbeam/interfaces`
- refresh the lockfile importer metadata

## Validation

- `pnpm --filter @starbeam/interfaces --filter @starbeam/modifier --filter @domtree/any --filter @domtree/browser --filter @domtree/flavors --filter @domtree/interface --filter @domtree/minimal test:types`
- `pnpm test:workspace:pack` -> `Verified 17 publishable packages.`
- pre-commit: workspace types + lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types

## Notes

This keeps the domtree source boundaries intact while removing them from the 0.9 publish surface. The only remaining non-domtree usage is private/internal `@starbeam/modifier` via a devDependency on `@domtree/flavors`.
