### PR TITLE
Classify renderer public surface

### DIFF
--- a/packages/universal/renderer/README.md
+++ b/packages/universal/renderer/README.md
@@ -21,6 +21,24 @@ shared manager model. React has stricter lifecycle constraints than Preact and
 Vue, so its adapter uses the same renderer vocabulary but owns more of the
 resource timing itself.
 
+## Surface Layers
+
+The renderer surface is organized for framework adapter authors, not app code.
+Its exports fall into a few layers:
+
+| Layer | Exports | Purpose |
+| ----- | ------- | ------- |
+| Contract vocabulary | `RendererManager`, `Lifecycle`, `ComponentScheduler`, `Handler`, `SetupBlueprint`, `ReactiveBlueprint`, `UseReactive` | Describes the boundary an adapter implements and the lifecycle object Starbeam code receives. |
+| Resource conversion | `IntoResourceBlueprint`, `intoResourceBlueprint` | Normalizes resource-like input before an adapter creates or looks up resources. |
+| Shared manager helpers | `managerCreateLifecycle`, `managerSetupReactive`, `managerSetupResource`, `managerSetupService` | Implements the common setup path for adapters whose lifecycle can use the shared manager model. |
+| Handler utility | `runHandlers` | Invokes a set of lifecycle or scheduler handlers. |
+
+`RendererManager` also includes hooks such as `createNotifier` and
+`createScheduler` that official adapters implement at their framework boundary.
+Not every shared helper consumes every manager hook, but the manager contract is
+the single place where adapter-specific scheduling and notification behavior is
+described.
+
 ## Official Renderer Compatibility
 
 | Framework | Renderer Status | Spec Compatibility |
@@ -34,9 +52,11 @@ resource timing itself.
 
 "Spec compatibility" means compatibility with the API design in this document.
 
-## Core API
+## Official Adapter API Shape
 
-These APIs exist in all renderers.
+The sections below describe the APIs that official framework packages expose on
+top of the renderer contract. They are the expected shape of framework adapters,
+not direct exports from `@starbeam/renderer`.
 
 | API             | Parameter               | Returns                 |
 | --------------- | ----------------------- | ----------------------- |

--- a/packages/universal/renderer/index.ts
+++ b/packages/universal/renderer/index.ts
@@ -1,3 +1,4 @@
+// Contract vocabulary for framework adapter authors.
 export type {
   Scheduler as ComponentScheduler,
   Handler,
@@ -7,6 +8,8 @@ export type {
   SetupBlueprint,
   UseReactive,
 } from "./src/renderer.js";
+
+// Shared manager helpers and handler utility.
 export {
   managerCreateLifecycle,
   managerSetupReactive,
@@ -14,5 +17,7 @@ export {
   managerSetupService,
   runHandlers,
 } from "./src/renderer.js";
+
+// Resource conversion.
 export type { IntoResourceBlueprint } from "./src/resource.js";
 export { intoResourceBlueprint } from "./src/resource.js";

--- a/packages/universal/renderer/src/renderer.ts
+++ b/packages/universal/renderer/src/renderer.ts
@@ -182,6 +182,6 @@ export function managerSetupService<T>(
 
 export type Handler = () => void;
 
-export function runHandlers(handlers: Set<() => void>): void {
+export function runHandlers(handlers: ReadonlySet<Handler>): void {
   handlers.forEach((handler) => void handler());
 }

--- a/packages/universal/renderer/src/renderer.ts
+++ b/packages/universal/renderer/src/renderer.ts
@@ -91,7 +91,7 @@ class LifecycleImpl implements Lifecycle {
   };
 
   get lifetime(): object {
-    return this.#manager.getComponent() as object;
+    return this.#component;
   }
 
   use = <T>(blueprint: IntoResourceBlueprint<T>): T =>

--- a/packages/universal/renderer/tests/smoke.spec.ts
+++ b/packages/universal/renderer/tests/smoke.spec.ts
@@ -6,6 +6,7 @@ import {
   managerSetupReactive,
   managerSetupResource,
   managerSetupService,
+  runHandlers,
 } from "@starbeam/renderer";
 import { Resource } from "@starbeam/resource";
 import { finalize } from "@starbeam/shared";
@@ -78,6 +79,28 @@ describe("RendererManager", () => {
 
     manager.flushLayout();
     events.expect("layout");
+  });
+
+  test("createLifecycle captures the component lifetime", () => {
+    const manager = TestManager.create();
+    const component = manager.getComponent();
+    const lifecycle = managerCreateLifecycle(manager);
+    const nextComponent = manager.replaceComponent();
+
+    expect(nextComponent).not.toBe(component);
+    expect(lifecycle.lifetime).toBe(component);
+  });
+
+  test("runHandlers invokes registered handlers", () => {
+    const events = new RecordedEvents();
+    const handlers = new Set<Handler>();
+
+    handlers.add(() => void events.record("first"));
+    handlers.add(() => void events.record("second"));
+
+    runHandlers(handlers);
+
+    events.expect("first", "second");
   });
 
   test("setupResource defers sync and subscriptions until mounted", () => {
@@ -191,7 +214,7 @@ class TestManager implements RendererManager<object> {
     return new TestManager(options.app);
   }
 
-  readonly component = {};
+  #component = {};
   readonly #app: object | undefined;
   readonly #values = new WeakMap<() => unknown, unknown>();
   readonly #refs = new Map<object, { current: unknown }>();
@@ -209,8 +232,17 @@ class TestManager implements RendererManager<object> {
     return this.#scheduledCount;
   }
 
-  getComponent = (): object => this.component;
+  get component(): object {
+    return this.#component;
+  }
+
+  getComponent = (): object => this.#component;
   getApp = (): object | undefined => this.#app;
+
+  replaceComponent(): object {
+    this.#component = {};
+    return this.#component;
+  }
 
   setupValue = <T>(_instance: object, create: () => T): T => {
     if (this.#values.has(create)) {
@@ -258,23 +290,19 @@ class TestManager implements RendererManager<object> {
   };
 
   mount(): void {
-    run(this.#mountedHandlers);
+    runHandlers(this.#mountedHandlers);
   }
 
   flushScheduled(): void {
     this.#scheduledCount = 0;
-    run(this.#schedulerHandlers);
+    runHandlers(this.#schedulerHandlers);
   }
 
   flushIdle(): void {
-    run(this.#idleHandlers);
+    runHandlers(this.#idleHandlers);
   }
 
   flushLayout(): void {
-    run(this.#layoutHandlers);
+    runHandlers(this.#layoutHandlers);
   }
-}
-
-function run(handlers: Set<Handler>): void {
-  for (const handler of handlers) handler();
 }


### PR DESCRIPTION
## Summary
- document `@starbeam/renderer` surface layers for adapter authors
- group the public exports by contract vocabulary, manager helpers, resource conversion, and handler utility
- pin lifecycle identity and `runHandlers` behavior in renderer tests
- make `LifecycleImpl.lifetime` return the component captured when the lifecycle was created

## Prepare / Execute / Review (PER)
This is the Renderer Surface Taxonomy slice of the renderer hardening arc. The hypothesis was that renderer can remain plausibly public if its public surface is visibly layered and tested as an adapter-author contract, without changing package visibility.

Review found no blockers: the docs do not overclaim direct exports, the source fix matches the lifecycle contract, and the scope stayed inside renderer docs/index/source/tests.

## Validation
- `pnpm --filter @starbeam/renderer test:types`
- `pnpm --filter @starbeam/renderer test:specs`
- `pnpm --filter @starbeam/renderer test:lint`
- `pnpm test:workspace:pack`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types