### PR TITLE
Harden renderer manager contract tests

### DIFF
--- a/packages/universal/renderer/src/renderer.ts
+++ b/packages/universal/renderer/src/renderer.ts
@@ -46,7 +46,11 @@ export interface RendererManager<C extends object> {
   readonly getApp?: (instance: C) => object | undefined;
   readonly setupValue: <T>(instance: C, create: () => T) => T;
   readonly setupRef: <T>(instance: C, value: T) => { readonly current: T };
+
+  /** Create a framework-native notifier for adapters that need one. */
   readonly createNotifier: (instance: C) => () => void;
+
+  /** Create the scheduler used by shared resource setup after mount. */
   readonly createScheduler: (instance: C) => Scheduler;
   readonly on: {
     readonly mounted: (instance: C, handler: Handler) => void;

--- a/packages/universal/renderer/src/renderer.ts
+++ b/packages/universal/renderer/src/renderer.ts
@@ -50,7 +50,10 @@ export interface RendererManager<C extends object> {
   /** Create a framework-native notifier for adapters that need one. */
   readonly createNotifier: (instance: C) => () => void;
 
-  /** Create the scheduler used by shared resource setup after mount. */
+  /**
+   * Create a scheduler during setup. Shared resource setup registers scheduler
+   * handlers and runtime subscriptions when the component mounts.
+   */
   readonly createScheduler: (instance: C) => Scheduler;
   readonly on: {
     readonly mounted: (instance: C, handler: Handler) => void;

--- a/packages/universal/renderer/tests/smoke.spec.ts
+++ b/packages/universal/renderer/tests/smoke.spec.ts
@@ -236,7 +236,7 @@ class TestManager implements RendererManager<object> {
 
   #component = {};
   readonly #app: object | undefined;
-  readonly #createNotifier: () => () => void;
+  readonly #createNotifier: (instance: object) => () => void;
   readonly #values = new WeakMap<() => unknown, unknown>();
   readonly #refs = new Map<object, { current: unknown }>();
   readonly #mountedHandlers = new Set<Handler>();
@@ -293,9 +293,10 @@ class TestManager implements RendererManager<object> {
     return ref as { readonly current: T };
   };
 
-  createNotifier = (): (() => void) => this.#createNotifier();
+  createNotifier = (instance: object): (() => void) =>
+    this.#createNotifier(instance);
 
-  createScheduler = (): {
+  createScheduler = (_instance: object): {
     readonly onSchedule: (handler: Handler) => void;
     readonly schedule: () => void;
   } => ({
@@ -335,5 +336,5 @@ class TestManager implements RendererManager<object> {
 
 interface TestManagerOptions {
   readonly app?: object;
-  readonly createNotifier?: () => () => void;
+  readonly createNotifier?: (instance: object) => () => void;
 }

--- a/packages/universal/renderer/tests/smoke.spec.ts
+++ b/packages/universal/renderer/tests/smoke.spec.ts
@@ -103,6 +103,24 @@ describe("RendererManager", () => {
     events.expect("first", "second");
   });
 
+  test("shared manager helpers do not consume notifier", () => {
+    const app = {};
+    const manager = TestManager.create({
+      app,
+      createNotifier: () => {
+        throw Error("createNotifier should not be called by shared helpers");
+      },
+    });
+
+    const cell = Cell(1);
+    const Counter = Resource(() => ({ count: cell.current }));
+
+    expect(managerCreateLifecycle(manager).lifetime).toBe(manager.component);
+    expect(managerSetupReactive(manager, cell).current).toBe(1);
+    expect(managerSetupResource(manager, Counter).count).toBe(1);
+    expect(managerSetupService(manager, Counter).count).toBe(1);
+  });
+
   test("setupResource defers sync and subscriptions until mounted", () => {
     const manager = TestManager.create();
     const events = new RecordedEvents();
@@ -131,9 +149,11 @@ describe("RendererManager", () => {
     invalidate.mark();
     events.expect([]);
     expect(manager.scheduledCount).toBe(0);
+    expect(manager.schedulerHandlerCount).toBe(0);
 
     manager.mount();
     events.expect("resource:sync");
+    expect(manager.schedulerHandlerCount).toBe(1);
 
     invalidate.mark();
     events.expect([]);
@@ -210,12 +230,13 @@ describe("RendererManager", () => {
 });
 
 class TestManager implements RendererManager<object> {
-  static create(options: { app?: object } = {}): TestManager {
-    return new TestManager(options.app);
+  static create(options: TestManagerOptions = {}): TestManager {
+    return new TestManager(options);
   }
 
   #component = {};
   readonly #app: object | undefined;
+  readonly #createNotifier: () => () => void;
   readonly #values = new WeakMap<() => unknown, unknown>();
   readonly #refs = new Map<object, { current: unknown }>();
   readonly #mountedHandlers = new Set<Handler>();
@@ -224,12 +245,17 @@ class TestManager implements RendererManager<object> {
   readonly #schedulerHandlers = new Set<Handler>();
   #scheduledCount = 0;
 
-  private constructor(app: object | undefined) {
-    this.#app = app;
+  private constructor(options: TestManagerOptions) {
+    this.#app = options.app;
+    this.#createNotifier = options.createNotifier ?? (() => () => {});
   }
 
   get scheduledCount(): number {
     return this.#scheduledCount;
+  }
+
+  get schedulerHandlerCount(): number {
+    return this.#schedulerHandlers.size;
   }
 
   get component(): object {
@@ -267,7 +293,7 @@ class TestManager implements RendererManager<object> {
     return ref as { readonly current: T };
   };
 
-  createNotifier = (): (() => void) => () => {};
+  createNotifier = (): (() => void) => this.#createNotifier();
 
   createScheduler = (): {
     readonly onSchedule: (handler: Handler) => void;
@@ -305,4 +331,9 @@ class TestManager implements RendererManager<object> {
   flushLayout(): void {
     runHandlers(this.#layoutHandlers);
   }
+}
+
+interface TestManagerOptions {
+  readonly app?: object;
+  readonly createNotifier?: () => () => void;
 }


### PR DESCRIPTION
## Summary
- document the renderer manager hooks that matter to adapter authors
- prove shared renderer helpers do not consume `createNotifier`
- strengthen the resource setup test around mount-gated scheduler handler registration

## Prepare / Execute / Review (PER)
This is the Manager Contract Conformance slice of the renderer hardening arc. The hypothesis was that `RendererManager` is a credible adapter-author boundary if we make the helper obligations explicit and test the difference between framework-boundary vocabulary and shared-helper dependencies.

The review pass found no blockers. One nuance: this PR proves scheduler handler/subscription registration is mounted-gated; `managerSetupResource` still constructs the scheduler before mount.

## Validation
- `pnpm --filter @starbeam/renderer test:specs`
- `pnpm --filter @starbeam/renderer test:types`
- `pnpm --filter @starbeam/renderer test:lint`
- `pnpm --filter @starbeam/react test:types`
- `pnpm --filter @starbeam/preact test:types`
- `pnpm --filter @starbeam/vue test:types`
- `pnpm test:workspace:pack`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types