### PR TITLE
Document React resource contract boundary

### DIFF
--- a/packages/universal/renderer/README.md
+++ b/packages/universal/renderer/README.md
@@ -39,6 +39,12 @@ Not every shared helper consumes every manager hook, but the manager contract is
 the single place where adapter-specific scheduling and notification behavior is
 described.
 
+React participates in the renderer contract vocabulary, but resources are the
+important exception. React resource setup requires React hook state, so
+resources must be declared through the public `useResource` hook at top-level
+hook position. `Lifecycle.use` inside `useSetup` is not a supported React
+resource path. React does not expose a direct `setupResource` package API.
+
 ## Official Renderer Compatibility
 
 | Framework | Renderer Status | Spec Compatibility |
@@ -61,10 +67,11 @@ not direct exports from `@starbeam/renderer`.
 | API             | Parameter               | Returns                 |
 | --------------- | ----------------------- | ----------------------- |
 | `setupReactive` | `() => Reactive<T>`     | [`Native<T>`]           |
-| `setupResource` | `IntoResourceBlueprint` | [`Native<T>`] React[^1] |
+| `setupResource` | `IntoResourceBlueprint` | [`Native<T>`][^1]       |
 | `getService`    | `IntoResourceBlueprint` | [`Native<T>`]           |
 
-[^1]: React returns `Reactive<T | undefined>` from `setupResource` (see [React Resources](#resources-in-react)).
+[^1]: React's resource path is the public `useResource` hook, not a direct
+  `setupResource` export.
 
 ### Framework-Native Reactive Values (`Native<T>`)
 
@@ -109,15 +116,17 @@ React and Preact are hook-style renderers. Solid is not.
 
 ### API Summary
 
-Hook-style renderers include the core APIs, which return reactive values.
+Hook-style renderers can include core APIs, which return reactive values. React
+is the resource exception: React resources are declared through `useResource`,
+not through a setup-lifecycle resource API.
 
 In addition, they include idiomatic hooks that return bare values.
 
-| Purpose  | Core API                                           | Hook API                                 |
-| -------- | -------------------------------------------------- | ---------------------------------------- |
-| Reactive | `setupReactive(ReactiveBlueprint<T>) => Native<T>` | `useReactive(ReactiveBlueprint<T>) => T` |
-| Resource | `setupResource(ResourceBlueprint<T>) => Native<T>` | `useResource(ResourceBlueprint<T>) => T` |
-| Service  | `setupService(ResourceBlueprint<T>) => Native<T>`  | `useService(ResourceBlueprint<T>) => T`  |
+| Purpose  | Core API                                                   | Hook API                                 |
+| -------- | ---------------------------------------------------------- | ---------------------------------------- |
+| Reactive | `setupReactive(ReactiveBlueprint<T>) => Native<T>`         | `useReactive(ReactiveBlueprint<T>) => T` |
+| Resource | `setupResource(ResourceBlueprint<T>) => Native<T>` except React | `useResource(ResourceBlueprint<T>) => T` |
+| Service  | `setupService(ResourceBlueprint<T>) => Native<T>`          | `useService(ResourceBlueprint<T>) => T`  |
 
 In addition, hook-style renderers include a hook that runs during Starbeam's
 setup phase: `useInstance`.
@@ -327,7 +336,7 @@ other, they are fundamental very similar:
 
 | Renderer | Setup API                             | Hook API             |
 | -------- | ------------------------------------- | -------------------- |
-| React    | `setupResource() => Reactive<T>`      | `useResource() => T` |
+| React    | Not supported via setup lifecycle     | `useResource() => T` |
 | Preact   | `setupResource() => Signal<T>`        | `useResource() => T` |
 | Solid    | `setupResource() => Signal<T>`        | N/A                  |
 | Vue      | `setupResource() => Ref<T>`           | N/A                  |
@@ -338,7 +347,7 @@ other, they are fundamental very similar:
 
 | Renderer | Setup API                          | Hook API            |
 | -------- | ---------------------------------- | ------------------- |
-| React    | `getService() => Reactive<T>`      | `useService() => T` |
+| React    | `Lifecycle.service() via useSetup()` | `useService() => T` |
 | Preact   | `getService() => Signal<T>`        | `useService() => T` |
 | Solid    | `getService() => Signal<T>`        | N/A                 |
 | Vue      | `getService() => Ref<T>`           | N/A                 |

--- a/packages/universal/renderer/README.md
+++ b/packages/universal/renderer/README.md
@@ -67,7 +67,7 @@ not direct exports from `@starbeam/renderer`.
 | API             | Parameter               | Returns                 |
 | --------------- | ----------------------- | ----------------------- |
 | `setupReactive` | `() => Reactive<T>`     | [`Native<T>`]           |
-| `setupResource` | `IntoResourceBlueprint` | [`Native<T>`][^1]       |
+| `setupResource` | `IntoResourceBlueprint` | [`Native<T>`] [^1]      |
 | `getService`    | `IntoResourceBlueprint` | [`Native<T>`]           |
 
 [^1]: React's resource path is the public `useResource` hook, not a direct
@@ -390,7 +390,7 @@ _unmounting_.
 
 Most users will encounter this when using React strict mode. Because Starbeam is
 going with the React grain and cleaning up resources when a component is
-unmounted, `setupResource` and `useResource` work transparently in React strict mode.
+unmounted, `useResource` works transparently in React strict mode.
 
 ### Resources in React
 
@@ -403,10 +403,11 @@ run, or a cleanup phase may not run at all.
 As a result, Starbeam resources cannot be instantiated until React's special
 [Resource Setup Phase](#special-phases).
 
-In practice, this means that resources are `undefined` during the initial render
-of a React component. If `undefined` is not desirable, React's `setupResource`
-has an `initial` option that you can use to specify what the initial value of
-the resource should be during initial render.
+In practice, React resources are declared through the public `useResource` hook.
+That hook creates the resource value at top-level hook position and defers sync,
+subscriptions, and cleanup registration until React's resource setup phase.
+`Lifecycle.use` inside `useSetup` is not a supported React resource path because
+it would call React hooks from inside a setup blueprint.
 
 > Note that this is a fundamental consequence of React's decision to disallow
 > render functions from registering cleanup handlers at the top level.


### PR DESCRIPTION
## Summary
- clarify that React participates in renderer contract vocabulary but is not resource-helper equivalent
- document `useResource` as React's resource path instead of implying a direct `setupResource` API
- update hook-style and renderer API tables so React no longer overclaims setup-lifecycle resource support

## Prepare / Execute / Review (PER)
This is the React Contract Equivalence slice of the renderer hardening arc. The initial discriminator tested whether `useSetup(({ use }) => use(resource))` matched `useResource(resource)` activation timing. That hypothesis was falsified: both `react` and `react-compiler` failed with an invalid hook call because React resource setup requires top-level hook state.

The resulting safe slice is docs-only: React shares renderer vocabulary, but resources remain the important exception and must be declared through `useResource`.

## Validation
- `pnpm exec vitest --run --pool forks --project react packages/react/react/tests/activation-probes.spec.ts packages/react/react/tests/resource-stages.spec.ts packages/react/react/tests/service.spec.ts packages/react/react/tests/use-reactive.spec.ts`
- `pnpm exec vitest --run --pool forks --project react-compiler packages/react/react/tests/activation-probes.spec.ts packages/react/react/tests/resource-stages.spec.ts packages/react/react/tests/service.spec.ts packages/react/react/tests/use-reactive.spec.ts`
- `pnpm exec vitest --run --pool forks --project renderer packages/universal/renderer/tests/smoke.spec.ts`
- `pnpm --filter @starbeam/react test:types`
- `pnpm --filter @starbeam/renderer test:types`
- `pnpm test:workspace:pack`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types