### PR TITLE
Harden renderer app lifetime contract

### DIFF
--- a/packages/universal/renderer/src/renderer.ts
+++ b/packages/universal/renderer/src/renderer.ts
@@ -43,6 +43,13 @@ export type UseReactive<T> = ReactiveBlueprint<T> | Reactive<T>;
 
 export interface RendererManager<C extends object> {
   readonly getComponent: () => C;
+
+  /**
+   * Return the Starbeam app lifetime identity for this component.
+   *
+   * Framework context, providers, or plugins are the transport for this value;
+   * the value itself is the semantic app lifetime used to scope services.
+   */
   readonly getApp?: (instance: C) => object | undefined;
   readonly setupValue: <T>(instance: C, create: () => T) => T;
   readonly setupRef: <T>(instance: C, value: T) => { readonly current: T };

--- a/packages/universal/renderer/tests/package.json
+++ b/packages/universal/renderer/tests/package.json
@@ -15,6 +15,7 @@
     "@starbeam/reactive": "workspace:^",
     "@starbeam/renderer": "workspace:^",
     "@starbeam/resource": "workspace:^",
+    "@starbeam/runtime": "workspace:^",
     "@starbeam/shared": "workspace:^",
     "@starbeam-workspace/test-utils": "workspace:^"
   },

--- a/packages/universal/renderer/tests/smoke.spec.ts
+++ b/packages/universal/renderer/tests/smoke.spec.ts
@@ -9,6 +9,7 @@ import {
   runHandlers,
 } from "@starbeam/renderer";
 import { Resource } from "@starbeam/resource";
+import { CONTEXT } from "@starbeam/runtime";
 import { finalize } from "@starbeam/shared";
 import {
   describe,
@@ -227,11 +228,78 @@ describe("RendererManager", () => {
     expect(firstCounter.count).toBe(2);
     expect(setups).toBe(1);
   });
+
+  test("setupService isolates service instances by app", () => {
+    const first = TestManager.create({ app: {} });
+    const second = TestManager.create({ app: {} });
+    let setups = 0;
+
+    const Counter = Resource(() => ({ id: ++setups }));
+
+    const firstCounter = managerSetupService(first, Counter);
+    const secondCounter = managerSetupService(second, Counter);
+
+    expect(firstCounter).not.toBe(secondCounter);
+    expect(firstCounter.id).toBe(1);
+    expect(secondCounter.id).toBe(2);
+    expect(setups).toBe(2);
+  });
+
+  test("setupService has app lifetime, not component lifetime", () => {
+    const app = {};
+    const manager = TestManager.create({ app });
+    const events = new RecordedEvents();
+
+    const Service = Resource(({ on }) => {
+      events.record("setup");
+      on.finalize(() => void events.record("finalize"));
+
+      return {};
+    });
+
+    managerSetupService(manager, Service);
+    events.expect("setup");
+
+    finalize(manager.component);
+    events.expect([]);
+
+    finalize(app);
+    events.expect("finalize");
+  });
+
+  test("setupService falls back to the current app context", () => {
+    const app = {};
+    const manager = TestManager.createWithoutAppHook();
+    let setups = 0;
+
+    const Counter = Resource(() => ({ id: ++setups }));
+    const restoreApp = CONTEXT.hasApp() ? CONTEXT.app : {};
+
+    try {
+      CONTEXT.app = app;
+
+      const first = managerSetupService(manager, Counter);
+      const second = managerSetupService(manager, Counter);
+
+      expect(first).toBe(second);
+      expect(first.id).toBe(1);
+      expect(setups).toBe(1);
+    } finally {
+      CONTEXT.app = restoreApp;
+    }
+  });
 });
 
 class TestManager implements RendererManager<object> {
   static create(options: TestManagerOptions = {}): TestManager {
     return new TestManager(options);
+  }
+
+  static createWithoutAppHook(): Omit<RendererManager<object>, "getApp"> {
+    const manager = new TestManager({});
+    const { getApp: _getApp, ...managerWithoutApp } = manager;
+
+    return managerWithoutApp;
   }
 
   #component = {};

--- a/packages/universal/renderer/tests/smoke.spec.ts
+++ b/packages/universal/renderer/tests/smoke.spec.ts
@@ -273,7 +273,8 @@ describe("RendererManager", () => {
     let setups = 0;
 
     const Counter = Resource(() => ({ id: ++setups }));
-    const restoreApp = CONTEXT.hasApp() ? CONTEXT.app : {};
+    const hadApp = CONTEXT.hasApp();
+    const restoreApp = hadApp ? CONTEXT.app : null;
 
     try {
       CONTEXT.app = app;
@@ -285,10 +286,18 @@ describe("RendererManager", () => {
       expect(first.id).toBe(1);
       expect(setups).toBe(1);
     } finally {
-      CONTEXT.app = restoreApp;
+      if (hadApp) {
+        CONTEXT.app = restoreApp as object;
+      } else {
+        clearAppForTest();
+      }
     }
   });
 });
+
+function clearAppForTest(): void {
+  CONTEXT.app = undefined as unknown as object;
+}
 
 class TestManager implements RendererManager<object> {
   static create(options: TestManagerOptions = {}): TestManager {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -823,6 +823,9 @@ importers:
       '@starbeam/resource':
         specifier: workspace:^
         version: link:../../resource
+      '@starbeam/runtime':
+        specifier: workspace:^
+        version: link:../../runtime
       '@starbeam/shared':
         specifier: workspace:^
         version: link:../../shared


### PR DESCRIPTION
## Summary
- document `RendererManager.getApp` as the Starbeam app lifetime identity hook
- add renderer tests for service sharing, app isolation, and app-vs-component finalization
- cover the `CONTEXT.app` fallback for managers without `getApp`
- declare the renderer test package's direct runtime dependency

## Prepare / Execute / Review (PER)
This is the Service/App Lifetime Contract slice of the renderer hardening arc. The premise is positive: services and app lifetime are strongly motivated. Framework context/providers/plugins are transport; Starbeam app lifetime is the semantic concept used to scope services and test app-level behavior.

The Execute slice keeps the public story narrow: no package visibility or export changes, just contract docs on `getApp` and renderer tests that pin the service lifetime behavior.

## Validation
- `pnpm exec vitest --run --pool forks --project renderer packages/universal/renderer/tests/smoke.spec.ts`
- `pnpm --filter @starbeam/renderer test:types`
- `pnpm --filter @starbeam-tests/renderer test:types`
- `pnpm --filter @starbeam/renderer test:lint`
- `pnpm install --frozen-lockfile --lockfile-only`
- `pnpm test:workspace:pack`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types