### PR TITLE
Keep renderer setupFormula internal

### DIFF
--- a/packages/universal/renderer/src/renderer.ts
+++ b/packages/universal/renderer/src/renderer.ts
@@ -135,7 +135,7 @@ export const managerCreateLifecycle = <M extends SomeRendererManager>(
   manager: M,
 ): Lifecycle => new LifecycleImpl(manager, manager.getComponent() as object);
 
-export function setupFormula<T>(
+function setupFormula<T>(
   blueprint: UniversalRef<UseReactive<T>>,
   lifecycle: Lifecycle,
 ): FormulaFn<ReadValue<T>> {


### PR DESCRIPTION
## Summary
- remove the source export from the internal `setupFormula` helper
- keep the root `@starbeam/renderer` surface unchanged
- reduce accidental nested declaration surface from generated artifacts

## Prepare / Execute / Review (PER)
This is the Low-Level Dependency Surface slice of the renderer hardening arc. Artifact inspection found no package-surface blocker: runtime JS imports are limited to the intended renderer implementation dependencies, declarations expose only `interfaces`, `reactive`, and `resource`, and private/internal packages do not appear in renderer artifacts.

The one cleanup found was `setupFormula`: it was not root-exported, but because the source function was exported, it appeared in nested generated declarations. This PR makes it an internal helper without changing the public package root.

## Validation
- `pnpm --filter @starbeam/renderer build`
- `pnpm --filter @starbeam/renderer test:types`
- `pnpm --filter @starbeam/renderer test:specs`
- `pnpm --filter @starbeam/renderer test:lint`
- `pnpm test:workspace:pack`
- artifact grep for renderer JS/declaration package references
- private/internal package reference scan for `@starbeam/debug`, `@starbeam/verify`, `@starbeam/core-utils`, and `@starbeam/tags`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types