### PR TITLE
Frame modifier DOM attachment concept

### DIFF
--- a/docs/PACKAGE-SURFACE-TRIAGE.md
+++ b/docs/PACKAGE-SURFACE-TRIAGE.md
@@ -42,6 +42,33 @@ current package names are the right public surface.
 | `@starbeam/universal`  | Main public umbrella candidate                                                 | Best current framework-agnostic entrypoint over cells, formulas, resources, and common integration concepts.                                                                                                                   | Leaks low-level package names in JS and declarations; service docs conflict with exports.                                                                     | Make it the public umbrella over private substrates. Re-export service if public; stop exposing raw runtime/protocol pieces as the story.                                             |
 | `@starbeam/core`       | Compatibility decision                                                         | Deprecated alias over `@starbeam/universal`.                                                                                                                                                                                   | Root badge still points at it, but code is only a warning + re-export.                                                                                        | Decide old-import compatibility policy for 0.9.                                                                                                                                       |
 
+### Modifier / DOM attachment decision frame
+
+Direct imports of `@starbeam/modifier` are not the decision heuristic. The
+question is whether Starbeam has a public DOM attachment concept that should be
+stable, documented, and shared across adapters.
+
+Current leading hypothesis: **public concept, internal kernel**. The public
+concept is element attachment for framework reactivity: a framework obtains an
+element, Starbeam runs resource-backed work for that element, and cleanup follows
+the framework's element/component lifetime. `@starbeam/modifier` and
+`@domtree/*` remain internal unless a later PER finds a stable adapter-author
+contract that needs those package boundaries directly.
+
+Other live possibilities:
+
+- **Public adapter-author kit:** a stable DOM-integration package or renderer
+   extension for third-party adapters.
+- **Internal implementation only:** official adapters eventually implement the
+   concept privately without exposing a shared public API.
+- **Stale boundary:** the current modifier package shrinks or disappears if the
+   old concept no longer matches the active adapter story.
+
+Current evidence: `@starbeam/modifier` only exposes `ElementPlaceholder`; React
+modifier docs say the feature is under construction; the runtime README still
+contains historical `useReactiveElement` / `useModifier` examples that describe
+the concept but not current public APIs.
+
 ## Private packages with cleanup debt
 
 These packages are private. Some still have source-level cleanup work, but they

--- a/packages/universal/runtime/README.md
+++ b/packages/universal/runtime/README.md
@@ -281,6 +281,12 @@ Once linked, `ElementSize` is a regular formula that can be used as part of othe
 
 ### 📒 _Framework-Specific Details_
 
+> ⚠️ The examples in this section are historical. They describe the DOM
+> attachment concept Starbeam still needs to decide, but APIs such as
+> `useReactiveElement`, `ref`, and `useModifier` are not current public
+> Starbeam React APIs. See the modifier / DOM attachment decision frame in
+> `docs/PACKAGE-SURFACE-TRIAGE.md`.
+
 Starbeam's framework adapters provide a way to attach a function that takes an Element (called an "element modifier") to an element when the framework has created it using framework-specific APIs.
 
 For example, you would use the `ref` API to attach a modifier in React, while you would use the `use:` directive syntax to attach a modifier in Svelte. Check out the framework-specific documentation for more details.


### PR DESCRIPTION
## Summary
- add a modifier / DOM attachment decision frame to package-surface triage
- record direct imports as the wrong heuristic for deciding this concept
- mark runtime README modifier examples as historical rather than current React APIs

## Prepare / Execute / Review (PER)
This is the first Modifier / DOM Integration Concept Decision PER. The leading hypothesis is: public concept, internal kernel. The public concept is DOM attachment for framework reactivity; `@starbeam/modifier` and `@domtree/*` remain internal unless a later PER finds a stable adapter-author contract that needs those package boundaries directly.

This slice is intentionally docs/evidence only. It does not add APIs, rename packages, or make modifier/domtree public.

## Validation
- `pnpm --filter @starbeam/modifier test:types`
- `pnpm --filter @starbeam/modifier test:specs`
- `pnpm test:workspace:pack`
- modifier concept inventory grep for `@starbeam/modifier`, `ElementPlaceholder`, `useReactiveElement`, `useModifier`, and `@domtree/`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types