### PR TITLE
Add React DOM attachment probe

### DIFF
--- a/packages/react/react/tests/dom-attachment-probe.spec.ts
+++ b/packages/react/react/tests/dom-attachment-probe.spec.ts
@@ -70,8 +70,14 @@ testReact<void, AttachmentProbe["status"]>(
     expect(result.value).toBe("attached");
     expect(result.innerHTML).toBe("<p>attached</p><div>box</div>");
 
-    // This pins the current discriminator: React can render the attached value
-    // before the attached resource's sync handler runs.
+    // `resource:sync` is recorded above on purpose, but omitted here.
+    // The attached resource's sync handler runs from `useScheduledHandler`'s
+    // passive effect. This ref-driven render can reach `attached` after the
+    // initial passive effect pass, and `handler.register(sync)` does not
+    // schedule another pass by itself.
+    //
+    // If `resource:sync` starts appearing here, React/Starbeam timing changed
+    // and this probe should be updated deliberately.
     mode.match({
       strict: () => {
         events.expect(

--- a/packages/react/react/tests/dom-attachment-probe.spec.ts
+++ b/packages/react/react/tests/dom-attachment-probe.spec.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+
+import { useResource } from "@starbeam/react";
+import { Resource } from "@starbeam/universal";
+import { html, react, testReact } from "@starbeam-workspace/react-test-utils";
+import { expect, RecordedEvents } from "@starbeam-workspace/test-utils";
+import { useCallback, useState } from "react";
+
+interface AttachmentProbe {
+  readonly ref: (element: HTMLDivElement | null) => void;
+  readonly status: "pending" | "attached";
+}
+
+function useElementAttachmentProbeForTest(
+  events: RecordedEvents,
+): AttachmentProbe {
+  const [element, setElement] = useState<HTMLDivElement | null>(null);
+
+  const ref = useCallback(
+    (next: HTMLDivElement | null) => {
+      events.record(next ? "ref:attach" : "ref:cleanup");
+      setElement(next);
+    },
+    [events],
+  );
+
+  const attachment = useResource(
+    () =>
+      Resource(({ on }) => {
+        if (element === null) {
+          events.record("resource:pending");
+
+          return { status: "pending" as const };
+        }
+
+        events.record("resource:attached");
+
+        on.sync(() => {
+          events.record("resource:sync");
+          element.dataset["starbeamAttachment"] = "attached";
+        });
+
+        on.finalize(() => {
+          events.record("resource:finalize");
+        });
+
+        return { status: "attached" as const };
+      }),
+    [element],
+  );
+
+  return { ref, status: attachment.status };
+}
+
+testReact<void, AttachmentProbe["status"]>(
+  "DOM attachment probe — React Strict Mode ref timing",
+  async (root, mode) => {
+    const events = new RecordedEvents();
+
+    const result = await root.render((state) => {
+      const { ref, status } = useElementAttachmentProbeForTest(events);
+
+      state.value(status);
+
+      return react.fragment(html.p(status), html.div({ ref }, "box"));
+    });
+
+    await result.rerender();
+
+    expect(result.value).toBe("attached");
+    expect(result.innerHTML).toBe("<p>attached</p><div>box</div>");
+
+    // This pins the current discriminator: React can render the attached value
+    // before the attached resource's sync handler runs.
+    mode.match({
+      strict: () => {
+        events.expect(
+          "resource:pending",
+          "resource:pending",
+          "ref:attach",
+          "ref:cleanup",
+          "ref:attach",
+          "resource:pending",
+          "resource:attached",
+        );
+      },
+      loose: () => {
+        events.expect(
+          "resource:pending",
+          "ref:attach",
+          "resource:attached",
+        );
+      },
+    });
+
+    await result.unmount();
+
+    events.expect("resource:finalize", "ref:cleanup");
+  },
+);


### PR DESCRIPTION
## Summary
- add a test-local DOM attachment probe for React callback-ref timing
- exercise `pending` to `attached` under both React and React Compiler projects
- pin Strict Mode ref attach / cleanup / reattach behavior without exporting a public API

## Prepare / Execute / Review (PER)
This is the React Strict Mode DOM Attachment Discriminator PER. The goal is to test the hard case from the DOM attachment contract sketch without creating a public API or importing `@starbeam/modifier` / `@domtree/*`.

The probe uses a local helper built from React callback refs, React state, and `useResource(..., [element])`. It shows React can render the `attached` value after the ref-driven rerender, while also pinning that attached render state is distinct from the attached resource sync timing.

## Validation
- `pnpm exec vitest --run --pool forks --project react packages/react/react/tests/dom-attachment-probe.spec.ts`
- `pnpm exec vitest --run --pool forks --project react-compiler packages/react/react/tests/dom-attachment-probe.spec.ts`
- React/resource activation baseline tests in both projects
- `pnpm --filter @starbeam/react test:lint`
- `pnpm --filter @starbeam/react test:types`
- `pnpm test:workspace:pack`
- grep verified no `@starbeam/modifier` or `@domtree/*` imports
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types