### PR TITLE
Probe React DOM attachment sync boundary

### DIFF
--- a/packages/react/react/tests/dom-attachment-probe.spec.ts
+++ b/packages/react/react/tests/dom-attachment-probe.spec.ts
@@ -1,8 +1,13 @@
 // @vitest-environment jsdom
 
 import { useResource } from "@starbeam/react";
-import { Resource } from "@starbeam/universal";
-import { html, react, testReact } from "@starbeam-workspace/react-test-utils";
+import { Marker, Resource } from "@starbeam/universal";
+import {
+  act,
+  html,
+  react,
+  testReact,
+} from "@starbeam-workspace/react-test-utils";
 import { expect, RecordedEvents } from "@starbeam-workspace/test-utils";
 import { useCallback, useState } from "react";
 
@@ -11,8 +16,13 @@ interface AttachmentProbe {
   readonly status: "pending" | "attached";
 }
 
+interface AttachmentProbeOptions {
+  readonly invalidate?: (() => void) | undefined;
+}
+
 function useElementAttachmentProbeForTest(
   events: RecordedEvents,
+  options: AttachmentProbeOptions = {},
 ): AttachmentProbe {
   const [element, setElement] = useState<HTMLDivElement | null>(null);
 
@@ -37,6 +47,7 @@ function useElementAttachmentProbeForTest(
 
         on.sync(() => {
           events.record("resource:sync");
+          options.invalidate?.();
           element.dataset["starbeamAttachment"] = "attached";
         });
 
@@ -97,6 +108,70 @@ testReact<void, AttachmentProbe["status"]>(
           "resource:attached",
         );
       },
+    });
+
+    await result.unmount();
+
+    events.expect("resource:finalize", "ref:cleanup");
+  },
+);
+
+testReact<void, AttachmentProbe["status"]>(
+  "DOM attachment probe — invalidation does not sync before first sync",
+  async (root, mode) => {
+    const events = new RecordedEvents();
+    const marker = Marker();
+
+    const result = await root.render((state) => {
+      const { ref, status } = useElementAttachmentProbeForTest(events, {
+        invalidate: () => void marker.read(),
+      });
+
+      state.value(status);
+
+      return react.fragment(html.p(status), html.div({ ref }, "box"));
+    });
+
+    await result.rerender();
+
+    expect(result.value).toBe("attached");
+    expect(result.innerHTML).toBe("<p>attached</p><div>box</div>");
+    result.raw((element) => {
+      expect(element.querySelector("div")?.dataset["starbeamAttachment"]).toBe(
+        undefined,
+      );
+    });
+
+    mode.match({
+      strict: () => {
+        events.expect(
+          "resource:pending",
+          "resource:pending",
+          "ref:attach",
+          "ref:cleanup",
+          "ref:attach",
+          "resource:pending",
+          "resource:attached",
+        );
+      },
+      loose: () => {
+        events.expect(
+          "resource:pending",
+          "ref:attach",
+          "resource:attached",
+        );
+      },
+    });
+
+    await act(() => {
+      marker.mark();
+    });
+
+    events.expect([]);
+    result.raw((element) => {
+      expect(element.querySelector("div")?.dataset["starbeamAttachment"]).toBe(
+        undefined,
+      );
     });
 
     await result.unmount();


### PR DESCRIPTION
## Summary
- extend the React DOM attachment probe with a sync-boundary discriminator
- show `attached` render state does not imply the attached resource sync has run
- show marking a value read only by the not-yet-run sync handler does not bootstrap first sync

## Prepare / Execute / Review (PER)
This is the DOM Attachment Sync Boundary PER. It follows #200 by testing whether a public DOM attachment contract should include a separate ready/synced boundary after `attached`.

The result is a negative boundary probe: a value that is only read inside a not-yet-run `on.sync` handler cannot cause that handler's first run by being marked. This keeps the distinction between attached render state and resource sync timing explicit without changing React resource semantics or adding a public API.

## Validation
- `pnpm exec vitest --run --pool forks --project react packages/react/react/tests/dom-attachment-probe.spec.ts`
- `pnpm exec vitest --run --pool forks --project react-compiler packages/react/react/tests/dom-attachment-probe.spec.ts`
- React/resource activation baseline tests in both projects
- `pnpm --filter @starbeam/react test:lint`
- `pnpm --filter @starbeam/react test:types`
- `pnpm test:workspace:pack`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types