### PR TITLE
Probe DOM attachment first sync bootstrap

### DIFF
--- a/packages/react/react/tests/dom-attachment-probe.spec.ts
+++ b/packages/react/react/tests/dom-attachment-probe.spec.ts
@@ -102,11 +102,7 @@ testReact<void, AttachmentProbe["status"]>(
         );
       },
       loose: () => {
-        events.expect(
-          "resource:pending",
-          "ref:attach",
-          "resource:attached",
-        );
+        events.expect("resource:pending", "ref:attach", "resource:attached");
       },
     });
 
@@ -117,7 +113,7 @@ testReact<void, AttachmentProbe["status"]>(
 );
 
 testReact<void, AttachmentProbe["status"]>(
-  "DOM attachment probe — invalidation does not sync before first sync",
+  "DOM attachment probe — first sync is not bootstrapped after attachment",
   async (root, mode) => {
     const events = new RecordedEvents();
     const marker = Marker();
@@ -155,12 +151,30 @@ testReact<void, AttachmentProbe["status"]>(
         );
       },
       loose: () => {
-        events.expect(
-          "resource:pending",
-          "ref:attach",
-          "resource:attached",
-        );
+        events.expect("resource:pending", "ref:attach", "resource:attached");
       },
+    });
+
+    // If sync was just waiting in a passive queue, either of these turns would
+    // flush it.
+    await act(() => {});
+
+    events.expect([]);
+    result.raw((element) => {
+      expect(element.querySelector("div")?.dataset["starbeamAttachment"]).toBe(
+        undefined,
+      );
+    });
+
+    await result.rerender();
+
+    expect(result.value).toBe("attached");
+    expect(result.innerHTML).toBe("<p>attached</p><div>box</div>");
+    events.expect([]);
+    result.raw((element) => {
+      expect(element.querySelector("div")?.dataset["starbeamAttachment"]).toBe(
+        undefined,
+      );
     });
 
     await act(() => {


### PR DESCRIPTION
## Summary
- sharpen the React DOM attachment sync-boundary probe
- show the attached resource sync is not merely waiting for another passive turn
- verify an empty act turn, a forced rerender, and a marker invalidation still do not bootstrap first sync

## Prepare / Execute / Review (PER)
This is an evidence-only DOM attachment first-sync bootstrap PER. It distinguishes a delayed passive effect from an unbootstrapped first attached sync.

The result keeps the package/API conclusion unchanged: this remains a React timing probe, not a public DOM attachment API and not a decision to expose `@starbeam/modifier` or `@domtree/*`.

## Validation
- `pnpm exec vitest --run --pool forks --project react packages/react/react/tests/dom-attachment-probe.spec.ts packages/react/react/tests/resource-stages.spec.ts`
- `pnpm exec vitest --run --pool forks --project react-compiler packages/react/react/tests/dom-attachment-probe.spec.ts packages/react/react/tests/resource-stages.spec.ts`
- `pnpm --filter @starbeam/react test:lint`
- `pnpm --filter @starbeam/react test:types`
- `git diff --check -- packages/react/react/tests/dom-attachment-probe.spec.ts`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types