### PR TITLE
Bootstrap registered resource sync

### DIFF
--- a/packages/react/react/src/hooks/setup.ts
+++ b/packages/react/react/src/hooks/setup.ts
@@ -81,8 +81,9 @@ export function setupFormula<T>(
  * A {@linkcode ScheduledHandler} is a function that is called in React's
  * `useEffect` timing.
  *
- * The `register` method registers the handler function, and the `schedule`
- * method schedules the handler to run in the next `useEffect`.
+ * The `register` method registers the handler function and marks it to run in
+ * the next passive effect. The `schedule` method marks the handler to run and
+ * forces another passive effect turn.
  */
 interface ScheduledHandler {
   readonly register: (handler: Handler) => void;
@@ -93,26 +94,37 @@ interface ScheduledHandler {
  * Creates a {@linkcode ScheduledHandler} that will keep track of the
  * synchronization functions to run.
  *
- * This function sets up a `useEffect` to run the handlers. This `useEffect`
- * has a dependency on a `useState` that represents the set of handlers. The
- * `useState` invalidates whenever a handler is added or whenever
- * {@linkcode scheduleDep} is explicitly run.
+ * This function sets up a `useEffect` to run the handlers. The effect checks
+ * whether the current handler needs to run after each commit. Runtime
+ * invalidations use a state tick to force another passive effect turn.
  *
  * Importantly, handlers registered to the {@linkcode ScheduledHandler} are
  * always invoked in `useEffect` timing, which coordinates them with React's
  * scheduler.
  */
 function useScheduledHandler(): ScheduledHandler {
-  const [scheduleDep, setScheduleDep] = useState({});
+  const [, setScheduleDep] = useState({});
   const handlerRef = useRef(null as null | Handler);
+  const needsSyncRef = useRef(false);
 
   useEffect(() => {
-    if (handlerRef.current) handlerRef.current();
-  }, [scheduleDep]);
+    const handler = handlerRef.current;
+
+    if (handler && needsSyncRef.current) {
+      needsSyncRef.current = false;
+      handler();
+    }
+  });
 
   return {
-    register: (handler) => (handlerRef.current = handler),
-    schedule: () => void setScheduleDep({}),
+    register: (handler) => {
+      handlerRef.current = handler;
+      needsSyncRef.current = true;
+    },
+    schedule: () => {
+      needsSyncRef.current = true;
+      setScheduleDep({});
+    },
   };
 }
 
@@ -141,12 +153,11 @@ export function createResource<T>(
     );
 
     builder.on.layout(() => {
-      // Register the sync handler. This will schedule the sync immediately in
-      // the `useEffect` created in `useScheduledHandler`.
+      // Register the sync handler and mark it to run in passive effect timing.
       handler.register(sync);
 
-      // Whenever the sync handler changes, schedule it. This will run sync
-      // again in the `useEffect` created in `useScheduledHandler`.
+      // Whenever the sync handler changes, schedule it. This will force another
+      // passive effect turn for the handler registered above.
       const unsubscribe = RUNTIME.subscribe(sync, handler.schedule);
 
       // When the component unmounts, clean up.
@@ -157,9 +168,9 @@ export function createResource<T>(
         // Finalize the scope that the resource was created inside.
         finalize(scope);
 
-        // We don't need to do anything special with the handler ref because
-        // `useEffect` won't run again unless the component is remounted and the
-        // handler is set up again.
+        // We don't need to clear the handler ref. Once the component is
+        // unmounted, React won't run another passive effect for this instance
+        // unless it remounts and registers a fresh handler.
       });
     });
 

--- a/packages/react/react/tests/dom-attachment-probe.spec.ts
+++ b/packages/react/react/tests/dom-attachment-probe.spec.ts
@@ -79,16 +79,12 @@ testReact<void, AttachmentProbe["status"]>(
     await result.rerender();
 
     expect(result.value).toBe("attached");
-    expect(result.innerHTML).toBe("<p>attached</p><div>box</div>");
+    expect(result.innerHTML).toBe(
+      '<p>attached</p><div data-starbeam-attachment="attached">box</div>',
+    );
 
-    // `resource:sync` is recorded above on purpose, but omitted here.
-    // The attached resource's sync handler runs from `useScheduledHandler`'s
-    // passive effect. This ref-driven render can reach `attached` after the
-    // initial passive effect pass, and `handler.register(sync)` does not
-    // schedule another pass by itself.
-    //
-    // If `resource:sync` starts appearing here, React/Starbeam timing changed
-    // and this probe should be updated deliberately.
+    // The attached resource's sync handler runs in passive effect timing after
+    // the ref-driven render reaches `attached`.
     mode.match({
       strict: () => {
         events.expect(
@@ -99,10 +95,16 @@ testReact<void, AttachmentProbe["status"]>(
           "ref:attach",
           "resource:pending",
           "resource:attached",
+          "resource:sync",
         );
       },
       loose: () => {
-        events.expect("resource:pending", "ref:attach", "resource:attached");
+        events.expect(
+          "resource:pending",
+          "ref:attach",
+          "resource:attached",
+          "resource:sync",
+        );
       },
     });
 
@@ -113,7 +115,7 @@ testReact<void, AttachmentProbe["status"]>(
 );
 
 testReact<void, AttachmentProbe["status"]>(
-  "DOM attachment probe — first sync is not bootstrapped after attachment",
+  "DOM attachment probe — first sync is bootstrapped after attachment",
   async (root, mode) => {
     const events = new RecordedEvents();
     const marker = Marker();
@@ -131,10 +133,12 @@ testReact<void, AttachmentProbe["status"]>(
     await result.rerender();
 
     expect(result.value).toBe("attached");
-    expect(result.innerHTML).toBe("<p>attached</p><div>box</div>");
+    expect(result.innerHTML).toBe(
+      '<p>attached</p><div data-starbeam-attachment="attached">box</div>',
+    );
     result.raw((element) => {
       expect(element.querySelector("div")?.dataset["starbeamAttachment"]).toBe(
-        undefined,
+        "attached",
       );
     });
 
@@ -148,32 +152,40 @@ testReact<void, AttachmentProbe["status"]>(
           "ref:attach",
           "resource:pending",
           "resource:attached",
+          "resource:sync",
         );
       },
       loose: () => {
-        events.expect("resource:pending", "ref:attach", "resource:attached");
+        events.expect(
+          "resource:pending",
+          "ref:attach",
+          "resource:attached",
+          "resource:sync",
+        );
       },
     });
 
-    // If sync was just waiting in a passive queue, either of these turns would
-    // flush it.
+    // After first sync, extra turns don't resync unless a tracked dependency
+    // changes.
     await act(() => {});
 
     events.expect([]);
     result.raw((element) => {
       expect(element.querySelector("div")?.dataset["starbeamAttachment"]).toBe(
-        undefined,
+        "attached",
       );
     });
 
     await result.rerender();
 
     expect(result.value).toBe("attached");
-    expect(result.innerHTML).toBe("<p>attached</p><div>box</div>");
+    expect(result.innerHTML).toBe(
+      '<p>attached</p><div data-starbeam-attachment="attached">box</div>',
+    );
     events.expect([]);
     result.raw((element) => {
       expect(element.querySelector("div")?.dataset["starbeamAttachment"]).toBe(
-        undefined,
+        "attached",
       );
     });
 
@@ -181,10 +193,10 @@ testReact<void, AttachmentProbe["status"]>(
       marker.mark();
     });
 
-    events.expect([]);
+    events.expect("resource:sync");
     result.raw((element) => {
       expect(element.querySelector("div")?.dataset["starbeamAttachment"]).toBe(
-        undefined,
+        "attached",
       );
     });
 


### PR DESCRIPTION
## Summary
- mark newly registered React resource sync handlers for one passive-effect run
- keep runtime invalidations as the path that forces another passive turn
- update the DOM attachment probe to prove first attached sync now runs without duplicate syncs on empty turns or plain rerenders

## Prepare / Execute / Review (PER)
This is the resource sync bootstrap PER following #203. The hypothesis was that registering a new resource sync handler should bootstrap one passive-effect run without calling `setState` during layout registration.

The implementation keeps registration and scheduling distinct: `register()` stores the handler and marks it pending; `schedule()` marks it pending and forces another passive turn for runtime invalidations.

## Validation
- `pnpm exec vitest --run --pool forks --project react packages/react/react/tests/dom-attachment-probe.spec.ts packages/react/react/tests/resource-stages.spec.ts`
- `pnpm exec vitest --run --pool forks --project react-compiler packages/react/react/tests/dom-attachment-probe.spec.ts packages/react/react/tests/resource-stages.spec.ts`
- `pnpm exec vitest --run --pool forks --project react packages/react/react/tests/dom-attachment-probe.spec.ts packages/react/react/tests/resource-stages.spec.ts packages/react/react/tests/activation-probes.spec.ts packages/react/react/tests/activity-probe.spec.ts`
- `pnpm exec vitest --run --pool forks --project react-compiler packages/react/react/tests/dom-attachment-probe.spec.ts packages/react/react/tests/resource-stages.spec.ts packages/react/react/tests/activation-probes.spec.ts packages/react/react/tests/activity-probe.spec.ts`
- `pnpm --filter @starbeam/react test:lint`
- `pnpm --filter @starbeam/react test:types`
- `pnpm test:workspace:pack`
- `git diff --check`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types