### PR TITLE
Add React element resource hook

### DIFF
--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -364,9 +364,9 @@ gets memoized — and its hook calls get lifted into the memoization
 wrapper, which produces runtime "Rendered fewer hooks than expected"
 errors.
 
-Starbeam's adapter exposes exactly four hooks: `useSetup`,
-`useReactive`, `useResource`, `useService`. All four are
-`use*`-prefixed by design. Historical names without the prefix
+Starbeam's adapter exposes a small hook surface: `useSetup`,
+`useReactive`, `useResource`, `useService`, and `useElementResource`.
+These names are `use*`-prefixed by design. Historical names without the prefix
 (`setup`, `setupReactive`, `setupResource`, `setupService`) were
 renamed or removed specifically to satisfy this heuristic. Starbeam
 core's `setup`/`update`/`finalize` lifecycle phases (§14/§15, from

--- a/docs/PACKAGE-SURFACE-TRIAGE.md
+++ b/docs/PACKAGE-SURFACE-TRIAGE.md
@@ -11,18 +11,18 @@ complete conceptual model, or intentional experiment.
 
 These packages currently have a positive public-package story.
 
-| Package                          | Hypothesis                     | Reason                                                                                     | Action                                                                                               |
-| -------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| `@starbeam/react`                | Public                         | React adapter; distinct user audience.                                                     | Keep public. Reduce internal manifest deps.                                                          |
-| `@starbeam/preact`               | Public                         | Preact adapter; distinct user audience.                                                    | Keep public.                                                                                         |
-| `@starbeam/vue`                  | Public, if Vue is in 0.9 scope | Vue adapter; distinct user audience.                                                       | Confirm release scope.                                                                               |
-| `@starbeam/shared`               | Public                         | Architectural substrate for cross-copy and cross-version interoperability.                 | Keep public. Majors should require explicit intent.                                                  |
-| `@starbeam/collections`          | Public                         | Documented reactive collection package with direct value proposition.                      | Keep public. Remove support deps.                                                                    |
-| `@starbeam/resource`             | Public                         | Direct resource composition package with package-level docs.                               | Keep public if resources are standalone API.                                                         |
+| Package                          | Hypothesis                     | Reason                                                                                                                                  | Action                                                                                               |
+| -------------------------------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `@starbeam/react`                | Public                         | React adapter; distinct user audience.                                                                                                  | Keep public. Reduce internal manifest deps.                                                          |
+| `@starbeam/preact`               | Public                         | Preact adapter; distinct user audience.                                                                                                 | Keep public.                                                                                         |
+| `@starbeam/vue`                  | Public, if Vue is in 0.9 scope | Vue adapter; distinct user audience.                                                                                                    | Confirm release scope.                                                                               |
+| `@starbeam/shared`               | Public                         | Architectural substrate for cross-copy and cross-version interoperability.                                                              | Keep public. Majors should require explicit intent.                                                  |
+| `@starbeam/collections`          | Public                         | Documented reactive collection package with direct value proposition.                                                                   | Keep public. Remove support deps.                                                                    |
+| `@starbeam/resource`             | Public                         | Direct resource composition package with package-level docs.                                                                            | Keep public if resources are standalone API.                                                         |
 | `@starbeam/renderer`             | Public adapter-author kit      | Shared adapter contract for framework implementors: manager identity, setup storage, scheduling, resources, services, and app lifetime. | Keep public. Renderer hardening arc completed in #190-#195.                                          |
-| `@starbeam/use-strict-lifecycle` | Public reusable infrastructure | Solves a standalone React lifecycle problem under Strict Mode, remounts, and hidden trees. | Write README from THEORY; separate public lifecycle API from Starbeam-specific read-barrier helpers. |
-| `@starbeamx/store`               | Public experiment              | Usable reactive table/query/group/aggregate experiment.                                    | Keep as `@starbeamx`; align README with actual API.                                                  |
-| `@starbeamx/vanilla`             | Public experiment              | Minimal DOM renderer and reference implementation for Starbeam renderer authors.           | Keep as `@starbeamx`; add usage docs and round out tests.                                            |
+| `@starbeam/use-strict-lifecycle` | Public reusable infrastructure | Solves a standalone React lifecycle problem under Strict Mode, remounts, and hidden trees.                                              | Write README from THEORY; separate public lifecycle API from Starbeam-specific read-barrier helpers. |
+| `@starbeamx/store`               | Public experiment              | Usable reactive table/query/group/aggregate experiment.                                                                                 | Keep as `@starbeamx`; align README with actual API.                                                  |
+| `@starbeamx/vanilla`             | Public experiment              | Minimal DOM renderer and reference implementation for Starbeam renderer authors.                                                        | Keep as `@starbeamx`; add usage docs and round out tests.                                            |
 
 ## Conceptual boundaries that need decisions
 
@@ -58,14 +58,14 @@ contract that needs those package boundaries directly.
 Other live possibilities:
 
 - **Public adapter-author kit:** a stable DOM-integration package or renderer
-   extension for third-party adapters.
+  extension for third-party adapters.
 - **Internal implementation only:** official adapters eventually implement the
-   concept privately without exposing a shared public API.
+  concept privately without exposing a shared public API.
 - **Stale boundary:** the current modifier package shrinks or disappears if the
-   old concept no longer matches the active adapter story.
+  old concept no longer matches the active adapter story.
 
-Current evidence: React now has test-local DOM attachment probes for the timing
-shape, but not a public DOM attachment API. `@starbeam/modifier` only exposes
+Current evidence: React has `useElementResource`, a small public hook that wraps
+the tested callback-ref/resource pattern. `@starbeam/modifier` only exposes
 `ElementPlaceholder`; React modifier docs say the feature is under construction;
 the runtime README still contains historical `useReactiveElement` /
 `useModifier` examples that describe the concept but not current public APIs.
@@ -75,24 +75,24 @@ the runtime README still contains historical `useReactiveElement` /
 **Vocabulary**
 
 - **DOM attachment** is the public concept: Starbeam coordinates
-   framework-created DOM elements with reactive/resource work.
+  framework-created DOM elements with reactive/resource work.
 - **Element attachment** is one concrete lifetime of one element supplied by a
-   framework.
+  framework.
 - **Refs, directives, and modifiers** are framework dialects for delivering an
-   element. They are not the stable Starbeam contract name.
+  element. They are not the stable Starbeam contract name.
 - `@starbeam/modifier` and `@domtree/*` remain internal candidates unless a
-   later PER finds that adapter authors need those package boundaries directly.
+  later PER finds that adapter authors need those package boundaries directly.
 
 **Minimal state model**
 
 - `pending`: the adapter has not supplied an element yet. Element-backed work
-   has not started.
+  has not started.
 - `attached`: the adapter supplied an element, and Starbeam has produced
-   element-backed resource state with cleanup registered to the framework
-   lifetime. This does not imply that `on.sync` work has run.
+  element-backed resource state with cleanup registered to the framework
+  lifetime. This does not imply that `on.sync` work has run.
 - `cleaned-up`: the attachment lifetime ended. Observers, subscriptions, and
-   resource scopes tied to that element have been released. A later element is a
-   new attachment lifetime.
+  resource scopes tied to that element have been released. A later element is a
+  new attachment lifetime.
 
 Avoid using `detached` as the core state until we decide how it relates to
 React hidden trees, Vue deactivation, and element replacement. Use
@@ -101,24 +101,24 @@ React hidden trees, Vue deactivation, and element replacement. Use
 **Framework timing**
 
 - React is the hard case. The API must let React declare the element-backed
-   resource at top-level hook position while the actual element arrives after
-   render through ref/commit timing. Resource work must wait for React's paired
-   setup/cleanup phase.
+  resource at top-level hook position while the actual element arrives after
+  render through ref/commit timing. Resource work must wait for React's paired
+  setup/cleanup phase.
 - Preact can use the shared renderer manager shape, but an element API still
-   needs to define how the element arrives and how replacement is represented.
+  needs to define how the element arrives and how replacement is represented.
 - Vue setup/resource timing can use the shared manager shape, while a future
-   directive/ref API would supply the element around mount/update/unmount. Vue
-   deactivation remains a separate question.
+  directive/ref API would supply the element around mount/update/unmount. Vue
+  deactivation remains a separate question.
 
 **Boundary candidates**
 
 - Official framework adapters expose idiomatic APIs first.
 - `@starbeam/renderer` may grow adapter-author vocabulary if third-party
-   adapters need it.
+  adapters need it.
 - `@starbeam/universal` may document the framework-neutral concept if
-   app/library authors need to talk about element resources directly.
+  app/library authors need to talk about element resources directly.
 - A new package is only justified if the concept becomes independently
-   installable.
+  installable.
 - No public API yet remains a valid outcome for 0.9.
 
 **React findings from #200 and #201**
@@ -128,16 +128,16 @@ hypothesis without adding a public API or importing `@starbeam/modifier` /
 `@domtree/*`.
 
 - Before React supplies a ref, the element-backed resource can be declared but
-   returns `pending`.
+  returns `pending`.
 - After a ref-driven rerender, the resource can return `attached`.
 - Strict Mode performs a ref attach/cleanup/reattach sequence before the stable
-   attached state.
+  attached state.
 - On final unmount, the resource finalizer runs before React calls the ref
-   cleanup.
+  cleanup.
 - `attached` render state is not a sync/ready boundary. The attached resource's
-   `on.sync` handler has not necessarily run.
+  `on.sync` handler has not necessarily run.
 - Marking a value that would only be read by the not-yet-run `on.sync` handler
-   does not bootstrap first sync.
+  does not bootstrap first sync.
 
 Next implementation work should treat element attachment and sync scheduling as
 separate problems. A later API may choose to expose a ready/synced boundary, but
@@ -149,11 +149,11 @@ These packages are private. Some still have source-level cleanup work, but they
 do not appear in public runtime dependency fields, public generated JavaScript,
 or public generated declarations.
 
-| Package                | Hypothesis        | Why                                                                                               | Main blockers                                                                             | Suggested PER                                                                                    |
-| ---------------------- | ----------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `@starbeam/verify`     | Private           | Internal assertion/type-narrowing support. A tidy API is not a public-package argument by itself. | Done: private/internal, inlined in public artifacts, no public runtime manifest leaks.    | Monitor verifier; no public surface unless a real audience appears.                              |
-| `@starbeam/debug`      | Private           | Dev/runtime support and bootstrap implementation, not a direct install target.                    | Done: private/internal; `@starbeam/universal` owns and verifies the public DEV bootstrap. | Keep `test:workspace:debug-bootstrap` green; revisit only if a public diagnostics story appears. |
-| `@starbeam/core-utils` | Private           | Generic JS utilities are not a Starbeam public goal by default.                                   | Done: private/internal; public JS/declarations are clean, while dev metadata and source maps still mention it. | Keep private. Treat remaining references as source-map/provenance policy and low-level consolidation cleanup. |
+| Package                | Hypothesis | Why                                                                                               | Main blockers                                                                                                  | Suggested PER                                                                                                 |
+| ---------------------- | ---------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `@starbeam/verify`     | Private    | Internal assertion/type-narrowing support. A tidy API is not a public-package argument by itself. | Done: private/internal, inlined in public artifacts, no public runtime manifest leaks.                         | Monitor verifier; no public surface unless a real audience appears.                                           |
+| `@starbeam/debug`      | Private    | Dev/runtime support and bootstrap implementation, not a direct install target.                    | Done: private/internal; `@starbeam/universal` owns and verifies the public DEV bootstrap.                      | Keep `test:workspace:debug-bootstrap` green; revisit only if a public diagnostics story appears.              |
+| `@starbeam/core-utils` | Private    | Generic JS utilities are not a Starbeam public goal by default.                                   | Done: private/internal; public JS/declarations are clean, while dev metadata and source maps still mention it. | Keep private. Treat remaining references as source-map/provenance policy and low-level consolidation cleanup. |
 
 ## Possible new public surfaces
 

--- a/docs/PACKAGE-SURFACE-TRIAGE.md
+++ b/docs/PACKAGE-SURFACE-TRIAGE.md
@@ -64,11 +64,11 @@ Other live possibilities:
 - **Stale boundary:** the current modifier package shrinks or disappears if the
   old concept no longer matches the active adapter story.
 
-Current evidence: React has `useElementResource`, a small public hook that wraps
-the tested callback-ref/resource pattern. `@starbeam/modifier` only exposes
-`ElementPlaceholder`; React modifier docs say the feature is under construction;
-the runtime README still contains historical `useReactiveElement` /
-`useModifier` examples that describe the concept but not current public APIs.
+Current evidence: `@starbeam/react` has `useElementResource`, a small public
+hook that wraps the tested callback-ref/resource pattern. `@starbeam/modifier`
+only exposes `ElementPlaceholder`; React modifier docs say the feature is under
+construction; the runtime README still contains historical `useReactiveElement`
+/ `useModifier` examples that describe the concept but not current public APIs.
 
 #### DOM attachment contract sketch
 

--- a/packages/react/react/index.ts
+++ b/packages/react/react/index.ts
@@ -2,5 +2,12 @@ import "./src/debug/warnings.js";
 
 export { type ReactApp, Starbeam, useStarbeamApp } from "./src/app.js";
 export { useSetup } from "./src/hooks/setup.js";
-export { useReactive, useResource, useService } from "./src/hooks/use.js";
+export {
+  type ElementResource,
+  type ElementResourceBlueprint,
+  useElementResource,
+  useReactive,
+  useResource,
+  useService,
+} from "./src/hooks/use.js";
 export { useProp } from "./src/utils.js";

--- a/packages/react/react/src/hooks/use.ts
+++ b/packages/react/react/src/hooks/use.ts
@@ -1,8 +1,6 @@
 import type { ReactiveBlueprint } from "@starbeam/renderer";
-import type {
-  IntoResourceBlueprint,
-  ResourceBlueprint,
-} from "@starbeam/resource";
+import { intoResourceBlueprint } from "@starbeam/renderer";
+import type { IntoResourceBlueprint } from "@starbeam/resource";
 import { Resource } from "@starbeam/resource";
 import {
   unsafeTrackedElsewhere,
@@ -38,12 +36,6 @@ export type ElementResource<T, E extends Element> =
 export type ElementResourceBlueprint<E extends Element, T> = (
   element: E,
 ) => IntoResourceBlueprint<T>;
-
-function intoResourceBlueprint<T>(
-  blueprint: IntoResourceBlueprint<T>,
-): ResourceBlueprint<T> {
-  return typeof blueprint === "function" ? blueprint() : blueprint;
-}
 
 /**
  * `useReactive(compute)` runs `compute` and returns its value, re-running
@@ -97,11 +89,12 @@ export function useElementResource<E extends Element, T>(
     () =>
       Resource(({ use }) => {
         if (element === null) {
-          return { status: "pending" as const };
+          return { status: "pending" as const, ref };
         }
 
         return {
           status: "attached" as const,
+          ref,
           current: use(
             intoResourceBlueprint(currentBlueprint.current(element)),
           ),
@@ -110,5 +103,5 @@ export function useElementResource<E extends Element, T>(
     bridge ? [element, ...bridge] : [element],
   );
 
-  return { ...attachment, ref };
+  return attachment;
 }

--- a/packages/react/react/src/hooks/use.ts
+++ b/packages/react/react/src/hooks/use.ts
@@ -1,9 +1,14 @@
 import type { ReactiveBlueprint } from "@starbeam/renderer";
-import type { IntoResourceBlueprint } from "@starbeam/resource";
+import type {
+  IntoResourceBlueprint,
+  ResourceBlueprint,
+} from "@starbeam/resource";
+import { Resource } from "@starbeam/resource";
 import {
   unsafeTrackedElsewhere,
   useLastRenderRef,
 } from "@starbeam/use-strict-lifecycle";
+import { useCallback, useState } from "react";
 
 import { createReactive, createResource, useSetup } from "./setup.js";
 
@@ -18,6 +23,27 @@ import { createReactive, createResource, useSetup } from "./setup.js";
  * don't have a bridge at all." See docs/INVARIANTS.md §17.
  */
 type Bridge = readonly [unknown, ...unknown[]];
+
+export type ElementResource<T, E extends Element> =
+  | {
+      readonly status: "pending";
+      readonly ref: (element: E | null) => void;
+    }
+  | {
+      readonly status: "attached";
+      readonly ref: (element: E | null) => void;
+      readonly current: T;
+    };
+
+export type ElementResourceBlueprint<E extends Element, T> = (
+  element: E,
+) => IntoResourceBlueprint<T>;
+
+function intoResourceBlueprint<T>(
+  blueprint: IntoResourceBlueprint<T>,
+): ResourceBlueprint<T> {
+  return typeof blueprint === "function" ? blueprint() : blueprint;
+}
 
 /**
  * `useReactive(compute)` runs `compute` and returns its value, re-running
@@ -54,4 +80,35 @@ export function useResource<T>(
   bridge?: Bridge,
 ): T {
   return createResource(blueprint, bridge);
+}
+
+export function useElementResource<E extends Element, T>(
+  blueprint: ElementResourceBlueprint<E, T>,
+  bridge?: Bridge,
+): ElementResource<T, E> {
+  const [element, setElement] = useState<E | null>(null);
+  const [currentBlueprint] = useLastRenderRef(blueprint);
+
+  const ref = useCallback((element: E | null) => {
+    setElement(element);
+  }, []);
+
+  const attachment = useResource(
+    () =>
+      Resource(({ use }) => {
+        if (element === null) {
+          return { status: "pending" as const };
+        }
+
+        return {
+          status: "attached" as const,
+          current: use(
+            intoResourceBlueprint(currentBlueprint.current(element)),
+          ),
+        };
+      }),
+    bridge ? [element, ...bridge] : [element],
+  );
+
+  return { ...attachment, ref };
 }

--- a/packages/react/react/tests/element-resource.spec.ts
+++ b/packages/react/react/tests/element-resource.spec.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { useElementResource } from "@starbeam/react";
+import { Cell, Marker, Resource } from "@starbeam/universal";
+import {
+  act,
+  html,
+  react,
+  testReact,
+} from "@starbeam-workspace/react-test-utils";
+import { expect, RecordedEvents } from "@starbeam-workspace/test-utils";
+
+const INITIAL_WIDTH = 0;
+
+function ElementSizeForTest(
+  element: HTMLElement,
+  events: RecordedEvents,
+  marker: ReturnType<typeof Marker>,
+) {
+  return Resource(({ on }) => {
+    events.record("resource:attached");
+
+    const width = Cell(INITIAL_WIDTH);
+
+    on.sync(() => {
+      events.record("resource:sync");
+      marker.read();
+      width.set(element.getBoundingClientRect().width);
+      element.dataset["starbeamAttachment"] = "attached";
+    });
+
+    on.finalize(() => {
+      events.record("resource:finalize");
+    });
+
+    return { width };
+  });
+}
+
+testReact<void, "pending" | "attached">(
+  "useElementResource attaches an element-backed resource",
+  async (root, mode) => {
+    const events = new RecordedEvents();
+    const marker = Marker();
+
+    const result = await root.render((state) => {
+      const size = useElementResource((element: HTMLElement) =>
+        ElementSizeForTest(element, events, marker),
+      );
+
+      state.value(size.status);
+
+      return react.fragment(
+        html.p(size.status),
+        size.status === "attached"
+          ? html.p(String(size.current.width.current))
+          : null,
+        html.div({ ref: size.ref }, "box"),
+      );
+    });
+
+    await result.rerender();
+
+    expect(result.value).toBe("attached");
+    expect(result.innerHTML).toBe(
+      '<p>attached</p><p>0</p><div data-starbeam-attachment="attached">box</div>',
+    );
+
+    mode.match({
+      strict: () => {
+        events.expect("resource:attached", "resource:sync");
+      },
+      loose: () => {
+        events.expect("resource:attached", "resource:sync");
+      },
+    });
+
+    await act(() => {});
+    events.expect([]);
+
+    await result.rerender();
+    events.expect([]);
+
+    await act(() => {
+      marker.mark();
+    });
+
+    events.expect("resource:sync");
+
+    await result.unmount();
+
+    events.expect("resource:finalize");
+  },
+);

--- a/packages/universal/runtime/README.md
+++ b/packages/universal/runtime/README.md
@@ -281,8 +281,8 @@ Once linked, `ElementSize` is a regular formula that can be used as part of othe
 
 ### 📒 _Framework-Specific Details_
 
-> ⚠️ The examples in this section are historical. React now exposes the
-> callback-ref/resource pattern as `useElementResource`; the older
+> ⚠️ The examples in this section are historical. `@starbeam/react` now exposes
+> the callback-ref/resource pattern as `useElementResource`; the older
 > `useReactiveElement`, `ref`, and `useModifier` names shown below are not
 > current public Starbeam React APIs. See the modifier / DOM attachment decision
 > frame in `docs/PACKAGE-SURFACE-TRIAGE.md`.

--- a/packages/universal/runtime/README.md
+++ b/packages/universal/runtime/README.md
@@ -281,11 +281,11 @@ Once linked, `ElementSize` is a regular formula that can be used as part of othe
 
 ### 📒 _Framework-Specific Details_
 
-> ⚠️ The examples in this section are historical. They describe the DOM
-> attachment concept Starbeam still needs to decide, but APIs such as
-> `useReactiveElement`, `ref`, and `useModifier` are not current public
-> Starbeam React APIs. See the modifier / DOM attachment decision frame in
-> `docs/PACKAGE-SURFACE-TRIAGE.md`.
+> ⚠️ The examples in this section are historical. React now exposes the
+> callback-ref/resource pattern as `useElementResource`; the older
+> `useReactiveElement`, `ref`, and `useModifier` names shown below are not
+> current public Starbeam React APIs. See the modifier / DOM attachment decision
+> frame in `docs/PACKAGE-SURFACE-TRIAGE.md`.
 
 Starbeam's framework adapters provide a way to attach a function that takes an Element (called an "element modifier") to an element when the framework has created it using framework-specific APIs.
 


### PR DESCRIPTION
## Summary
- add `useElementResource()` as the public React wrapper for callback-ref element attachment
- return a `pending | attached` result with a stable `ref` and attached `current` value
- cover first sync, no duplicate sync on empty turns/rerenders, marker-driven resync, and finalization
- update docs that listed the React hook surface or called DOM attachment not public

## Prepare / Execute / Review (PER)
This is the ergonomic React DOM attachment hook PER after #204. The implementation packages the proven callback-ref/resource pattern without exposing `@starbeam/modifier` or `@domtree/*`.

The hook accepts an element-to-resource builder: `useElementResource((element) => ElementSize(element))`. React owns element arrival through a stable callback ref; Starbeam owns the element-backed resource lifetime.

## Validation
- `pnpm exec prettier --write docs/INVARIANTS.md docs/PACKAGE-SURFACE-TRIAGE.md packages/universal/runtime/README.md packages/react/react/index.ts packages/react/react/src/hooks/use.ts packages/react/react/tests/element-resource.spec.ts`
- `pnpm exec vitest --run --pool forks --project react packages/react/react/tests/element-resource.spec.ts packages/react/react/tests/dom-attachment-probe.spec.ts`
- `pnpm exec vitest --run --pool forks --project react-compiler packages/react/react/tests/element-resource.spec.ts packages/react/react/tests/dom-attachment-probe.spec.ts`
- `pnpm --filter @starbeam/react test:lint`
- `pnpm --filter @starbeam/react test:types`
- `pnpm test:workspace:pack`
- `git diff --check`
- `pnpm --filter @starbeam/react build` and checked generated JS/types include `useElementResource`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types