### PR TITLE
Document React element resources

### DIFF
--- a/packages/react/react/README.md
+++ b/packages/react/react/README.md
@@ -1,0 +1,92 @@
+# `@starbeam/react`
+
+React bindings for Starbeam.
+
+## Public hooks
+
+- `useReactive(compute, bridge?)`: read Starbeam reactive values during React render.
+- `useResource(resource, bridge?)`: create a Starbeam resource with React lifecycle.
+- `useElementResource(build, bridge?)`: attach an element-backed resource to a React ref.
+- `useService(resource)`: resolve an app-scoped Starbeam service.
+- `useSetup(setup)`: low-level setup hook for adapter/resource integration.
+- `useProp(variable, description?)`: store a React prop in a Starbeam cell.
+
+Use the optional `bridge` argument when the callback captures React-owned values
+such as props, state, or route params. Starbeam reactive values do not need to be
+listed in `bridge`; Starbeam tracks them directly.
+
+## Element resources
+
+`useElementResource()` is the React API for element-backed Starbeam resources.
+It handles React's callback-ref timing and gives the resource a real DOM element
+only after React has created it.
+
+The hook returns a discriminated result:
+
+- `pending`: React has not supplied the element yet.
+- `attached`: React supplied the element, and the Starbeam resource is available
+  as `current`.
+
+The result always includes a stable `ref` to put on the element.
+
+```tsx
+import { useElementResource, useReactive } from "@starbeam/react";
+import { Cell, Resource } from "@starbeam/universal";
+
+function ElementSize(element: Element) {
+  return Resource(({ on }) => {
+    const width = Cell(0);
+    const height = Cell(0);
+
+    on.sync(() => {
+      const observer = new ResizeObserver(([entry]) => {
+        if (!entry) return;
+
+        width.set(entry.contentRect.width);
+        height.set(entry.contentRect.height);
+      });
+
+      observer.observe(element);
+
+      return () => observer.disconnect();
+    });
+
+    return { width, height };
+  });
+}
+
+export function MeasuredPanel() {
+  const size = useElementResource((element: HTMLDivElement) =>
+    ElementSize(element),
+  );
+
+  const label = useReactive(() => {
+    if (size.status === "pending") {
+      return "Measuring…";
+    }
+
+    return `${size.current.width.current} × ${size.current.height.current}`;
+  }, [size]);
+
+  return <section ref={size.ref}>{label}</section>;
+}
+```
+
+### Timing model
+
+React supplies refs after render. That means an element-backed resource starts as
+`pending`, then becomes `attached` after React calls the callback ref and the
+component rerenders.
+
+Once the resource is attached, its first `on.sync` handler runs in React passive
+effect timing. Later Starbeam invalidations of values read by `on.sync` schedule
+future syncs. Plain rerenders do not resync by themselves.
+
+Finalizers registered by the element-backed resource run when the attachment
+lifetime ends.
+
+## Historical modifier names
+
+Older Starbeam notes may mention `useReactiveElement`, `ref`, or `useModifier`.
+Those names are historical. The current React API for the same public concept is
+`useElementResource()`.

--- a/packages/react/react/README.md
+++ b/packages/react/react/README.md
@@ -5,15 +5,19 @@ React bindings for Starbeam.
 ## Public hooks
 
 - `useReactive(compute, bridge?)`: read Starbeam reactive values during React render.
-- `useResource(resource, bridge?)`: create a Starbeam resource with React lifecycle.
+- `useResource(blueprint, bridge?)`: create a Starbeam resource with React lifecycle.
 - `useElementResource(build, bridge?)`: attach an element-backed resource to a React ref.
-- `useService(resource)`: resolve an app-scoped Starbeam service.
+- `useService(blueprint)`: resolve an app-scoped Starbeam service.
 - `useSetup(setup)`: low-level setup hook for adapter/resource integration.
 - `useProp(variable, description?)`: store a React prop in a Starbeam cell.
 
-Use the optional `bridge` argument when the callback captures React-owned values
-such as props, state, or route params. Starbeam reactive values do not need to be
-listed in `bridge`; Starbeam tracks them directly.
+Use the optional `bridge` argument when the callback captures non-reactive
+values that can change across renders, such as props, state, route params, or a
+`useElementResource()` result. Starbeam reactive values do not need to be listed
+in `bridge`; Starbeam tracks them directly.
+
+`bridge` is a non-empty tuple. If there is nothing to bridge, omit the argument
+instead of passing `[]`.
 
 ## Element resources
 


### PR DESCRIPTION
## Summary
- add a React package README
- document the public hook surface, including `useElementResource`
- add an `ElementSize` example using `useElementResource((element) => ElementSize(element))`
- explain `pending` / `attached`, passive sync timing, bridge usage, and historical modifier names

## Prepare / Execute / Review (PER)
This is the React documentation PER after #205. It records the public leaf API before we move on to Preact parity or modifier-package inventory.

## Validation
- `pnpm exec prettier --write packages/react/react/README.md`
- `git diff --check -- packages/react/react/README.md`
- `pnpm test:workspace:pack`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types