### PR TITLE
Probe Preact DOM attachment parity

### DIFF
--- a/packages/preact/preact/tests/dom-attachment-probe.spec.ts
+++ b/packages/preact/preact/tests/dom-attachment-probe.spec.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { install, useResource } from "@starbeam/preact";
+import { Marker } from "@starbeam/reactive";
+import { Resource } from "@starbeam/resource";
+import { html, render } from "@starbeam-workspace/preact-testing-utils";
+import {
+  beforeAll,
+  describe,
+  expect,
+  RecordedEvents,
+  test,
+} from "@starbeam-workspace/test-utils";
+import { createElement, Fragment, options } from "preact";
+import { useCallback, useState } from "preact/hooks";
+import { act } from "preact/test-utils";
+
+interface AttachmentProbe {
+  readonly ref: (element: HTMLDivElement | null) => void;
+  readonly status: "pending" | "attached";
+}
+
+interface AttachmentProbeOptions {
+  readonly invalidate?: (() => void) | undefined;
+}
+
+function useElementAttachmentProbeForTest(
+  events: RecordedEvents,
+  options: AttachmentProbeOptions = {},
+): AttachmentProbe {
+  const [element, setElement] = useState<HTMLDivElement | null>(null);
+
+  const ref = useCallback(
+    (next: HTMLDivElement | null) => {
+      events.record(next ? "ref:attach" : "ref:cleanup");
+      setElement(next);
+    },
+    [events],
+  );
+
+  const attachment = useResource(
+    () =>
+      Resource(({ on }) => {
+        if (element === null) {
+          events.record("resource:pending");
+
+          return { status: "pending" as const };
+        }
+
+        events.record("resource:attached");
+
+        on.sync(() => {
+          events.record("resource:sync");
+          options.invalidate?.();
+          element.dataset["starbeamAttachment"] = "attached";
+        });
+
+        on.finalize(() => {
+          events.record("resource:finalize");
+        });
+
+        return { status: "attached" as const };
+      }),
+    [],
+  );
+
+  return { ref, status: attachment.status };
+}
+
+describe("DOM attachment probe", () => {
+  beforeAll(() => void install(options));
+
+  test("React-shaped resource helper stays pending after Preact ref attachment", async () => {
+    const events = new RecordedEvents();
+    const marker = Marker();
+
+    function App() {
+      const { ref, status } = useElementAttachmentProbeForTest(events, {
+        invalidate: () => void marker.read(),
+      });
+
+      return createElement(
+        Fragment,
+        {},
+        html`<p>${status}</p>`,
+        createElement("div", { ref }, "box"),
+      );
+    }
+
+    const result = render(App);
+
+    result.rerender({});
+
+    expect(result.innerHTML).toBe(`<p>pending</p><div>box</div>`);
+    events.expect("resource:pending", "ref:attach");
+
+    await act(() => {});
+    events.expect([]);
+
+    result.rerender({});
+    events.expect([]);
+
+    await act(() => {
+      marker.mark();
+    });
+
+    events.expect([]);
+
+    result.unmount();
+    events.expect("ref:cleanup");
+  });
+});


### PR DESCRIPTION
## Summary
- add a test-local Preact DOM attachment probe
- show Preact callback refs fire, but the React-shaped resource helper stays `pending`
- confirm extra turns, rerenders, and marker invalidation do not attach/sync the resource
- keep this as evidence only: no public Preact API yet

## Prepare / Execute / Review (PER)
This is the Preact parity PER after the React `useElementResource` leaf. The hypothesis was that Preact ref timing is usable, but the current Preact resource setup/deps model blocks a direct React-shaped helper.

The probe supports that: `ref:attach` fires, but the resource constructor does not rebuild with the attached element. This points at Preact dependency/resource rebuild semantics as the next PER, not public API exposure.

## Validation
- `pnpm exec prettier --write packages/preact/preact/tests/dom-attachment-probe.spec.ts`
- `pnpm exec vitest --run --pool forks --project preact packages/preact/preact/tests/dom-attachment-probe.spec.ts packages/preact/preact/tests/resources.spec.ts`
- `pnpm --filter @starbeam-tests/preact test:lint`
- `pnpm --filter @starbeam-tests/preact test:types`
- `pnpm test:workspace:pack`
- `git diff --check`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types