### PR TITLE
Support Preact resource deps

### DIFF
--- a/packages/preact/preact/src/resource.ts
+++ b/packages/preact/preact/src/resource.ts
@@ -11,9 +11,18 @@ import type {
   IntoResourceBlueprint,
   ResourceBlueprint,
   Sync,
+  SyncFn,
 } from "@starbeam/resource";
+import { pushingScope, RUNTIME } from "@starbeam/runtime";
+import { finalize } from "@starbeam/shared";
 import type { Reactive } from "@starbeam/universal";
-import { useMemo } from "preact/hooks";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "preact/hooks";
 
 import { MANAGER } from "./renderer.js";
 
@@ -48,17 +57,123 @@ export function setupSync(blueprint: Sync<void>): void {
 }
 
 export function useResource<T>(blueprint: ResourceBlueprint<T>): T;
-export function useResource<T>(setup: () => ResourceBlueprint<T>, deps: []): T;
+export function useResource<T>(
+  setup: () => ResourceBlueprint<T>,
+  deps: readonly unknown[],
+): T;
 export function useResource<T>(
   blueprint: IntoResourceBlueprint<T>,
-  /**
-   * Preact currently doesn't support deps, but when we support deps, you will
-   * need to pass `[]` when there are no dependencies.
-   */
-  _deps?: [],
+  deps?: readonly unknown[],
 ): T {
   DEBUG?.markEntryPoint(["function:call", "useResource"]);
-  return setupResource(blueprint);
+  return useResourceInstance(blueprint, deps ?? []);
+}
+
+interface ScheduledHandler {
+  readonly register: (handler: () => void) => void;
+  readonly schedule: () => void;
+}
+
+interface ResourceInstance<T> {
+  readonly deps: readonly unknown[];
+  readonly scope: object;
+  readonly sync: SyncFn<void>;
+  readonly value: T;
+  unsubscribe: (() => void) | undefined;
+  finalized: boolean;
+}
+
+function useResourceInstance<T>(
+  blueprint: IntoResourceBlueprint<T>,
+  deps: readonly unknown[],
+): T {
+  const [currentBlueprint] = useLatestRef(blueprint);
+  const instance = useRef<ResourceInstance<T> | null>(null);
+  const handler = useScheduledHandler();
+
+  if (instance.current === null || !sameDeps(deps, instance.current.deps)) {
+    cleanupResourceInstance(instance.current);
+    instance.current = createResourceInstance(currentBlueprint.current, deps);
+  }
+
+  const current = instance.current;
+
+  useLayoutEffect(() => {
+    handler.register(current.sync);
+    current.unsubscribe = RUNTIME.subscribe(current.sync, handler.schedule);
+
+    return () => {
+      cleanupResourceInstance(current);
+    };
+  }, [current]);
+
+  return current.value;
+}
+
+function createResourceInstance<T>(
+  blueprint: IntoResourceBlueprint<T>,
+  deps: readonly unknown[],
+): ResourceInstance<T> {
+  const [scope, { sync, value }] = pushingScope(() =>
+    typeof blueprint === "function" ? blueprint().setup() : blueprint.setup(),
+  );
+
+  return {
+    deps,
+    scope,
+    sync,
+    value,
+    unsubscribe: undefined,
+    finalized: false,
+  };
+}
+
+function cleanupResourceInstance<T>(
+  instance: ResourceInstance<T> | null,
+): void {
+  if (instance === null || instance.finalized) return;
+
+  instance.unsubscribe?.();
+  instance.unsubscribe = undefined;
+  finalize(instance.scope);
+  instance.finalized = true;
+}
+
+function useScheduledHandler(): ScheduledHandler {
+  const [, setScheduleDep] = useState({});
+  const handlerRef = useRef(null as null | (() => void));
+  const needsSyncRef = useRef(false);
+
+  useEffect(() => {
+    const handler = handlerRef.current;
+
+    if (handler && needsSyncRef.current) {
+      needsSyncRef.current = false;
+      handler();
+    }
+  });
+
+  return {
+    register: (handler) => {
+      handlerRef.current = handler;
+      needsSyncRef.current = true;
+    },
+    schedule: () => {
+      needsSyncRef.current = true;
+      setScheduleDep({});
+    },
+  };
+}
+
+function useLatestRef<T>(value: T): readonly [{ readonly current: T }] {
+  const ref = useRef(value);
+  ref.current = value;
+  return [ref];
+}
+
+function sameDeps(next: readonly unknown[], prev: readonly unknown[]): boolean {
+  if (next.length !== prev.length) return false;
+  return next.every((value, index) => Object.is(value, prev[index]));
 }
 
 export function setupService<T>(blueprint: IntoResourceBlueprint<T>): T {

--- a/packages/preact/preact/src/resource.ts
+++ b/packages/preact/preact/src/resource.ts
@@ -9,7 +9,6 @@ import {
 } from "@starbeam/renderer";
 import type {
   IntoResourceBlueprint,
-  ResourceBlueprint,
   Sync,
   SyncFn,
 } from "@starbeam/resource";
@@ -56,11 +55,6 @@ export function setupSync(blueprint: Sync<void>): void {
   managerSetupResource(MANAGER, blueprint);
 }
 
-export function useResource<T>(blueprint: ResourceBlueprint<T>): T;
-export function useResource<T>(
-  setup: () => ResourceBlueprint<T>,
-  deps: readonly unknown[],
-): T;
 export function useResource<T>(
   blueprint: IntoResourceBlueprint<T>,
   deps?: readonly unknown[],
@@ -92,7 +86,6 @@ function useResourceInstance<T>(
   const handler = useScheduledHandler();
 
   if (instance.current === null || !sameDeps(deps, instance.current.deps)) {
-    cleanupResourceInstance(instance.current);
     instance.current = createResourceInstance(currentBlueprint.current, deps);
   }
 

--- a/packages/preact/preact/tests/dom-attachment-probe.spec.ts
+++ b/packages/preact/preact/tests/dom-attachment-probe.spec.ts
@@ -61,7 +61,7 @@ function useElementAttachmentProbeForTest(
 
         return { status: "attached" as const };
       }),
-    [],
+    [element],
   );
 
   return { ref, status: attachment.status };
@@ -70,7 +70,7 @@ function useElementAttachmentProbeForTest(
 describe("DOM attachment probe", () => {
   beforeAll(() => void install(options));
 
-  test("React-shaped resource helper stays pending after Preact ref attachment", async () => {
+  test("React-shaped resource helper attaches when Preact ref is a resource dep", async () => {
     const events = new RecordedEvents();
     const marker = Marker();
 
@@ -91,8 +91,15 @@ describe("DOM attachment probe", () => {
 
     result.rerender({});
 
-    expect(result.innerHTML).toBe(`<p>pending</p><div>box</div>`);
-    events.expect("resource:pending", "ref:attach");
+    expect(result.innerHTML).toBe(
+      `<p>attached</p><div data-starbeam-attachment="attached">box</div>`,
+    );
+    events.expect(
+      "resource:pending",
+      "ref:attach",
+      "resource:attached",
+      "resource:sync",
+    );
 
     await act(() => {});
     events.expect([]);
@@ -104,9 +111,9 @@ describe("DOM attachment probe", () => {
       marker.mark();
     });
 
-    events.expect([]);
+    events.expect("resource:sync");
 
     result.unmount();
-    events.expect("ref:cleanup");
+    events.expect("resource:finalize", "ref:cleanup");
   });
 });

--- a/packages/preact/preact/tests/resources.spec.ts
+++ b/packages/preact/preact/tests/resources.spec.ts
@@ -49,9 +49,9 @@ describe("useResource", () => {
     result.rerender({ resource: second });
     expect(result.innerHTML).toBe(`<p>second</p>`);
     events.expect(
+      "second:setup",
       "first:cleanup",
       "first:finalize",
-      "second:setup",
       "second:sync",
     );
 

--- a/packages/preact/preact/tests/resources.spec.ts
+++ b/packages/preact/preact/tests/resources.spec.ts
@@ -1,15 +1,13 @@
- 
- 
- 
- 
 // @vitest-environment jsdom
 
 import { install, setupResource, useResource } from "@starbeam/preact";
-import type { ResourceBlueprint } from "@starbeam/resource";
+import { Resource } from "@starbeam/resource";
 import { html, render } from "@starbeam-workspace/preact-testing-utils";
 import {
   beforeAll,
   describe,
+  expect,
+  RecordedEvents,
   test,
   TestResource,
   withCause,
@@ -26,6 +24,44 @@ describe("useResource", () => {
   test("resources can be passed as a callback", () => {
     expectResource((blueprint) => useResource(() => blueprint, []));
   });
+
+  test("resources rebuild when deps change", () => {
+    const events = new RecordedEvents();
+
+    const first = ResourceForDeps("first", events);
+    const second = ResourceForDeps("second", events);
+
+    function App({ resource }: { resource: ResourceForDeps }) {
+      const test = useResource(() => resource, [resource]);
+      return html`<p>${test.id}</p>`;
+    }
+
+    const result = render(App, { resource: first });
+
+    expect(result.innerHTML).toBe(`<p>first</p>`);
+
+    events.expect("first:setup", "first:sync");
+
+    result.rerender({ resource: first });
+    expect(result.innerHTML).toBe(`<p>first</p>`);
+    events.expect([]);
+
+    result.rerender({ resource: second });
+    expect(result.innerHTML).toBe(`<p>second</p>`);
+    events.expect(
+      "first:cleanup",
+      "first:finalize",
+      "second:setup",
+      "second:sync",
+    );
+
+    result.rerender({ resource: second });
+    expect(result.innerHTML).toBe(`<p>second</p>`);
+    events.expect([]);
+
+    result.unmount();
+    events.expect("second:cleanup", "second:finalize");
+  });
 });
 
 describe("setupResource", () => {
@@ -41,7 +77,9 @@ describe("setupResource", () => {
 });
 
 function expectResource(
-  appFn: (resource: ResourceBlueprint<{ id: number }>) => { id: number },
+  appFn: (resource: ReturnType<typeof TestResource>["resource"]) => {
+    id: number;
+  },
 ): void {
   withCause(
     () => {
@@ -69,4 +107,23 @@ function expectResource(
     "test function was defined here",
     { entryFn: expectResource },
   );
+}
+
+type ResourceForDeps = ReturnType<typeof ResourceForDeps>;
+
+function ResourceForDeps(id: string, events: RecordedEvents) {
+  return Resource(({ on }) => {
+    events.record(`${id}:setup`);
+
+    on.sync(() => {
+      events.record(`${id}:sync`);
+      return () => void events.record(`${id}:cleanup`);
+    });
+
+    on.finalize(() => {
+      events.record(`${id}:finalize`);
+    });
+
+    return { id };
+  });
 }


### PR DESCRIPTION
## Summary
- make Preact `useResource(() => blueprint, deps)` rebuild when deps change
- cleanup/finalize the previous resource and bootstrap the new resource sync
- keep same-deps rerenders stable
- flip the Preact DOM attachment probe to attached by using `[element]` deps

## Prepare / Execute / Review (PER)
This is the Preact resource dependency/rebuild PER after #207. The Preact parity probe showed ref timing works but the resource remained pending because deps were ignored.

The implementation keeps the change Preact-local: `setupResource`, `setupSync`, `setupService`, the Preact manager, and the universal renderer helper are unchanged.

## Validation
- `pnpm exec vitest --run --pool forks --project preact packages/preact/preact/tests/resources.spec.ts packages/preact/preact/tests/dom-attachment-probe.spec.ts`
- `pnpm --filter @starbeam/preact test:types`
- `pnpm --filter @starbeam/preact test:lint`
- `pnpm --filter @starbeam-tests/preact test:types`
- `pnpm --filter @starbeam-tests/preact test:lint`
- `pnpm --filter @starbeam/preact build`
- `pnpm test:workspace:pack`
- `git diff --check`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types