### PR TITLE
Add Preact element resource hook

### DIFF
--- a/packages/preact/preact/index.ts
+++ b/packages/preact/preact/index.ts
@@ -1,11 +1,14 @@
 export { createCell } from "./src/create.js";
 export { install } from "./src/options.js";
 export {
+  type ElementResource,
+  type ElementResourceBlueprint,
   setup,
   setupReactive,
   setupResource,
   setupService,
   setupSync,
+  useElementResource,
   useReactive,
   useResource,
   useService,

--- a/packages/preact/preact/src/resource.ts
+++ b/packages/preact/preact/src/resource.ts
@@ -2,20 +2,19 @@ import type { ReadValue } from "@starbeam/reactive";
 import { DEBUG } from "@starbeam/reactive";
 import type { Lifecycle, UseReactive } from "@starbeam/renderer";
 import {
+  intoResourceBlueprint,
   managerCreateLifecycle,
   managerSetupReactive,
   managerSetupResource,
   managerSetupService,
 } from "@starbeam/renderer";
-import type {
-  IntoResourceBlueprint,
-  Sync,
-  SyncFn,
-} from "@starbeam/resource";
+import type { IntoResourceBlueprint, Sync, SyncFn } from "@starbeam/resource";
+import { Resource } from "@starbeam/resource";
 import { pushingScope, RUNTIME } from "@starbeam/runtime";
 import { finalize } from "@starbeam/shared";
 import type { Reactive } from "@starbeam/universal";
 import {
+  useCallback,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -24,6 +23,23 @@ import {
 } from "preact/hooks";
 
 import { MANAGER } from "./renderer.js";
+
+type Bridge = readonly [unknown, ...unknown[]];
+
+export type ElementResource<T, E extends Element> =
+  | {
+      readonly status: "pending";
+      readonly ref: (element: E | null) => void;
+    }
+  | {
+      readonly status: "attached";
+      readonly ref: (element: E | null) => void;
+      readonly current: T;
+    };
+
+export type ElementResourceBlueprint<E extends Element, T> = (
+  element: E,
+) => IntoResourceBlueprint<T>;
 
 export function setupReactive<T>(
   blueprint: UseReactive<T>,
@@ -61,6 +77,38 @@ export function useResource<T>(
 ): T {
   DEBUG?.markEntryPoint(["function:call", "useResource"]);
   return useResourceInstance(blueprint, deps ?? []);
+}
+
+export function useElementResource<E extends Element, T>(
+  blueprint: ElementResourceBlueprint<E, T>,
+  bridge?: Bridge,
+): ElementResource<T, E> {
+  const [element, setElement] = useState<E | null>(null);
+  const [currentBlueprint] = useLatestRef(blueprint);
+
+  const ref = useCallback((element: E | null) => {
+    setElement(element);
+  }, []);
+
+  const attachment = useResource(
+    () =>
+      Resource(({ use }) => {
+        if (element === null) {
+          return { status: "pending" as const, ref };
+        }
+
+        return {
+          status: "attached" as const,
+          ref,
+          current: use(
+            intoResourceBlueprint(currentBlueprint.current(element)),
+          ),
+        };
+      }),
+    bridge ? [element, ...bridge] : [element],
+  );
+
+  return attachment;
 }
 
 interface ScheduledHandler {

--- a/packages/preact/preact/tests/element-resource.spec.ts
+++ b/packages/preact/preact/tests/element-resource.spec.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { install, useElementResource } from "@starbeam/preact";
+import { Cell, Marker, Resource } from "@starbeam/universal";
+import { html, render } from "@starbeam-workspace/preact-testing-utils";
+import {
+  beforeAll,
+  describe,
+  expect,
+  RecordedEvents,
+  test,
+} from "@starbeam-workspace/test-utils";
+import { createElement, Fragment, options } from "preact";
+import { act } from "preact/test-utils";
+
+const INITIAL_WIDTH = 0;
+
+function ElementSizeForTest(
+  element: HTMLElement,
+  events: RecordedEvents,
+  marker: ReturnType<typeof Marker>,
+) {
+  return Resource(({ on }) => {
+    events.record("resource:attached");
+
+    const width = Cell(INITIAL_WIDTH);
+
+    on.sync(() => {
+      events.record("resource:sync");
+      marker.read();
+      width.set(element.getBoundingClientRect().width);
+      element.dataset["starbeamAttachment"] = "attached";
+    });
+
+    on.finalize(() => {
+      events.record("resource:finalize");
+    });
+
+    return { width };
+  });
+}
+
+describe("useElementResource", () => {
+  beforeAll(() => void install(options));
+
+  test("attaches an element-backed resource", async () => {
+    const events = new RecordedEvents();
+    const marker = Marker();
+
+    function App() {
+      const size = useElementResource((element: HTMLElement) =>
+        ElementSizeForTest(element, events, marker),
+      );
+
+      return createElement(
+        Fragment,
+        {},
+        html`<p>${size.status}</p>`,
+        size.status === "attached"
+          ? html`<p>${size.current.width.current}</p>`
+          : null,
+        createElement("div", { ref: size.ref }, "box"),
+      );
+    }
+
+    const result = render(App);
+
+    result.rerender({});
+
+    expect(result.innerHTML).toBe(
+      `<p>attached</p><p>0</p><div data-starbeam-attachment="attached">box</div>`,
+    );
+    events.expect("resource:attached", "resource:sync");
+
+    await act(() => {});
+    events.expect([]);
+
+    result.rerender({});
+    events.expect([]);
+
+    await act(() => {
+      marker.mark();
+    });
+
+    events.expect("resource:sync");
+
+    result.unmount();
+    events.expect("resource:finalize");
+  });
+});


### PR DESCRIPTION
## Summary
- add public `useElementResource()` to `@starbeam/preact`
- match the React `pending | attached` result shape with a stable callback ref
- add Preact coverage for first sync, no duplicate sync on empty turns/rerenders, marker-driven resync, and finalization

## Prepare / Execute / Review (PER)
This is the Preact `useElementResource` API PER after #208 added dependency-sensitive Preact resources. The implementation follows the React public API shape and uses Preact callback refs plus `useResource(..., [element])`.

## Validation
- `pnpm exec vitest --run --pool forks --project preact packages/preact/preact/tests/element-resource.spec.ts packages/preact/preact/tests/dom-attachment-probe.spec.ts packages/preact/preact/tests/resources.spec.ts`
- `pnpm --filter @starbeam/preact test:lint`
- `pnpm --filter @starbeam/preact test:types`
- `pnpm --filter @starbeam-tests/preact test:lint`
- `pnpm --filter @starbeam-tests/preact test:types`
- `pnpm --filter @starbeam/preact build`
- `pnpm test:workspace:pack`
- `git diff --check`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types