### PR TITLE
Reconcile modifier element resource direction

### DIFF
--- a/docs/PACKAGE-SURFACE-TRIAGE.md
+++ b/docs/PACKAGE-SURFACE-TRIAGE.md
@@ -30,17 +30,17 @@ These packages are not obviously wrong. They encode real architectural stories,
 but we need to decide which audiences are supported in 0.9 and whether the
 current package names are the right public surface.
 
-| Package                | Better hypothesis                                                              | Why we cared                                                                                                                                                                                                                   | Current conflict                                                                                                                                              | Suggested action                                                                                                                                                                      |
-| ---------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@starbeam/modifier`   | Internal element-attachment kernel; mandatory post-surface hardening candidate | Represents the ref/directive/modifier part of complete framework reactivity. The basic idea composes resources, element availability, and framework lifetimes. Historically backed React refs and universal element resources. | Current adapter APIs/docs are stale or removed; package only exposes `ElementPlaceholder`; React dependency appears stale. Cross-framework glue needs design. | Keep internal during the package-surface arc, then run a focused hardening PER sequence alongside renderer to see whether the ref/directive/modifier story can be made solid for 0.9. |
-| `@domtree/*`           | Internal DOM-type substrate; tied to modifier hardening                        | Type-level DOM flavor normalization: write DOM algorithms against minimal structural DOM while preserving browser/JSDOM/range types.                                                                                           | Original DOM renderer is gone; current active leak is mostly through `@starbeam/modifier` and stale manifests.                                                | Keep internal unless modifier/renderer hardening proves public authors need these types directly.                                                                                     |
-| `@starbeam/interfaces` | Decision needed / protocol surface                                             | Internal protocol type boundary for runtime/tags/reactive/debug without cycles.                                                                                                                                                | No README, special `library:interfaces`, stale-looking `src/protocol.ts`, stale `@domtree/any` manifest dependency, broad declaration leakage.                | Decide whether protocol types are public. Consider a better public `@starbeam/protocol` surface or re-export strategy.                                                                |
-| `@starbeam/tags`       | Decision needed                                                                | Validation/tag substrate extracted from runtime; core of demand-driven validation.                                                                                                                                             | Low-level implementor API, not normal app-user API.                                                                                                           | Bless as implementor API or hide behind `reactive`/`runtime`.                                                                                                                         |
-| `@starbeam/runtime`    | Decision needed                                                                | Runtime coordination, subscriptions, finalization scopes; intentionally split from reactive primitives.                                                                                                                        | README says stable for libraries but not app code; public exports are low-level.                                                                              | Decide whether runtime/library authors are supported. Refresh docs if public.                                                                                                         |
-| `@starbeam/service`    | Decision needed                                                                | App-scoped singleton resource machinery used by adapters/renderer.                                                                                                                                                             | README appears copied from resource docs; old universal docs say `service` belongs in `@starbeam/universal`, but current universal index does not export it.  | Decide if service is direct API, universal re-export, renderer-author API, or private adapter support.                                                                                |
-| `@starbeam/reactive`   | Public primitive surface, needs split                                          | Primitive reactive values are documented and useful to library authors.                                                                                                                                                        | Exports include runtime wiring/debug/tracking-frame substrate, not just public primitives.                                                                    | Keep public for primitives. Move/hide runtime wiring and tracking internals behind internal or future author-facing surfaces.                                                         |
-| `@starbeam/universal`  | Main public umbrella candidate                                                 | Best current framework-agnostic entrypoint over cells, formulas, resources, and common integration concepts.                                                                                                                   | Leaks low-level package names in JS and declarations; service docs conflict with exports.                                                                     | Make it the public umbrella over private substrates. Re-export service if public; stop exposing raw runtime/protocol pieces as the story.                                             |
-| `@starbeam/core`       | Compatibility decision                                                         | Deprecated alias over `@starbeam/universal`.                                                                                                                                                                                   | Root badge still points at it, but code is only a warning + re-export.                                                                                        | Decide old-import compatibility policy for 0.9.                                                                                                                                       |
+| Package                | Better hypothesis                                                              | Why we cared                                                                                                                                                                                                                   | Current conflict                                                                                                                                                              | Suggested action                                                                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@starbeam/modifier`   | Internal element-attachment kernel; mandatory post-surface hardening candidate | Represents the ref/directive/modifier part of complete framework reactivity. The basic idea composes resources, element availability, and framework lifetimes. Historically backed React refs and universal element resources. | React and Preact now prove matching `useElementResource` leaves, but `@starbeam/modifier` still only exposes `ElementPlaceholder`. Vue's directive dialect is not proven yet. | Keep internal. Reconcile the docs around public concept/internal kernel; run a Vue directive probe before moving shared element-resource vocabulary into any public package. |
+| `@domtree/*`           | Internal DOM-type substrate; tied to modifier hardening                        | Type-level DOM flavor normalization: write DOM algorithms against minimal structural DOM while preserving browser/JSDOM/range types.                                                                                           | Original DOM renderer is gone; current active leak is mostly through `@starbeam/modifier` and stale manifests.                                                                | Keep internal unless modifier/renderer hardening proves public authors need these types directly.                                                                            |
+| `@starbeam/interfaces` | Decision needed / protocol surface                                             | Internal protocol type boundary for runtime/tags/reactive/debug without cycles.                                                                                                                                                | No README, special `library:interfaces`, stale-looking `src/protocol.ts`, stale `@domtree/any` manifest dependency, broad declaration leakage.                                | Decide whether protocol types are public. Consider a better public `@starbeam/protocol` surface or re-export strategy.                                                       |
+| `@starbeam/tags`       | Decision needed                                                                | Validation/tag substrate extracted from runtime; core of demand-driven validation.                                                                                                                                             | Low-level implementor API, not normal app-user API.                                                                                                                           | Bless as implementor API or hide behind `reactive`/`runtime`.                                                                                                                |
+| `@starbeam/runtime`    | Decision needed                                                                | Runtime coordination, subscriptions, finalization scopes; intentionally split from reactive primitives.                                                                                                                        | README says stable for libraries but not app code; public exports are low-level.                                                                                              | Decide whether runtime/library authors are supported. Refresh docs if public.                                                                                                |
+| `@starbeam/service`    | Decision needed                                                                | App-scoped singleton resource machinery used by adapters/renderer.                                                                                                                                                             | README appears copied from resource docs; old universal docs say `service` belongs in `@starbeam/universal`, but current universal index does not export it.                  | Decide if service is direct API, universal re-export, renderer-author API, or private adapter support.                                                                       |
+| `@starbeam/reactive`   | Public primitive surface, needs split                                          | Primitive reactive values are documented and useful to library authors.                                                                                                                                                        | Exports include runtime wiring/debug/tracking-frame substrate, not just public primitives.                                                                                    | Keep public for primitives. Move/hide runtime wiring and tracking internals behind internal or future author-facing surfaces.                                                |
+| `@starbeam/universal`  | Main public umbrella candidate                                                 | Best current framework-agnostic entrypoint over cells, formulas, resources, and common integration concepts.                                                                                                                   | Leaks low-level package names in JS and declarations; service docs conflict with exports.                                                                                     | Make it the public umbrella over private substrates. Re-export service if public; stop exposing raw runtime/protocol pieces as the story.                                    |
+| `@starbeam/core`       | Compatibility decision                                                         | Deprecated alias over `@starbeam/universal`.                                                                                                                                                                                   | Root badge still points at it, but code is only a warning + re-export.                                                                                                        | Decide old-import compatibility policy for 0.9.                                                                                                                              |
 
 ### Modifier / DOM attachment decision frame
 
@@ -64,11 +64,16 @@ Other live possibilities:
 - **Stale boundary:** the current modifier package shrinks or disappears if the
   old concept no longer matches the active adapter story.
 
-Current evidence: `@starbeam/react` has `useElementResource`, a small public
-hook that wraps the tested callback-ref/resource pattern. `@starbeam/modifier`
-only exposes `ElementPlaceholder`; React modifier docs say the feature is under
-construction; the runtime README still contains historical `useReactiveElement`
-/ `useModifier` examples that describe the concept but not current public APIs.
+Current evidence: `@starbeam/react` and `@starbeam/preact` both expose
+`useElementResource`, with matching local `ElementResource` /
+`ElementResourceBlueprint` shapes: a function from `element` to
+`IntoResourceBlueprint<T>`, plus a `pending | attached` result that always
+carries the framework callback ref. This is stronger evidence for a shared
+Starbeam DOM attachment concept than the earlier React-only probe.
+`@starbeam/modifier` still only exposes `ElementPlaceholder`, which models
+element availability but not the resource-shaped public contract. Vue currently
+has `setupResource` and component lifecycle integration, but the idiomatic
+directive dialect for reusable low-level DOM access is still unproven.
 
 #### DOM attachment contract sketch
 
@@ -143,6 +148,35 @@ Next implementation work should treat element attachment and sync scheduling as
 separate problems. A later API may choose to expose a ready/synced boundary, but
 the current evidence does not justify adding a public state name yet.
 
+**React / Preact convergence after #205-#209**
+
+React and Preact now independently expose the same leaf API shape:
+
+- `ElementResourceBlueprint<E, T>` is `(element: E) => IntoResourceBlueprint<T>`.
+- The returned `ElementResource<T, E>` is either `pending` or `attached`.
+- Both states carry the adapter callback ref.
+- `attached.current` is the value produced by the element-backed resource.
+
+This supports the hypothesis that Starbeam has a universal resource-shaped DOM
+attachment concept. It does not yet prove that `@starbeam/modifier` should be
+public. The duplicated adapter-local types may be the right short-term state
+until Vue proves the directive dialect and the owning package boundary is clear.
+
+**`ElementPlaceholder` reconciliation**
+
+`ElementPlaceholder` is the current internal artifact in `@starbeam/modifier`.
+It is a reactive placeholder for an element: `current` is `null` before
+initialization, `initialize()` verifies the element constructor in DEV, and
+initialization freezes the underlying cell. That overlaps with the first step of
+DOM attachment: the framework supplies an element later. It is not the same
+abstraction as `ElementResourceBlueprint`.
+
+The proven adapter shape is resource-shaped. Once an element exists, Starbeam
+runs an `IntoResourceBlueprint<T>` for that element and ties cleanup to the
+framework lifetime. `ElementPlaceholder` does not encode `pending | attached`,
+resource setup, `on.sync` timing, cleanup, or element replacement. Treat it as
+internal historical kernel evidence, not as the public API shape.
+
 ## Private packages with cleanup debt
 
 These packages are private. Some still have source-level cleanup work, but they
@@ -179,9 +213,11 @@ bounded change, then review the result against the prediction.
    public runtime dependency fields, JS, and declarations clean. Remaining
    dev metadata, source-map, and source-level references are cleanup debt for
    low-level surface consolidation.
-4. Modifier/domtree hardening PER sequence alongside renderer. Goal: determine
-   whether ref/directive/modifier integration can become a solid 0.9 story
-   across framework adapters.
+4. Modifier / DOM attachment reconciliation. First update the triage docs with
+   React + Preact convergence and the `ElementPlaceholder` comparison. Then run
+   a Vue directive probe. Only after the directive probe should we consider
+   moving shared `ElementResource` vocabulary into `@starbeam/renderer`,
+   `@starbeam/universal`, `@starbeam/modifier`, or another public boundary.
 5. Low-level surface consolidation: make `@starbeam/universal` the umbrella,
    split public `@starbeam/reactive` primitives from runtime wiring, place
    service intentionally, and target interfaces/tags/runtime as internal unless


### PR DESCRIPTION
## Summary
- update package-surface triage with React/Preact `useElementResource` convergence
- compare current `@starbeam/modifier` / `ElementPlaceholder` to the resource-shaped element attachment model
- keep `@starbeam/modifier` internal while naming Vue directive proof as the next gate

## Prepare / Execute / Review (PER)
This is the modifier / element-resource reconciliation PER. It records the emerging architecture without moving shared types or making `@starbeam/modifier` public yet.

The key conclusion is public concept, internal kernel: React and Preact now prove the element-resource leaf API, while Vue still needs a directive probe before we decide where shared vocabulary belongs.

## Validation
- `pnpm exec prettier --write docs/PACKAGE-SURFACE-TRIAGE.md`
- `git diff --check -- docs/PACKAGE-SURFACE-TRIAGE.md`
- `pnpm test:workspace:pack`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types