### PR TITLE
Probe Vue directive element resources

### DIFF
--- a/packages/vue/vue/tests/dom-attachment-probe.spec.ts
+++ b/packages/vue/vue/tests/dom-attachment-probe.spec.ts
@@ -7,7 +7,7 @@ import { finalize } from "@starbeam/shared";
 import { describe, RecordedEvents, test } from "@starbeam-workspace/test-utils";
 import { App, renderApp } from "@starbeam-workspace/vue-testing-utils";
 import type { Directive } from "vue";
-import { Fragment, h, withDirectives } from "vue";
+import { Fragment, h, nextTick, withDirectives } from "vue";
 
 interface AttachmentOptions {
   readonly invalidate?: (() => void) | undefined;
@@ -39,7 +39,7 @@ function elementResourceDirective(
   events: RecordedEvents,
   options: AttachmentOptions = {},
 ): Directive<HTMLElement> {
-  let cleanup: (() => void) | undefined;
+  const cleanups = new WeakMap<HTMLElement, () => void>();
 
   return {
     mounted(element) {
@@ -49,17 +49,28 @@ function elementResourceDirective(
 
       sync();
 
-      const unsubscribe = RUNTIME.subscribe(sync, () => void sync());
+      let scheduled = false;
+      const scheduleSync = () => {
+        if (scheduled) return;
+        scheduled = true;
 
-      cleanup = () => {
+        void nextTick(() => {
+          scheduled = false;
+          sync();
+        });
+      };
+
+      const unsubscribe = RUNTIME.subscribe(sync, scheduleSync);
+
+      cleanups.set(element, () => {
         if (unsubscribe) unsubscribe();
         finalize(scope);
-      };
+      });
     },
 
-    unmounted() {
-      cleanup?.();
-      cleanup = undefined;
+    unmounted(element) {
+      cleanups.get(element)?.();
+      cleanups.delete(element);
     },
   };
 }
@@ -95,9 +106,12 @@ describe("DOM attachment probe", () => {
     await result.rerender().andExpect({ output: expectedHTML });
 
     marker.mark();
-    result.expect({ output: expectedHTML, events: ["resource:sync"] });
+    result.expect({ output: expectedHTML });
 
-    await result.flush().andExpect({ output: expectedHTML });
+    await result.flush().andExpect({
+      output: expectedHTML,
+      events: ["resource:sync"],
+    });
     await result
       .unmount()
       .andExpect({ output: "", events: ["resource:finalize"] });

--- a/packages/vue/vue/tests/dom-attachment-probe.spec.ts
+++ b/packages/vue/vue/tests/dom-attachment-probe.spec.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { Marker } from "@starbeam/reactive";
+import { Resource, setupResource } from "@starbeam/resource";
+import { pushingScope, RUNTIME } from "@starbeam/runtime";
+import { finalize } from "@starbeam/shared";
+import { describe, RecordedEvents, test } from "@starbeam-workspace/test-utils";
+import { App, renderApp } from "@starbeam-workspace/vue-testing-utils";
+import type { Directive } from "vue";
+import { Fragment, h, withDirectives } from "vue";
+
+interface AttachmentOptions {
+  readonly invalidate?: (() => void) | undefined;
+}
+
+function ElementAttachmentForTest(
+  element: HTMLElement,
+  events: RecordedEvents,
+  options: AttachmentOptions = {},
+) {
+  return Resource(({ on }) => {
+    events.record("resource:attached");
+
+    on.sync(() => {
+      events.record("resource:sync");
+      options.invalidate?.();
+      element.dataset["starbeamAttachment"] = "attached";
+    });
+
+    on.finalize(() => {
+      events.record("resource:finalize");
+    });
+
+    return { element };
+  });
+}
+
+function elementResourceDirective(
+  events: RecordedEvents,
+  options: AttachmentOptions = {},
+): Directive<HTMLElement> {
+  let cleanup: (() => void) | undefined;
+
+  return {
+    mounted(element) {
+      const [scope, { sync }] = pushingScope(() =>
+        setupResource(ElementAttachmentForTest(element, events, options)),
+      );
+
+      sync();
+
+      const unsubscribe = RUNTIME.subscribe(sync, () => void sync());
+
+      cleanup = () => {
+        if (unsubscribe) unsubscribe();
+        finalize(scope);
+      };
+    },
+
+    unmounted() {
+      cleanup?.();
+      cleanup = undefined;
+    },
+  };
+}
+
+describe("DOM attachment probe", () => {
+  test("directive attaches an element-backed resource", async () => {
+    const events = new RecordedEvents();
+    const marker = Marker();
+
+    const vElementResource = elementResourceDirective(events, {
+      invalidate: () => void marker.read(),
+    });
+
+    const app = App({
+      setup: () => {
+        return () =>
+          h(Fragment, [
+            h("p", "attached"),
+            withDirectives(h("div", "box"), [[vElementResource]]),
+          ]);
+      },
+    });
+
+    const expectedHTML =
+      '<p>attached</p><div data-starbeam-attachment="attached">box</div>';
+
+    const result = await renderApp(app, { events }).andExpect({
+      output: expectedHTML,
+      events: ["resource:attached", "resource:sync"],
+    });
+
+    await result.flush().andExpect({ output: expectedHTML });
+    await result.rerender().andExpect({ output: expectedHTML });
+
+    marker.mark();
+    result.expect({ output: expectedHTML, events: ["resource:sync"] });
+
+    await result.flush().andExpect({ output: expectedHTML });
+    await result
+      .unmount()
+      .andExpect({ output: "", events: ["resource:finalize"] });
+
+    marker.mark();
+    events.expect([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a test-local Vue directive element-resource probe
- show a Vue directive can own an element-backed Starbeam resource lifetime directly
- verify initial sync, no extra sync on flush/rerender, marker-driven sync, unmount finalization, and post-unmount unsubscribe

## Prepare / Execute / Review (PER)
This is the Vue directive DOM attachment PER. It validates the non-hooks framework dialect after React and Preact proved callback-ref leaves.

The key finding is that `@starbeam/vue` component `setupResource()` cannot be used from directive hooks because Vue directive hooks do not have setup-time `getCurrentInstance()` context. The test-local directive therefore owns the resource scope directly with `@starbeam/resource`, `pushingScope`, `RUNTIME.subscribe`, and `finalize`.

This is intentionally a probe, not a public Vue directive API yet.

## Validation
- `prettier --write packages/vue/vue/tests/dom-attachment-probe.spec.ts`
- direct eslint on `packages/vue/vue/tests/dom-attachment-probe.spec.ts`
- direct `tsc -b packages/vue/vue/tests/tsconfig.json`
- `vitest --run --pool forks --project vue packages/vue/vue/tests/dom-attachment-probe.spec.ts packages/vue/vue/tests/resources.spec.ts`
- `pnpm test:workspace:pack`
- `git diff --check`
- pre-commit: workspace types, workspace lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types