### PR TITLE
Document domain-shaped reactive APIs

### DIFF
--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -25,6 +25,20 @@ private fields really is a class. A formula is just a function. A library
 author doesn't "make their abstraction reactive" — if the root state is
 reactive, reading through any abstraction is reactive.
 
+### Public APIs expose domain concepts, not reactive storage
+
+Reactive storage is an implementation detail of higher-level abstractions.
+Use `Cell.current` when working directly with a cell. When publishing an
+abstraction backed by reactive storage, expose domain-shaped properties and
+methods instead: `size.width`, `session.user`, `form.isValid`, not
+`size.width.current`, `session.user.current`, or `form.isValid.current`.
+
+This preserves the rule that the boundary is at storage. A getter, method, or
+object remains ordinary JavaScript; it becomes reactive because it reads
+reactive storage internally. Consumers should not need to know whether an
+abstraction uses a `Cell`, a `Formula`, a resource, or another storage strategy
+unless the abstraction is intentionally exposing primitive reactive storage.
+
 **User code runs in two modes.** Outside rendering — event handlers, effects,
 async continuations, plain function calls — read and write freely. Reactive
 state behaves like ordinary state. Inside rendering — the frame during which a

--- a/packages/react/react/README.md
+++ b/packages/react/react/README.md
@@ -55,7 +55,15 @@ function ElementSize(element: Element) {
       return () => observer.disconnect();
     });
 
-    return { width, height };
+    return {
+      get width() {
+        return width.current;
+      },
+
+      get height() {
+        return height.current;
+      },
+    };
   });
 }
 
@@ -69,7 +77,7 @@ export function MeasuredPanel() {
       return "Measuring…";
     }
 
-    return `${size.current.width.current} × ${size.current.height.current}`;
+    return `${size.current.width} × ${size.current.height}`;
   }, [size]);
 
   return <section ref={size.ref}>{label}</section>;

--- a/packages/universal/resource/README.md
+++ b/packages/universal/resource/README.md
@@ -193,7 +193,8 @@ object that stores a cell and exposes reactive getters:
 
 This is the usual shape for public APIs backed by reactive storage: keep the
 cell private, and expose domain properties or methods that read the cell. See
-the public API guidance in [Starbeam Invariants](../../../docs/INVARIANTS.md#public-apis-expose-domain-concepts-not-reactive-storage).
+the public API guidance in
+[Starbeam Invariants](https://github.com/starbeamjs/starbeam/blob/main/docs/INVARIANTS.md#public-apis-expose-domain-concepts-not-reactive-storage).
 
 ```ts
 const Stopwatch = Resource(({ on }) => {

--- a/packages/universal/resource/README.md
+++ b/packages/universal/resource/README.md
@@ -191,6 +191,10 @@ While assimilation is often useful, a resource's instance value does not
 **need** to be a reactive value. For example, it could be an instance of an
 object that stores a cell and exposes reactive getters:
 
+This is the usual shape for public APIs backed by reactive storage: keep the
+cell private, and expose domain properties or methods that read the cell. See
+the public API guidance in [Starbeam Invariants](../../../docs/INVARIANTS.md#public-apis-expose-domain-concepts-not-reactive-storage).
+
 ```ts
 const Stopwatch = Resource(({ on }) => {
   const now = Cell(Date.now());
@@ -227,7 +231,6 @@ A resource is a reactive value that evaluates to its _current value_.
 The steps for evaluating the constructor are:
 
 1. Evaluate the resource's constructor formula. Evaluating the formula:
-
    1. Collects the run's reactive dependencies.
    2. Collects a list of the run's cleanup functions.
    3. Links any resources created within the run to the run's lifetime. If the

--- a/packages/universal/service/README.md
+++ b/packages/universal/service/README.md
@@ -191,7 +191,8 @@ object that stores a cell and exposes reactive getters:
 
 This is the usual shape for public APIs backed by reactive storage: keep the
 cell private, and expose domain properties or methods that read the cell. See
-the public API guidance in [Starbeam Invariants](../../../docs/INVARIANTS.md#public-apis-expose-domain-concepts-not-reactive-storage).
+the public API guidance in
+[Starbeam Invariants](https://github.com/starbeamjs/starbeam/blob/main/docs/INVARIANTS.md#public-apis-expose-domain-concepts-not-reactive-storage).
 
 ```ts
 const Stopwatch = Resource(({ on }) => {

--- a/packages/universal/service/README.md
+++ b/packages/universal/service/README.md
@@ -189,6 +189,10 @@ While assimilation is often useful, a resource's instance value does not
 **need** to be a reactive value. For example, it could be an instance of an
 object that stores a cell and exposes reactive getters:
 
+This is the usual shape for public APIs backed by reactive storage: keep the
+cell private, and expose domain properties or methods that read the cell. See
+the public API guidance in [Starbeam Invariants](../../../docs/INVARIANTS.md#public-apis-expose-domain-concepts-not-reactive-storage).
+
 ```ts
 const Stopwatch = Resource(({ on }) => {
   const now = Cell(Date.now());
@@ -225,7 +229,6 @@ A resource is a reactive value that evaluates to its _current value_.
 The steps for evaluating the constructor are:
 
 1. Evaluate the resource's constructor formula. Evaluating the formula:
-
    1. Collects the run's reactive dependencies.
    2. Collects a list of the run's cleanup functions.
    3. Links any resources created within the run to the run's lifetime. If the


### PR DESCRIPTION
## Summary

- add the public API axiom to Starbeam invariants: public abstractions expose domain concepts, not reactive storage
- update the React element-resource README example to expose width/height through getters instead of leaking cells
- link resource/service instance-value docs back to the invariant

## Validation

- pnpm exec prettier --write docs/INVARIANTS.md packages/react/react/README.md packages/universal/resource/README.md packages/universal/service/README.md
- git diff --check
- pnpm test:workspace:pack
- pre-commit: typecheck + lint
- pre-push: build, build-verify, debug-bootstrap, lint, pack, specs, specs-prod, types