### PR TITLE
Add Vue element resource directive

### DIFF
--- a/docs/DOM-ATTACHMENT-BOUNDARY.md
+++ b/docs/DOM-ATTACHMENT-BOUNDARY.md
@@ -9,7 +9,7 @@ For 0.9, DOM attachment is a public concept with official adapter APIs, not a
 new shared public package boundary.
 
 - React and Preact keep their idiomatic `useElementResource` leaves.
-- Vue has a proven directive-owned lifetime, but no public directive API yet.
+- Vue exposes `elementResourceDirective` for directive-owned element resources.
 - `@starbeam/modifier` stays internal. Its current `ElementPlaceholder` is
   historical kernel evidence, not the public contract.
 - `@starbeam/renderer` remains the best future home for adapter-author
@@ -19,8 +19,8 @@ new shared public package boundary.
   resources for app and library authors, but should not expose ref, directive,
   or modifier-shaped APIs in 0.9.
 
-The next code move should be driven by adapter duplication or a concrete Vue
-API, not by the existence of the old modifier package name.
+Future code moves should be driven by adapter duplication or another concrete
+framework dialect, not by the existence of the old modifier package name.
 
 ## What is stable
 
@@ -82,11 +82,11 @@ primitive or an adapter result slot such as React's attached resource value.
 Refs, directives, and modifiers are framework dialects for delivering the
 element. They are not the stable Starbeam contract name.
 
-| Framework | Dialect          | Proven API or evidence                                                   | Current status                         |
-| --------- | ---------------- | ------------------------------------------------------------------------ | -------------------------------------- |
-| React     | callback ref     | `useElementResource`                                                     | Public adapter leaf                    |
-| Preact    | callback ref     | `useElementResource`                                                     | Public adapter leaf                    |
-| Vue       | custom directive | directive probe in `packages/vue/vue/tests/dom-attachment-probe.spec.ts` | Mechanism proven, public API undecided |
+| Framework | Dialect          | Proven API or evidence     | Current status      |
+| --------- | ---------------- | -------------------------- | ------------------- |
+| React     | callback ref     | `useElementResource`       | Public adapter leaf |
+| Preact    | callback ref     | `useElementResource`       | Public adapter leaf |
+| Vue       | custom directive | `elementResourceDirective` | Public adapter leaf |
 
 ### React and Preact
 
@@ -111,7 +111,8 @@ state without new evidence.
 
 ### Vue
 
-Vue proves the non-hooks dialect. A custom directive can:
+Vue proves the non-hooks dialect. `elementResourceDirective` creates a custom
+directive that can:
 
 - create a resource scope when `mounted` receives the element;
 - subscribe runtime invalidations with `RUNTIME.subscribe`;
@@ -119,10 +120,10 @@ Vue proves the non-hooks dialect. A custom directive can:
 - keep cleanup per element with a `WeakMap`;
 - unsubscribe and finalize the scope on `unmounted`.
 
-The probe also shows that the component-centered `@starbeam/vue` `setupResource`
-path is not the right directive-hook mechanism. Directive hooks do not have
-setup-time `getCurrentInstance()` context, so a future Vue element-attachment API
-needs a directive-owned lifetime path.
+The public API uses the same directive-owned lifetime path proven by the probe.
+The component-centered `@starbeam/vue` `setupResource` path is not the right
+directive-hook mechanism. Directive hooks do not have setup-time
+`getCurrentInstance()` context.
 
 ## Boundary matrix
 

--- a/docs/PACKAGE-SURFACE-TRIAGE.md
+++ b/docs/PACKAGE-SURFACE-TRIAGE.md
@@ -69,9 +69,10 @@ Current evidence: `@starbeam/react` and `@starbeam/preact` both expose
 `ElementResourceBlueprint` shapes: a function from `element` to
 `IntoResourceBlueprint<T>`, plus a `pending | attached` result that always
 carries the framework callback ref. Vue adds the non-hooks version of that
-evidence: a custom directive can own the resource scope for an element,
-subscribe to runtime invalidations, schedule sync through Vue, and finalize when
-the element unmounts. This is stronger evidence for a shared Starbeam DOM
+evidence: `@starbeam/vue` exposes `elementResourceDirective`, whose custom
+directive owns the resource scope for an element, subscribes to runtime
+invalidations, schedules sync through Vue, and finalizes when the element
+unmounts. This is stronger evidence for a shared Starbeam DOM
 attachment concept than the earlier React-only probe. `@starbeam/modifier`
 still only exposes `ElementPlaceholder`, which models element availability but
 not the resource-shaped public contract.
@@ -113,9 +114,9 @@ React hidden trees, Vue deactivation, and element replacement. Use
 - Preact can use the shared renderer manager shape, but an element API still
   needs to define how the element arrives and how replacement is represented.
 - Vue component setup/resource timing can use the shared manager shape. Vue
-  directives supply the element around mount/unmount, and #211 proves that a
-  directive can own an element-backed resource lifetime. Vue deactivation
-  remains a separate question.
+  directives supply the element around mount/unmount, and
+  `elementResourceDirective` owns an element-backed resource lifetime. Vue
+  deactivation remains a separate question.
 
 **Boundary candidates**
 
@@ -164,9 +165,10 @@ attachment concept. It does not yet prove that `@starbeam/modifier` should be
 public. The duplicated adapter-local types may be the right short-term state
 until the owning package boundary is clear.
 
-**Vue directive findings from #211**
+**Vue directive findings from #211 and #215**
 
-Vue proves that a non-hooks dialect is feasible. A custom directive can own an
+Vue proves that a non-hooks dialect is feasible. `@starbeam/vue` now exposes
+`elementResourceDirective`, a custom directive factory that can own an
 element-backed resource lifetime directly:
 
 - `mounted` receives the element and creates the resource scope.

--- a/packages/vue/vue/README.md
+++ b/packages/vue/vue/README.md
@@ -1,0 +1,90 @@
+# @starbeam/vue
+
+Vue adapter for Starbeam reactive values, resources, services, and element-backed
+resources.
+
+## Public APIs
+
+- `setupReactive(blueprint)`: expose a Starbeam reactive value as a Vue ref.
+- `setupResource(blueprint)`: create a Starbeam resource in component setup.
+- `setupService(blueprint)`: access an app-scoped Starbeam service.
+- `elementResourceDirective(blueprint, options?)`: attach an element-backed
+  resource to a Vue custom directive.
+- `Starbeam`: Vue plugin that owns app-scoped Starbeam services.
+
+## Element resources
+
+`elementResourceDirective()` is the Vue API for element-backed Starbeam
+resources. It accepts a function from an element to a resource blueprint and
+returns a Vue custom directive.
+
+Vue directives do not return values to templates, so pass an `into` ref when the
+component needs to read the resource value.
+
+```vue
+<script setup lang="ts">
+import { Cell, Resource } from "@starbeam/universal";
+import { elementResourceDirective } from "@starbeam/vue";
+import { shallowRef } from "vue";
+
+interface Size {
+  readonly width: number;
+  readonly height: number;
+}
+
+function ElementSize(element: Element) {
+  return Resource(({ on }) => {
+    const width = Cell(0);
+    const height = Cell(0);
+
+    on.sync(() => {
+      const observer = new ResizeObserver(([entry]) => {
+        if (!entry) return;
+
+        width.set(entry.contentRect.width);
+        height.set(entry.contentRect.height);
+      });
+
+      observer.observe(element);
+      return () => observer.disconnect();
+    });
+
+    return {
+      get width() {
+        return width.current;
+      },
+
+      get height() {
+        return height.current;
+      },
+    } satisfies Size;
+  });
+}
+
+const size = shallowRef<Size | null>(null);
+const vSize = elementResourceDirective(ElementSize, { into: size });
+</script>
+
+<template>
+  <section v-size>
+    {{ size ? `${size.width} × ${size.height}` : "Measuring…" }}
+  </section>
+</template>
+```
+
+The returned resource value should be domain-shaped. Keep cells private and
+expose getters or methods, so consumers read `size.width`, not
+`size.width.current`.
+
+## Timing model
+
+The directive creates the element-backed resource when Vue calls `mounted` and
+finalizes it when Vue calls `unmounted`.
+
+When `into` is provided:
+
+- before mount, keep the ref initialized to `null`;
+- after mount and the initial Starbeam sync, publish the resource value;
+- after later Starbeam sync invalidations, trigger the ref so Vue rerenders even
+  if the resource value identity is stable;
+- on unmount, reset the ref to `null`.

--- a/packages/vue/vue/index.ts
+++ b/packages/vue/vue/index.ts
@@ -1,2 +1,9 @@
-export { setupReactive, setupResource, setupService } from "./src/resource.js";
+export {
+  type ElementResourceBlueprint,
+  elementResourceDirective,
+  type ElementResourceDirectiveOptions,
+  setupReactive,
+  setupResource,
+  setupService,
+} from "./src/resource.js";
 export { Starbeam, useReactive } from "./src/setup.js";

--- a/packages/vue/vue/src/resource.ts
+++ b/packages/vue/vue/src/resource.ts
@@ -6,10 +6,22 @@ import {
   managerSetupService,
 } from "@starbeam/renderer";
 import type { IntoResourceBlueprint } from "@starbeam/resource";
-import type { Ref } from "vue";
+import { setupResource as setupStarbeamResource } from "@starbeam/resource";
+import { pushingScope, RUNTIME } from "@starbeam/runtime";
+import { finalize } from "@starbeam/shared";
+import type { Directive, Ref } from "vue";
+import { nextTick, triggerRef } from "vue";
 
 import { MANAGER } from "./renderer.js";
 import { useReactive } from "./setup.js";
+
+export type ElementResourceBlueprint<E extends Element, T> = (
+  element: E,
+) => IntoResourceBlueprint<T>;
+
+export interface ElementResourceDirectiveOptions<T> {
+  readonly into?: Ref<T | null> | undefined;
+}
 
 export function setupReactive<T>(blueprint: UseReactive<T>): Ref<ReadValue<T>> {
   const vueInstance = useReactive();
@@ -28,4 +40,59 @@ export function setupService<T>(blueprint: IntoResourceBlueprint<T>): T {
   useReactive();
 
   return managerSetupService(MANAGER, blueprint);
+}
+
+export function elementResourceDirective<E extends Element, T>(
+  blueprint: ElementResourceBlueprint<E, T>,
+  options: ElementResourceDirectiveOptions<T> = {},
+): Directive<E> {
+  const cleanups = new WeakMap<E, () => void>();
+
+  const publish = (value: T | null): void => {
+    if (!options.into) return;
+
+    options.into.value = value;
+    triggerRef(options.into);
+  };
+
+  return {
+    mounted(element) {
+      cleanups.get(element)?.();
+
+      const [scope, resource] = pushingScope(() =>
+        setupStarbeamResource(blueprint(element)),
+      );
+
+      resource.sync();
+      publish(resource.value);
+
+      let scheduled = false;
+      let active = true;
+      const scheduleSync = () => {
+        if (scheduled) return;
+        scheduled = true;
+
+        void nextTick(() => {
+          scheduled = false;
+          if (!active) return;
+          resource.sync();
+          publish(resource.value);
+        });
+      };
+
+      const unsubscribe = RUNTIME.subscribe(resource.sync, scheduleSync);
+
+      cleanups.set(element, () => {
+        active = false;
+        if (unsubscribe) unsubscribe();
+        finalize(scope);
+        publish(null);
+      });
+    },
+
+    unmounted(element) {
+      cleanups.get(element)?.();
+      cleanups.delete(element);
+    },
+  };
 }

--- a/packages/vue/vue/tests/element-resource.spec.ts
+++ b/packages/vue/vue/tests/element-resource.spec.ts
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+
+import { Marker } from "@starbeam/reactive";
+import { Resource } from "@starbeam/resource";
+import { Cell } from "@starbeam/universal";
+import { elementResourceDirective } from "@starbeam/vue";
+import { describe, RecordedEvents, test } from "@starbeam-workspace/test-utils";
+import { App, renderApp } from "@starbeam-workspace/vue-testing-utils";
+import { Fragment, h, shallowRef, withDirectives } from "vue";
+
+interface AttachmentOptions {
+  readonly invalidate?: (() => void) | undefined;
+}
+
+const INITIAL_WIDTH = 0;
+
+function ElementAttachmentForTest(
+  element: HTMLElement,
+  events: RecordedEvents,
+  options: AttachmentOptions = {},
+) {
+  return Resource(({ on }) => {
+    events.record("resource:attached");
+
+    on.sync(() => {
+      events.record("resource:sync");
+      options.invalidate?.();
+      element.dataset["starbeamAttachment"] = "attached";
+    });
+
+    on.finalize(() => {
+      events.record("resource:finalize");
+    });
+
+    return { element };
+  });
+}
+
+function ElementSizeForTest(
+  element: HTMLElement,
+  events: RecordedEvents,
+  marker: ReturnType<typeof Marker>,
+) {
+  return Resource(({ on }) => {
+    const width = Cell(INITIAL_WIDTH);
+
+    events.record("size:attached");
+
+    on.sync(() => {
+      events.record("size:sync");
+      marker.read();
+      width.set(Number(element.dataset["width"] ?? INITIAL_WIDTH));
+    });
+
+    on.finalize(() => {
+      events.record("size:finalize");
+    });
+
+    return {
+      get width() {
+        return width.current;
+      },
+    };
+  });
+}
+
+describe("elementResourceDirective", () => {
+  test("directive attaches an element-backed resource", async () => {
+    const events = new RecordedEvents();
+    const marker = Marker();
+
+    const vElementResource = elementResourceDirective((element: HTMLElement) =>
+      ElementAttachmentForTest(element, events, {
+        invalidate: () => void marker.read(),
+      }),
+    );
+
+    const app = App({
+      setup: () => {
+        return () =>
+          h(Fragment, [
+            h("p", "attached"),
+            withDirectives(h("div", "box"), [[vElementResource]]),
+          ]);
+      },
+    });
+
+    const expectedHTML =
+      '<p>attached</p><div data-starbeam-attachment="attached">box</div>';
+
+    const result = await renderApp(app, { events }).andExpect({
+      output: expectedHTML,
+      events: ["resource:attached", "resource:sync"],
+    });
+
+    await result.flush().andExpect({ output: expectedHTML });
+    await result.rerender().andExpect({ output: expectedHTML });
+
+    marker.mark();
+    result.expect({ output: expectedHTML });
+
+    await result.flush().andExpect({
+      output: expectedHTML,
+      events: ["resource:sync"],
+    });
+    await result
+      .unmount()
+      .andExpect({ output: "", events: ["resource:finalize"] });
+
+    marker.mark();
+    events.expect([]);
+  });
+
+  test("publishes a domain-shaped resource value into a Vue ref", async () => {
+    const events = new RecordedEvents();
+    const marker = Marker();
+
+    const app = App({
+      setup: () => {
+        const elementWidth = shallowRef("100");
+        const size = shallowRef<{ readonly width: number } | null>(null);
+        const vSize = elementResourceDirective(
+          (element: HTMLElement) => ElementSizeForTest(element, events, marker),
+          { into: size },
+        );
+
+        return () =>
+          h(Fragment, [
+            h("p", size.value ? `width=${size.value.width}` : "pending"),
+            h(
+              "button",
+              {
+                onClick: () => {
+                  elementWidth.value = "101";
+                  marker.mark();
+                },
+              },
+              "+",
+            ),
+            withDirectives(
+              h("div", { "data-width": elementWidth.value }, "box"),
+              [[vSize]],
+            ),
+          ]);
+      },
+    });
+
+    const result = await renderApp(app, { events }).andExpect({
+      output:
+        '<p>width=100</p><button>+</button><div data-width="100">box</div>',
+      events: ["size:attached", "size:sync"],
+    });
+
+    await result.click().andExpect({
+      output:
+        '<p>width=100</p><button>+</button><div data-width="101">box</div>',
+    });
+
+    await result.flush().andExpect({
+      output:
+        '<p>width=101</p><button>+</button><div data-width="101">box</div>',
+      events: ["size:sync"],
+    });
+
+    marker.mark();
+    await result.flush().andExpect({
+      output:
+        '<p>width=101</p><button>+</button><div data-width="101">box</div>',
+      events: ["size:sync"],
+    });
+
+    await result.unmount().andExpect({ output: "", events: ["size:finalize"] });
+  });
+
+  test("clears the published value when the directive unmounts", async () => {
+    const events = new RecordedEvents();
+    const marker = Marker();
+
+    const app = App({
+      setup: () => {
+        const visible = shallowRef(true);
+        const size = shallowRef<{ readonly width: number } | null>(null);
+        const vSize = elementResourceDirective(
+          (element: HTMLElement) => ElementSizeForTest(element, events, marker),
+          { into: size },
+        );
+
+        return () =>
+          h(Fragment, [
+            h("p", size.value ? `width=${size.value.width}` : "pending"),
+            h("button", { onClick: () => (visible.value = false) }, "hide"),
+            visible.value
+              ? withDirectives(h("div", { "data-width": "100" }, "box"), [
+                  [vSize],
+                ])
+              : null,
+          ]);
+      },
+    });
+
+    const result = await renderApp(app, { events }).andExpect({
+      output:
+        '<p>width=100</p><button>hide</button><div data-width="100">box</div>',
+      events: ["size:attached", "size:sync"],
+    });
+
+    await result.click("hide").andExpect({
+      output: "<p>pending</p><button>hide</button><!---->",
+      events: ["size:finalize"],
+    });
+
+    marker.mark();
+    events.expect([]);
+  });
+});


### PR DESCRIPTION
## Summary

- expose `elementResourceDirective()` from `@starbeam/vue` as the Vue public leaf for element-backed resources
- publish domain-shaped resource values into an optional Vue ref sink via `into`
- add Vue adapter tests for directive lifetime, `into` updates, stable resource identity, and unmount cleanup
- document the Vue API and update DOM attachment boundary docs

## Validation

- `pnpm exec prettier --write docs/DOM-ATTACHMENT-BOUNDARY.md docs/PACKAGE-SURFACE-TRIAGE.md packages/vue/vue/index.ts packages/vue/vue/src/resource.ts packages/vue/vue/tests/element-resource.spec.ts packages/vue/vue/README.md`
- `./node_modules/.bin/eslint packages/vue/vue/src/resource.ts packages/vue/vue/index.ts packages/vue/vue/tests/element-resource.spec.ts --max-warnings 0`
- `./node_modules/.bin/tsc -b packages/vue/vue/tests/tsconfig.json`
- `./node_modules/.bin/vitest --run --pool forks --project vue packages/vue/vue/tests/element-resource.spec.ts packages/vue/vue/tests/dom-attachment-probe.spec.ts packages/vue/vue/tests/resources.spec.ts`
- `pnpm --filter @starbeam/vue build`
- `pnpm --filter @starbeam/vue test:lint`
- `pnpm --filter @starbeam/vue test:types`
- `pnpm test:workspace:pack`
- pre-commit: typecheck + lint

Note: `pnpm --filter @starbeam/vue test:specs` currently fails from the package cwd because the Vitest root/project globs resolve relative to that cwd and find no tests. Root-level targeted Vue specs pass.
