### PR TITLE
Document DOM attachment ergonomics review

### DIFF
--- a/docs/DOM-ATTACHMENT-BOUNDARY.md
+++ b/docs/DOM-ATTACHMENT-BOUNDARY.md
@@ -10,7 +10,7 @@ new shared public package boundary.
 
 - React and Preact keep their idiomatic `useElementResource` leaves.
 - Vue exposes `elementResourceDirective` for directive-owned element resources.
-- Svelte's attachment API is the next dialect to probe.
+- Svelte exposes an experimental attachment API for element resources.
 - `@starbeam/modifier` stays internal. Its current `ElementPlaceholder` is
   historical kernel evidence, not the public contract.
 - `@starbeam/renderer` remains the best future home for adapter-author
@@ -20,13 +20,10 @@ new shared public package boundary.
   resources for app and library authors, but should not expose ref, directive,
   or modifier-shaped APIs in 0.9.
 
-Future code moves should be driven by adapter duplication or another concrete
-framework dialect, not by the existence of the old modifier package name.
-
-The next concrete dialect is Svelte. Svelte 5.29 added attachments, which are
-element-first functions with cleanup and reactive rerun semantics. They look like
-a strong fit for Starbeam's element-resource creator shape, but the value
-publication story still needs a code probe.
+Future code moves should be driven by adapter duplication or concrete framework
+evidence, not by the existence of the old modifier package name. The current
+ergonomics evidence is reviewed in
+[DOM Attachment Ergonomics Review](./DOM-ATTACHMENT-ERGONOMICS.md).
 
 ## What is stable
 
@@ -88,12 +85,12 @@ primitive or an adapter result slot such as React's attached resource value.
 Refs, directives, and modifiers are framework dialects for delivering the
 element. They are not the stable Starbeam contract name.
 
-| Framework | Dialect          | Proven API or evidence     | Current status      |
-| --------- | ---------------- | -------------------------- | ------------------- |
-| React     | callback ref     | `useElementResource`       | Public adapter leaf |
-| Preact    | callback ref     | `useElementResource`       | Public adapter leaf |
-| Vue       | custom directive | `elementResourceDirective` | Public adapter leaf |
-| Svelte    | `{@attach ...}`  | Svelte docs recon          | Next probe target   |
+| Framework | Dialect          | Proven API or evidence      | Current status            |
+| --------- | ---------------- | --------------------------- | ------------------------- |
+| React     | callback ref     | `useElementResource`        | Public adapter leaf       |
+| Preact    | callback ref     | `useElementResource`        | Public adapter leaf       |
+| Vue       | custom directive | `elementResourceDirective`  | Public adapter leaf       |
+| Svelte    | `{@attach ...}`  | `elementResourceAttachment` | Experimental adapter leaf |
 
 ### React and Preact
 
@@ -140,12 +137,14 @@ cleanup function. Svelte reruns an attachment when state read by the attachment
 expression changes, and it calls cleanup before rerun or after the element is
 removed.
 
-That makes attachments the likely Svelte dialect for DOM attachment:
+The Svelte probe now exists as an experimental adapter leaf. It validates
+attachment-owned lifetime and compares callback-sink and store-sink publication
+styles:
 
 ```svelte
 <script lang="ts">
+  import { elementResourceAttachment } from "@starbeam/svelte";
   import type { IntoResourceBlueprint } from "@starbeam/resource";
-  import type { Attachment } from "svelte/attachments";
 
   interface Size {
     readonly width: number;
@@ -158,19 +157,18 @@ That makes attachments the likely Svelte dialect for DOM attachment:
 
   declare const ElementSize: ElementResourceBlueprint<HTMLElement, Size>;
 
-  function elementResourceAttachment<T>(
-    blueprint: ElementResourceBlueprint<HTMLElement, T>,
-  ): Attachment<HTMLElement> {
-    return (element) => {
-      // Create an element-backed Starbeam resource from `blueprint(element)`.
-      return () => {
-        // finalize element-backed Starbeam resource here
-      };
-    };
-  }
+  let size = $state<Size | null>(null);
+
+  const attachSize = elementResourceAttachment(ElementSize, {
+    into(value) {
+      size = value;
+    },
+  });
 </script>
 
-<section {@attach elementResourceAttachment(ElementSize)} />
+<section {@attach attachSize}>
+  {size ? `${size.width} × ${size.height}` : "Measuring…"}
+</section>
 ```
 
 Svelte actions (`use:`) remain available, but Svelte's docs say attachments
@@ -181,16 +179,10 @@ Svelte also provides `createAttachmentKey` for programmatic object-spread
 attachments. That may matter for library-author ergonomics, but it should follow
 the basic attachment probe.
 
-The open Svelte question is not whether Svelte can deliver an element and cleanup
-lifetime. It can. The open question is how Starbeam should publish the produced
-domain value back to Svelte without exposing reactive storage or prematurely
-moving shared vocabulary. Candidate shapes include a callback, a store, a
-rune-compatible state sink, or an `into`-style sink analogous to Vue.
-
-The code probe should create the smallest `@starbeam/svelte` adapter package and
-test harness needed to validate attachment lifetime and value publication. It
-should stay focused on proving the Svelte dialect before moving any shared
-vocabulary.
+The open Svelte question is no longer whether Svelte can deliver an element and
+cleanup lifetime. It can. The open question is which publication style should be
+primary and whether the store-shaped experiment is the right reusable
+attachable/readable object for Svelte authors.
 
 ## Boundary matrix
 

--- a/docs/DOM-ATTACHMENT-ERGONOMICS.md
+++ b/docs/DOM-ATTACHMENT-ERGONOMICS.md
@@ -173,8 +173,8 @@ For now:
 - Treat “modifier-shaped” as an ergonomic target: a reusable element-backed
   value that is attachable and readable.
 - Do not expose `ElementPlaceholder` as the public contract.
-- Do not create a public `@starbeam/modifier` package until a code PER proves
-  the kernel shape.
+- Do not create a public `@starbeam/modifier` package until a code Prepare /
+  Execute / Review (PER) cycle proves the kernel shape.
 
 The old `@starbeam/modifier` name is historical evidence. The adapter probes are
 the source of truth.
@@ -187,7 +187,7 @@ pressure, such as:
 - repeated non-trivial helper duplication across adapters;
 - a third-party adapter needing the same DOM attachment contract;
 - Svelte and Vue converging on the same attachable/readable handle shape;
-- a code PER proving a kernel that owns setup, sync, cleanup, element
+- a code PER cycle proving a kernel that owns setup, sync, cleanup, element
   replacement, and value publication;
 - adapter-author docs needing a stable name that cannot live in a single
   framework package.

--- a/docs/DOM-ATTACHMENT-ERGONOMICS.md
+++ b/docs/DOM-ATTACHMENT-ERGONOMICS.md
@@ -1,0 +1,207 @@
+# DOM Attachment Ergonomics Review
+
+This is the review record after the React, Preact, Vue, and Svelte DOM
+attachment probes.
+
+## Status
+
+This review records API evidence. It does not add a new implementation, rename
+adapter APIs, or promote `@starbeam/modifier` as a public package.
+
+The current hypothesis is:
+
+- DOM attachment is a public Starbeam concept.
+- Official adapters should expose idiomatic host-framework leaves.
+- The shared creator shape is stable.
+- The returned value should be domain-shaped.
+- Modifier-shaped ergonomics are the direction to test next.
+- The old `@starbeam/modifier` package name is not the source of truth.
+
+## Stable creator shape
+
+Every successful adapter probe uses the same creator shape:
+
+```ts
+type ElementResourceBlueprint<E extends Element, T> = (
+  element: E,
+) => IntoResourceBlueprint<T>;
+```
+
+A framework supplies an element. Starbeam creates resource-backed work for that
+element. Cleanup follows the framework's element lifetime.
+
+The produced value should be domain-shaped, not storage-shaped. A size resource
+should publish `size.width` and `size.height`, not `size.width.current` and
+`size.height.current`. The public storage boundary is described in
+[Starbeam Invariants](./INVARIANTS.md#public-apis-expose-domain-concepts-not-reactive-storage).
+
+## Framework evidence
+
+### React and Preact
+
+React and Preact prove the callback-ref dialect.
+
+`useElementResource()` returns a discriminated result with a stable `ref` and a
+`pending | attached` state. `pending` means the framework has not supplied the
+element. `attached` means Starbeam has created the element-backed resource value.
+
+This is idiomatic for React and Preact because the same value can carry the ref
+and the readable result:
+
+```tsx
+const size = useElementResource((element: HTMLDivElement) =>
+  ElementSize(element),
+);
+
+return (
+  <section ref={size.ref}>
+    {size.status === "attached" ? size.current.width : "Measuring…"}
+  </section>
+);
+```
+
+The `.current` here is the adapter's attached-result slot. The resource value
+inside that slot should still be domain-shaped.
+
+### Vue directive
+
+Vue proves directive-owned lifetime.
+
+`elementResourceDirective()` creates the resource when Vue calls `mounted`,
+schedules Starbeam sync through Vue timing, and finalizes the resource when Vue
+calls `unmounted`.
+
+Vue directives do not return values to templates, so the public directive API
+uses explicit publication when the component needs to read the resource value:
+
+```ts
+const size = shallowRef<Size | null>(null);
+const vSize = elementResourceDirective(ElementSize, { into: size });
+```
+
+This is mechanically clear: `vSize` is the directive and `size` is the readable
+Vue ref. The cost is that the author has to name and connect two values.
+
+### Vue handle experiment
+
+`elementResource()` bundles the directive and the readable Vue ref:
+
+```ts
+const size = elementResource(ElementSize);
+const vSize = size.directive;
+```
+
+That mirrors the modifier-shaped idea: one object is both attachable and
+readable, even though Vue template syntax still needs a directive alias.
+
+The ergonomic friction is the read path:
+
+```vue
+{{ size.value.value ? size.value.value.width : "Measuring…" }}
+```
+
+The first `.value` is the handle field. The second `.value` is Vue's ref slot.
+This is useful evidence, but it is not a shape to bless as final API yet.
+
+### Svelte callback sink
+
+Svelte proves attachment-owned lifetime with `{@attach ...}`.
+
+`elementResourceAttachment()` returns an attachment function. The callback-sink
+form publishes the resource value into author-owned state:
+
+```svelte
+<script lang="ts">
+  let size = $state<Size | null>(null);
+
+  const attachSize = elementResourceAttachment(ElementSize, {
+    into(value) {
+      size = value;
+    },
+  });
+</script>
+
+<section {@attach attachSize}>
+  {size ? `${size.width} × ${size.height}` : "Measuring…"}
+</section>
+```
+
+This matches Svelte runes well enough to prove the lifecycle, but it has the
+same split as Vue's `into` form: one value attaches, another value is read.
+
+### Svelte store sink
+
+`elementResourceStore()` is the strongest modifier-shaped evidence so far:
+
+```svelte
+<script lang="ts">
+  const size = elementResourceStore(ElementSize);
+</script>
+
+<section {@attach size.attach}>
+  {$size ? `${$size.width} × ${$size.height}` : "Measuring…"}
+</section>
+```
+
+The same object is attachable through `size.attach` and readable through
+Svelte's store syntax. That does not settle the final Svelte API, but it makes
+the cross-framework ergonomic target concrete: an element-backed value should be
+attachable and readable without exposing Starbeam storage.
+
+## Ergonomic comparison
+
+| Adapter shape                         | Element delivery        | Readable value                 | Pending state          | Cleanup             | Friction                                         |
+| ------------------------------------- | ----------------------- | ------------------------------ | ---------------------- | ------------------- | ------------------------------------------------ |
+| React / Preact `useElementResource()` | callback ref            | `size.current` when `attached` | `status === "pending"` | ref lifetime        | Hook-only shape; `.current` is an adapter slot   |
+| Vue `elementResourceDirective()`      | custom directive        | separate Vue ref               | `null`                 | directive lifetime  | explicit `into` wiring                           |
+| Vue `elementResource()`               | custom directive alias  | `size.value.value`             | `null`                 | directive lifetime  | doubled Vue-ref spelling                         |
+| Svelte callback sink                  | `{@attach ...}`         | author-owned `$state`          | `null`                 | attachment lifetime | split attach/read values                         |
+| Svelte store sink                     | `{@attach size.attach}` | `$size`                        | `null`                 | attachment lifetime | store shape may not be the final rune-native API |
+
+## API direction
+
+The next implementation work should test modifier-shaped ergonomics, not promote
+the old modifier package.
+
+For now:
+
+- Keep official adapter leaves public and adapter-local.
+- Use the shared `ElementResourceBlueprint<E, T>` creator shape.
+- Keep returned values domain-shaped.
+- Treat refs, directives, and attachments as framework dialects for delivering
+  the element.
+- Treat “modifier-shaped” as an ergonomic target: a reusable element-backed
+  value that is attachable and readable.
+- Do not expose `ElementPlaceholder` as the public contract.
+- Do not create a public `@starbeam/modifier` package until a code PER proves
+  the kernel shape.
+
+The old `@starbeam/modifier` name is historical evidence. The adapter probes are
+the source of truth.
+
+## What would justify shared vocabulary
+
+Move shared vocabulary out of adapter-local code only when there is concrete
+pressure, such as:
+
+- repeated non-trivial helper duplication across adapters;
+- a third-party adapter needing the same DOM attachment contract;
+- Svelte and Vue converging on the same attachable/readable handle shape;
+- a code PER proving a kernel that owns setup, sync, cleanup, element
+  replacement, and value publication;
+- adapter-author docs needing a stable name that cannot live in a single
+  framework package.
+
+Until then, the public 0.9 surface should stay as official adapter APIs plus
+framework-neutral prose.
+
+## Not in this review
+
+This review does not:
+
+- add or expose `@starbeam/modifier`;
+- rename React, Preact, Vue, or Svelte adapter APIs;
+- choose the final Svelte API;
+- bless the Vue handle spelling as final;
+- move shared types into `@starbeam/renderer` or `@starbeam/universal`;
+- change package manifests, generated artifacts, or tests.

--- a/docs/PACKAGE-SURFACE-TRIAGE.md
+++ b/docs/PACKAGE-SURFACE-TRIAGE.md
@@ -239,9 +239,11 @@ bounded change, then review the result against the prediction.
    low-level surface consolidation.
 4. Modifier / DOM attachment reconciliation. Done so far: React + Preact
    convergence, the `ElementPlaceholder` comparison, the Vue directive probe,
-   and the [DOM attachment boundary decision](./DOM-ATTACHMENT-BOUNDARY.md).
-   Keep official adapter APIs as the 0.9 public surface. Svelte attachments are
-   the next concrete dialect to probe. Move shared vocabulary only if
+   the [DOM attachment boundary decision](./DOM-ATTACHMENT-BOUNDARY.md), the
+   Svelte attachment experiment, and the Vue handle experiment. Keep official
+   adapter APIs as the 0.9 public surface. Use the
+   [DOM attachment ergonomics review](./DOM-ATTACHMENT-ERGONOMICS.md) to drive
+   the next modifier-shaped API experiment. Move shared vocabulary only if
    adapter-author pressure justifies it.
 5. Low-level surface consolidation: make `@starbeam/universal` the umbrella,
    split public `@starbeam/reactive` primitives from runtime wiring, place


### PR DESCRIPTION
## Summary

- Adds a DOM attachment ergonomics review after the React, Preact, Vue, and Svelte adapter experiments.
- Records the current API direction: DOM attachment is a public concept, adapter APIs stay idiomatic, ElementResourceBlueprint<E, T> is the stable creator shape, returned values stay domain-shaped, and modifier-shaped ergonomics are the next experiment.
- Updates the boundary and package-surface triage docs to replace stale Svelte-next-probe wording with links to the ergonomics review.

## Validation

- pnpm exec prettier --check docs/DOM-ATTACHMENT-ERGONOMICS.md docs/DOM-ATTACHMENT-BOUNDARY.md docs/PACKAGE-SURFACE-TRIAGE.md
- pre-commit: pnpm test:workspace:types
- pre-commit: pnpm test:workspace:lint

## Notes

Docs-only. The existing local renderer reflow edits are intentionally unstaged and not part of this PR.