### PR TITLE
Test Svelte element resource store reuse

### DIFF
--- a/.github/instructions/per-workflow.instructions.md
+++ b/.github/instructions/per-workflow.instructions.md
@@ -6,7 +6,14 @@ description: "Use when: planning or reviewing Starbeam work described as PER, Pr
 
 PER means **Prepare / Execute / Review**.
 
-Use PER for non-trivial Starbeam changes where the risk is not just typing code, but choosing the right boundary, preserving behavior, and validating release-surface consequences.
+Use PER for non-trivial Starbeam changes where the risk is not just typing code,
+but choosing the right boundary, preserving behavior, and validating
+release-surface consequences.
+
+Use PER especially when work touches public package surfaces, adapter APIs,
+reactive semantics, or cross-framework vocabulary. PER is also appropriate when
+an implementation should test a hypothesis from a decision record before the
+project commits to a broader API direction.
 
 ## Phases
 
@@ -27,6 +34,20 @@ Use PER for non-trivial Starbeam changes where the risk is not just typing code,
    - Compare the outcome to Prepare's predictions.
    - Call out mismatches and whether they matter.
    - Decide whether the result is safe to push, needs a targeted execute loop, or needs a new Prepare phase.
+
+## Coordination guidance
+
+When a user says "do the next PER" or asks to proceed with a PER-sized change:
+
+1. Start by loading this instruction file.
+2. If the task is ambiguous or consequential, run Prepare before editing.
+3. Keep Execute bounded to the smallest change that tests the hypothesis.
+4. Review the result against the Prepare predictions before opening or merging a
+   PR.
+
+Avoid treating PER as ceremony. For small local fixes, execute directly. For API
+or package-surface work, preserve the separation between prediction, change, and
+review.
 
 ## Starbeam package-surface use
 

--- a/packages/svelte/svelte/tests/element-resource.spec.ts
+++ b/packages/svelte/svelte/tests/element-resource.spec.ts
@@ -14,6 +14,7 @@ import { tick } from "svelte";
 
 import SinkExperiment from "./fixtures/SinkExperiment.svelte";
 import StoreExperiment from "./fixtures/StoreExperiment.svelte";
+import StoreToggleExperiment from "./fixtures/StoreToggleExperiment.svelte";
 import ToggleExperiment from "./fixtures/ToggleExperiment.svelte";
 
 const INITIAL_WIDTH = 0;
@@ -130,5 +131,51 @@ describe("Svelte element resource experiments", () => {
     marker.mark();
     await tick();
     events.expect();
+  });
+
+  test("store sink clears on attachment unmount and reuses the same handle", async () => {
+    const events = new RecordedEvents();
+    const marker = Marker();
+    const result = render(StoreToggleExperiment, {
+      props: { blueprint: ElementSizeForTest(events, marker) },
+    });
+
+    expect(html(result.container)).toBe(
+      '<p>width=100</p><button>hide</button><button>grow</button><div data-width="100">box</div><!---->',
+    );
+    events.expect("size:attached", "size:sync");
+
+    await fireEvent.click(result.getByRole("button", { name: "hide" }));
+    expect(html(result.container)).toBe(
+      "<p>pending</p><button>show</button><button>grow</button><!---->",
+    );
+    events.expect("size:finalize");
+
+    marker.mark();
+    await tick();
+    events.expect();
+
+    await fireEvent.click(result.getByRole("button", { name: "grow" }));
+    await fireEvent.click(result.getByRole("button", { name: "show" }));
+    expect(html(result.container)).toBe(
+      '<p>width=101</p><button>hide</button><button>grow</button><div data-width="101">box</div><!---->',
+    );
+    events.expect("size:attached", "size:sync");
+
+    await fireEvent.click(result.getByRole("button", { name: "grow" }));
+    expect(html(result.container)).toBe(
+      '<p>width=101</p><button>hide</button><button>grow</button><div data-width="102">box</div><!---->',
+    );
+    events.expect();
+
+    marker.mark();
+    await tick();
+    expect(html(result.container)).toBe(
+      '<p>width=102</p><button>hide</button><button>grow</button><div data-width="102">box</div><!---->',
+    );
+    events.expect("size:sync");
+
+    result.unmount();
+    events.expect("size:finalize");
   });
 });

--- a/packages/svelte/svelte/tests/fixtures/StoreToggleExperiment.svelte
+++ b/packages/svelte/svelte/tests/fixtures/StoreToggleExperiment.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { elementResourceStore } from "@starbeam/svelte";
+  import type { ElementResourceBlueprint } from "@starbeam/svelte";
+
+  interface Size {
+    readonly width: number;
+  }
+
+  let { blueprint }: { blueprint: ElementResourceBlueprint<HTMLElement, Size> } =
+    $props();
+
+  let visible = $state(true);
+  let width = $state("100");
+  const size = $derived(elementResourceStore(blueprint));
+
+  function toggle() {
+    visible = !visible;
+  }
+
+  function grow() {
+    width = String(Number(width) + 1);
+  }
+</script>
+
+<p>{$size ? `width=${$size.width}` : "pending"}</p>
+<button onclick={toggle}>{visible ? "hide" : "show"}</button>
+<button onclick={grow}>grow</button>
+{#if visible}
+  <div data-width={width} {@attach size.attach}>box</div>
+{/if}


### PR DESCRIPTION
## Summary

This tests the existing Svelte `elementResourceStore()` handle as a sequentially reusable element-backed value.

The new fixture mounts an element with `{@attach size.attach}`, reads the domain value through `$size`, unmounts the attachment, verifies the store clears to `null` and finalizes, then remounts using the same handle.

No production code changes are included.

## Validation

- `pnpm exec vitest --run --pool forks --project svelte`
- `pnpm --filter @starbeam/svelte test:types`
- `pnpm --filter @starbeam/svelte test:lint`
- pre-commit: `pnpm test:workspace:types`
- pre-commit: `pnpm test:workspace:lint`

## Notes

Also updates the Starbeam Prepare / Execute / Review (PER) instruction file with coordination guidance for future PER-sized work.

The existing local renderer reflow edits are intentionally unstaged and not part of this PR.