### PR TITLE
Add Svelte elementResource alias

### DIFF
--- a/docs/DOM-ATTACHMENT-ERGONOMICS.md
+++ b/docs/DOM-ATTACHMENT-ERGONOMICS.md
@@ -129,13 +129,14 @@ form publishes the resource value into author-owned state:
 This matches Svelte runes well enough to prove the lifecycle, but it has the
 same split as Vue's `into` form: one value attaches, another value is read.
 
-### Svelte store sink
+### Svelte element resource
 
-`elementResourceStore()` is the strongest modifier-shaped evidence so far:
+The Svelte primary-name experiment uses `elementResource()` for the strongest
+modifier-shaped evidence so far:
 
 ```svelte
 <script lang="ts">
-  const size = elementResourceStore(ElementSize);
+  const size = elementResource(ElementSize);
 </script>
 
 <section {@attach size.attach}>
@@ -144,19 +145,21 @@ same split as Vue's `into` form: one value attaches, another value is read.
 ```
 
 The same object is attachable through `size.attach` and readable through
-Svelte's store syntax. That does not settle the final Svelte API, but it makes
-the cross-framework ergonomic target concrete: an element-backed value should be
-attachable and readable without exposing Starbeam storage.
+Svelte's store syntax. `elementResourceStore()` remains available as the
+explicit store-shaped spelling while this naming experiment is evaluated. This
+does not settle the final Svelte API, but it makes the cross-framework ergonomic
+target concrete: an element-backed value should be attachable and readable
+without exposing Starbeam storage.
 
 ## Ergonomic comparison
 
-| Adapter shape                         | Element delivery        | Readable value                 | Pending state          | Cleanup             | Friction                                         |
-| ------------------------------------- | ----------------------- | ------------------------------ | ---------------------- | ------------------- | ------------------------------------------------ |
-| React / Preact `useElementResource()` | callback ref            | `size.current` when `attached` | `status === "pending"` | ref lifetime        | Hook-only shape; `.current` is an adapter slot   |
-| Vue `elementResourceDirective()`      | custom directive        | separate Vue ref               | `null`                 | directive lifetime  | explicit `into` wiring                           |
-| Vue `elementResource()`               | custom directive alias  | `size.value.value`             | `null`                 | directive lifetime  | doubled Vue-ref spelling                         |
-| Svelte callback sink                  | `{@attach ...}`         | author-owned `$state`          | `null`                 | attachment lifetime | split attach/read values                         |
-| Svelte store sink                     | `{@attach size.attach}` | `$size`                        | `null`                 | attachment lifetime | store shape may not be the final rune-native API |
+| Adapter shape                         | Element delivery        | Readable value                 | Pending state          | Cleanup             | Friction                                          |
+| ------------------------------------- | ----------------------- | ------------------------------ | ---------------------- | ------------------- | ------------------------------------------------- |
+| React / Preact `useElementResource()` | callback ref            | `size.current` when `attached` | `status === "pending"` | ref lifetime        | Hook-only shape; `.current` is an adapter slot    |
+| Vue `elementResourceDirective()`      | custom directive        | separate Vue ref               | `null`                 | directive lifetime  | explicit `into` wiring                            |
+| Vue `elementResource()`               | custom directive alias  | `size.value.value`             | `null`                 | directive lifetime  | doubled Vue-ref spelling                          |
+| Svelte callback sink                  | `{@attach ...}`         | author-owned `$state`          | `null`                 | attachment lifetime | split attach/read values                          |
+| Svelte `elementResource()`            | `{@attach size.attach}` | `$size`                        | `null`                 | attachment lifetime | store syntax may not be the final rune-native API |
 
 ## API direction
 

--- a/packages/svelte/svelte/README.md
+++ b/packages/svelte/svelte/README.md
@@ -32,14 +32,14 @@ type ElementResourceBlueprint<E extends Element, T> = (
 </section>
 ```
 
-## Store sink
+## Element resource
 
 ```svelte
 <script lang="ts">
-  import { elementResourceStore } from "@starbeam/svelte";
+  import { elementResource } from "@starbeam/svelte";
   import { ElementSize } from "./element-size";
 
-  const size = elementResourceStore(ElementSize);
+  const size = elementResource(ElementSize);
 </script>
 
 <section {@attach size.attach}>
@@ -47,5 +47,18 @@ type ElementResourceBlueprint<E extends Element, T> = (
 </section>
 ```
 
-Both forms keep cells private. Consumers read domain-shaped values such as
-`size.width`, not `size.width.current`.
+`elementResource()` returns one Svelte-readable object that is also attachable.
+Attach it with `size.attach`; read the published value with Svelte's store
+syntax.
+
+## Store sink
+
+`elementResourceStore()` is the explicit store-shaped spelling. It returns the
+same attachable/readable shape as `elementResource()`.
+
+```ts
+const size = elementResourceStore(ElementSize);
+```
+
+Both forms keep cells private. Consumers read domain-shaped values through
+Svelte's store syntax, such as `$size.width`, not `$size.width.current`.

--- a/packages/svelte/svelte/index.ts
+++ b/packages/svelte/svelte/index.ts
@@ -1,7 +1,9 @@
 export {
+  elementResource,
   type ElementResourceAttachment,
   elementResourceAttachment,
   type ElementResourceBlueprint,
+  type ElementResourceHandle,
   type ElementResourceSink,
   elementResourceStore,
 } from "./src/element-resource.js";

--- a/packages/svelte/svelte/src/element-resource.ts
+++ b/packages/svelte/svelte/src/element-resource.ts
@@ -18,8 +18,8 @@ export type ElementResourceAttachment<E extends Element = Element> =
   Attachment<E>;
 
 export type ElementResourceHandle<
-  E extends Element,
-  T,
+  E extends Element = Element,
+  T = unknown,
 > = SvelteReadable<T | null> & {
   readonly attach: ElementResourceAttachment<E>;
 };

--- a/packages/svelte/svelte/src/element-resource.ts
+++ b/packages/svelte/svelte/src/element-resource.ts
@@ -17,6 +17,13 @@ export type ElementResourceSink<T> = (value: T | null) => void;
 export type ElementResourceAttachment<E extends Element = Element> =
   Attachment<E>;
 
+export type ElementResourceHandle<
+  E extends Element,
+  T,
+> = SvelteReadable<T | null> & {
+  readonly attach: ElementResourceAttachment<E>;
+};
+
 interface ResourceState<T> {
   readonly scope: object;
   readonly sync: SyncFn<void>;
@@ -61,9 +68,7 @@ export function elementResourceAttachment<E extends Element, T>(
 
 export function elementResourceStore<E extends Element, T>(
   blueprint: ElementResourceBlueprint<E, T>,
-): SvelteReadable<T | null> & {
-  readonly attach: ElementResourceAttachment<E>;
-} {
+): ElementResourceHandle<E, T> {
   let value: T | null = null;
   const subscribers = new Set<SvelteSubscriber<T | null>>();
 
@@ -91,6 +96,12 @@ export function elementResourceStore<E extends Element, T>(
       into: (value) => void publish(value),
     }),
   });
+}
+
+export function elementResource<E extends Element, T>(
+  blueprint: ElementResourceBlueprint<E, T>,
+): ElementResourceHandle<E, T> {
+  return elementResourceStore(blueprint);
 }
 
 function createElementResource<E extends Element, T>(

--- a/packages/svelte/svelte/tests/element-resource.spec.ts
+++ b/packages/svelte/svelte/tests/element-resource.spec.ts
@@ -12,6 +12,7 @@ import {
 import { fireEvent, render } from "@testing-library/svelte";
 import { tick } from "svelte";
 
+import ElementResourceToggleExperiment from "./fixtures/ElementResourceToggleExperiment.svelte";
 import SinkExperiment from "./fixtures/SinkExperiment.svelte";
 import StoreExperiment from "./fixtures/StoreExperiment.svelte";
 import StoreToggleExperiment from "./fixtures/StoreToggleExperiment.svelte";
@@ -174,6 +175,34 @@ describe("Svelte element resource experiments", () => {
       '<p>width=102</p><button>hide</button><button>grow</button><div data-width="102">box</div><!---->',
     );
     events.expect("size:sync");
+
+    result.unmount();
+    events.expect("size:finalize");
+  });
+
+  test("elementResource is the primary attachable store shape", async () => {
+    const events = new RecordedEvents();
+    const marker = Marker();
+    const result = render(ElementResourceToggleExperiment, {
+      props: { blueprint: ElementSizeForTest(events, marker) },
+    });
+
+    expect(html(result.container)).toBe(
+      '<p>width=100</p><button>hide</button><button>grow</button><div data-width="100">box</div><!---->',
+    );
+    events.expect("size:attached", "size:sync");
+
+    await fireEvent.click(result.getByRole("button", { name: "hide" }));
+    expect(html(result.container)).toBe(
+      "<p>pending</p><button>show</button><button>grow</button><!---->",
+    );
+    events.expect("size:finalize");
+
+    await fireEvent.click(result.getByRole("button", { name: "show" }));
+    expect(html(result.container)).toBe(
+      '<p>width=100</p><button>hide</button><button>grow</button><div data-width="100">box</div><!---->',
+    );
+    events.expect("size:attached", "size:sync");
 
     result.unmount();
     events.expect("size:finalize");

--- a/packages/svelte/svelte/tests/fixtures/ElementResourceToggleExperiment.svelte
+++ b/packages/svelte/svelte/tests/fixtures/ElementResourceToggleExperiment.svelte
@@ -11,7 +11,7 @@
 
   let visible = $state(true);
   let width = $state("100");
-  const size = $derived(elementResource(blueprint));
+  const size = elementResource((element: HTMLElement) => blueprint(element));
 
   function toggle() {
     visible = !visible;

--- a/packages/svelte/svelte/tests/fixtures/ElementResourceToggleExperiment.svelte
+++ b/packages/svelte/svelte/tests/fixtures/ElementResourceToggleExperiment.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { elementResource } from "@starbeam/svelte";
+  import type { ElementResourceBlueprint } from "@starbeam/svelte";
+
+  interface Size {
+    readonly width: number;
+  }
+
+  let { blueprint }: { blueprint: ElementResourceBlueprint<HTMLElement, Size> } =
+    $props();
+
+  let visible = $state(true);
+  let width = $state("100");
+  const size = $derived(elementResource(blueprint));
+
+  function toggle() {
+    visible = !visible;
+  }
+
+  function grow() {
+    width = String(Number(width) + 1);
+  }
+</script>
+
+<p>{$size ? `width=${$size.width}` : "pending"}</p>
+<button onclick={toggle}>{visible ? "hide" : "show"}</button>
+<button onclick={grow}>grow</button>
+{#if visible}
+  <div data-width={width} {@attach size.attach}>box</div>
+{/if}

--- a/workspace/dev-compile/src/rollup/plugins/typescript.ts
+++ b/workspace/dev-compile/src/rollup/plugins/typescript.ts
@@ -115,12 +115,13 @@ export default function typescript(
 
     const minify = {
       format: {
-        comments: mode === 'production',
+        comments: mode === "production",
       },
       mangle: {
         toplevel: true,
         properties: {
           builtins: false,
+          reserved: ["attach", "into"],
         },
       },
       module: true,
@@ -152,8 +153,8 @@ export default function typescript(
     const jsxFactory = compilerOptions.jsxFactory;
 
     /**
-    * TODO: move react specific build code to react packages' rollup
-    */
+     * TODO: move react specific build code to react packages' rollup
+     */
     if (fragmentFactory && jsxFactory)
       jscConfig = withReact(jscConfig, {
         pragma: jsxFactory,

--- a/workspace/dev-compile/src/rollup/plugins/typescript.ts
+++ b/workspace/dev-compile/src/rollup/plugins/typescript.ts
@@ -115,7 +115,7 @@ export default function typescript(
 
     const minify = {
       format: {
-        comments: mode === "production",
+        comments: mode === 'production',
       },
       mangle: {
         toplevel: true,
@@ -153,8 +153,8 @@ export default function typescript(
     const jsxFactory = compilerOptions.jsxFactory;
 
     /**
-     * TODO: move react specific build code to react packages' rollup
-     */
+    * TODO: move react specific build code to react packages' rollup
+    */
     if (fragmentFactory && jsxFactory)
       jscConfig = withReact(jscConfig, {
         pragma: jsxFactory,


### PR DESCRIPTION
## Summary

- Adds `elementResource()` as the primary Svelte attachable/readable element resource handle.
- Keeps `elementResourceStore()` as the explicit store-shaped spelling.
- Exports `ElementResourceHandle` for the public Svelte surface.
- Updates Svelte docs and DOM attachment ergonomics notes.
- Reserves public `attach` and `into` property names from production property mangling.

## Validation

- `pnpm --filter @starbeam/svelte test:types`
- `pnpm --filter @starbeam-tests/svelte test:types`
- `pnpm vitest --project svelte --run packages/svelte/svelte/tests/element-resource.spec.ts`
- `pnpm --filter @starbeam-dev/compile build`
- `pnpm --filter @starbeam/svelte build`
- Verified production output preserves `attach` and `into`
- `pnpm test:workspace:pack` verified 18 publishable packages
- pre-commit: `pnpm test:workspace:types`
- pre-commit: `pnpm test:workspace:lint`

## Notes

This is additive: `elementResourceStore()` remains available.

The existing local renderer reflow edits are intentionally unstaged and not part of this PR.