### PR TITLE
Return augmented refs from Vue elementResource

### DIFF
--- a/docs/DOM-ATTACHMENT-ERGONOMICS.md
+++ b/docs/DOM-ATTACHMENT-ERGONOMICS.md
@@ -82,9 +82,9 @@ const vSize = elementResourceDirective(ElementSize, { into: size });
 This is mechanically clear: `vSize` is the directive and `size` is the readable
 Vue ref. The cost is that the author has to name and connect two values.
 
-### Vue handle experiment
+### Vue element resource
 
-`elementResource()` bundles the directive and the readable Vue ref:
+`elementResource()` returns a Vue ref augmented with the directive:
 
 ```ts
 const size = elementResource(ElementSize);
@@ -94,14 +94,17 @@ const vSize = size.directive;
 That mirrors the modifier-shaped idea: one object is both attachable and
 readable, even though Vue template syntax still needs a directive alias.
 
-The ergonomic friction is the read path:
+In Vue templates, the top-level ref unwraps:
 
 ```vue
-{{ size.value.value ? size.value.value.width : "Measuring…" }}
+{{ size ? size.width : "Measuring…" }}
 ```
 
-The first `.value` is the handle field. The second `.value` is Vue's ref slot.
-This is useful evidence, but it is not a shape to bless as final API yet.
+In scripts and render functions, the same handle reads through Vue's ref slot:
+
+```ts
+size.value ? `width=${size.value.width}` : "pending";
+```
 
 ### Svelte callback sink
 
@@ -153,13 +156,13 @@ without exposing Starbeam storage.
 
 ## Ergonomic comparison
 
-| Adapter shape                         | Element delivery        | Readable value                 | Pending state          | Cleanup             | Friction                                          |
-| ------------------------------------- | ----------------------- | ------------------------------ | ---------------------- | ------------------- | ------------------------------------------------- |
-| React / Preact `useElementResource()` | callback ref            | `size.current` when `attached` | `status === "pending"` | ref lifetime        | Hook-only shape; `.current` is an adapter slot    |
-| Vue `elementResourceDirective()`      | custom directive        | separate Vue ref               | `null`                 | directive lifetime  | explicit `into` wiring                            |
-| Vue `elementResource()`               | custom directive alias  | `size.value.value`             | `null`                 | directive lifetime  | doubled Vue-ref spelling                          |
-| Svelte callback sink                  | `{@attach ...}`         | author-owned `$state`          | `null`                 | attachment lifetime | split attach/read values                          |
-| Svelte `elementResource()`            | `{@attach size.attach}` | `$size`                        | `null`                 | attachment lifetime | store syntax may not be the final rune-native API |
+| Adapter shape                         | Element delivery        | Readable value                       | Pending state          | Cleanup             | Friction                                          |
+| ------------------------------------- | ----------------------- | ------------------------------------ | ---------------------- | ------------------- | ------------------------------------------------- |
+| React / Preact `useElementResource()` | callback ref            | `size.current` when `attached`       | `status === "pending"` | ref lifetime        | Hook-only shape; `.current` is an adapter slot    |
+| Vue `elementResourceDirective()`      | custom directive        | separate Vue ref                     | `null`                 | directive lifetime  | explicit `into` wiring                            |
+| Vue `elementResource()`               | custom directive alias  | template `size`, script `size.value` | `null`                 | directive lifetime  | still needs a directive alias                     |
+| Svelte callback sink                  | `{@attach ...}`         | author-owned `$state`                | `null`                 | attachment lifetime | split attach/read values                          |
+| Svelte `elementResource()`            | `{@attach size.attach}` | `$size`                              | `null`                 | attachment lifetime | store syntax may not be the final rune-native API |
 
 ## API direction
 

--- a/packages/vue/vue/README.md
+++ b/packages/vue/vue/README.md
@@ -80,9 +80,9 @@ expose getters or methods, so consumers read `size.width`, not
 
 ### Handle experiment
 
-`elementResource()` bundles the directive and the published Vue ref in one
-object. This mirrors the Svelte experiment where a modifier-like object is both
-attachable and readable.
+`elementResource()` returns a Vue ref augmented with the directive. This mirrors
+the Svelte experiment where a modifier-like object is both attachable and
+readable.
 
 ```ts
 const size = elementResource(ElementSize);
@@ -92,13 +92,15 @@ const vSize = size.directive;
 ```vue
 <template>
   <section v-size>
-    {{ size.value.value ? size.value.value.width : "Measuring…" }}
+    {{ size ? size.width : "Measuring…" }}
   </section>
 </template>
 ```
 
 This keeps the directive naming (`vSize`) separate from the readable value
-(`size`), while avoiding an explicit `into` ref.
+(`size`), while avoiding an explicit `into` ref. In templates, Vue unwraps the
+ref, so the resource reads as `size.width`. In scripts or render functions, read
+through Vue's ref slot: `size.value?.width`.
 
 ## Timing model
 

--- a/packages/vue/vue/src/resource.ts
+++ b/packages/vue/vue/src/resource.ts
@@ -107,7 +107,7 @@ export function elementResourceDirective<E extends Element, T>(
 export function elementResource<E extends Element, T>(
   blueprint: ElementResourceBlueprint<E, T>,
 ): ElementResourceHandle<E, T> {
-  const value = shallowRef(null) as ShallowRef<T | null>;
+  const value: ShallowRef<T | null> = shallowRef<T | null>(null);
 
   return Object.assign(value, {
     directive: elementResourceDirective(blueprint, { into: value }),

--- a/packages/vue/vue/src/resource.ts
+++ b/packages/vue/vue/src/resource.ts
@@ -23,10 +23,12 @@ export interface ElementResourceDirectiveOptions<T> {
   readonly into?: Ref<T | null> | undefined;
 }
 
-export interface ElementResourceHandle<E extends Element, T> {
-  readonly value: ShallowRef<T | null>;
+export type ElementResourceHandle<
+  E extends Element = Element,
+  T = unknown,
+> = ShallowRef<T | null> & {
   readonly directive: Directive<E>;
-}
+};
 
 export function setupReactive<T>(blueprint: UseReactive<T>): Ref<ReadValue<T>> {
   const vueInstance = useReactive();
@@ -105,10 +107,9 @@ export function elementResourceDirective<E extends Element, T>(
 export function elementResource<E extends Element, T>(
   blueprint: ElementResourceBlueprint<E, T>,
 ): ElementResourceHandle<E, T> {
-  const value = shallowRef<T | null>(null);
+  const value = shallowRef(null) as ShallowRef<T | null>;
 
-  return {
-    value,
+  return Object.assign(value, {
     directive: elementResourceDirective(blueprint, { into: value }),
-  };
+  });
 }

--- a/packages/vue/vue/tests/element-resource.spec.ts
+++ b/packages/vue/vue/tests/element-resource.spec.ts
@@ -229,10 +229,7 @@ describe("elementResource", () => {
 
         return () =>
           h(Fragment, [
-            h(
-              "p",
-              size.value.value ? `width=${size.value.value.width}` : "pending",
-            ),
+            h("p", size.value ? `width=${size.value.width}` : "pending"),
             h(
               "button",
               {
@@ -285,10 +282,7 @@ describe("elementResource", () => {
 
         return () =>
           h(Fragment, [
-            h(
-              "p",
-              size.value.value ? `width=${size.value.value.width}` : "pending",
-            ),
+            h("p", size.value ? `width=${size.value.width}` : "pending"),
             h("button", { onClick: () => (visible.value = false) }, "hide"),
             visible.value
               ? withDirectives(h("div", { "data-width": "100" }, "box"), [

--- a/workspace/dev-compile/src/rollup/plugins/typescript.ts
+++ b/workspace/dev-compile/src/rollup/plugins/typescript.ts
@@ -115,13 +115,21 @@ export default function typescript(
 
     const minify = {
       format: {
-        comments: mode === 'production',
+        comments: mode === "production",
       },
       mangle: {
         toplevel: true,
         properties: {
           builtins: false,
-          reserved: ["attach", "into"],
+          reserved: [
+            "attach",
+            "directive",
+            "install",
+            "into",
+            "mounted",
+            "unmounted",
+            "value",
+          ],
         },
       },
       module: true,
@@ -153,8 +161,8 @@ export default function typescript(
     const jsxFactory = compilerOptions.jsxFactory;
 
     /**
-    * TODO: move react specific build code to react packages' rollup
-    */
+     * TODO: move react specific build code to react packages' rollup
+     */
     if (fragmentFactory && jsxFactory)
       jscConfig = withReact(jscConfig, {
         pragma: jsxFactory,


### PR DESCRIPTION
## Summary

- Change Vue `elementResource()` to return the Vue shallow ref itself, augmented with `directive`.
- Update handle tests to read through `size.value` instead of `size.value.value`.
- Update Vue docs to show template-unwrapped `size` and script/render `size.value`.
- Preserve public/interoperability property names during production property mangling: `attach`, `directive`, `install`, `into`, `mounted`, `unmounted`, and `value`.

## Validation

- `pnpm --filter @starbeam/vue test:types`
- `pnpm vitest --project vue --run packages/vue/vue/tests/element-resource.spec.ts`
- `pnpm --filter @starbeam-dev/compile build`
- `pnpm --filter @starbeam/vue build`
- Verified production Vue output preserves public handle/directive/plugin property names
- `pnpm test:workspace:pack`
- pre-commit: `pnpm test:workspace:types`
- pre-commit: `pnpm test:workspace:lint`

## Notes

`pnpm --filter @starbeam/vue test:specs` still hits the known package-local Vitest cwd/project-glob issue, so the Vue spec was run from the workspace root.

The existing local renderer reflow edits are intentionally unstaged and not part of this PR.