### PR TITLE
Extract shared element resource setup

### DIFF
--- a/packages/svelte/svelte/package.json
+++ b/packages/svelte/svelte/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@starbeam/interfaces": "workspace:^",
     "@starbeam/reactive": "workspace:^",
+    "@starbeam/renderer": "workspace:^",
     "@starbeam/resource": "workspace:^",
     "@starbeam/runtime": "workspace:^",
     "@starbeam/shared": "workspace:^",

--- a/packages/svelte/svelte/src/element-resource.ts
+++ b/packages/svelte/svelte/src/element-resource.ts
@@ -1,16 +1,16 @@
-import type { IntoResourceBlueprint, SyncFn } from "@starbeam/resource";
-import { setupResource } from "@starbeam/resource";
-import { pushingScope, RUNTIME } from "@starbeam/runtime";
-import { finalize } from "@starbeam/shared";
+import type { ElementResourceBlueprint as RendererElementResourceBlueprint } from "@starbeam/renderer";
+import { setupElementResource } from "@starbeam/renderer";
+import { RUNTIME } from "@starbeam/runtime";
 import type { Attachment } from "svelte/attachments";
 
 type SvelteReadable<T> = import("svelte/store").Readable<T>;
 type SvelteSubscriber<T> = import("svelte/store").Subscriber<T>;
 type SvelteUnsubscriber = import("svelte/store").Unsubscriber;
 
-export type ElementResourceBlueprint<E extends Element, T> = (
-  element: E,
-) => IntoResourceBlueprint<T>;
+export type ElementResourceBlueprint<
+  E extends Element,
+  T,
+> = RendererElementResourceBlueprint<E, T>;
 
 export type ElementResourceSink<T> = (value: T | null) => void;
 
@@ -24,12 +24,6 @@ export type ElementResourceHandle<
   readonly attach: ElementResourceAttachment<E>;
 };
 
-interface ResourceState<T> {
-  readonly scope: object;
-  readonly sync: SyncFn<void>;
-  readonly value: T;
-}
-
 export function elementResourceAttachment<E extends Element, T>(
   blueprint: ElementResourceBlueprint<E, T>,
   options: { readonly into?: ElementResourceSink<T> | undefined } = {},
@@ -38,7 +32,7 @@ export function elementResourceAttachment<E extends Element, T>(
     let active = true;
     let scheduled = false;
 
-    const resource = createElementResource(blueprint, element);
+    const resource = setupElementResource(blueprint, element);
 
     resource.sync();
     options.into?.(resource.value);
@@ -60,7 +54,7 @@ export function elementResourceAttachment<E extends Element, T>(
     return () => {
       active = false;
       unsubscribe?.();
-      finalize(resource.scope);
+      resource.finalize();
       options.into?.(null);
     };
   };
@@ -102,19 +96,4 @@ export function elementResource<E extends Element, T>(
   blueprint: ElementResourceBlueprint<E, T>,
 ): ElementResourceHandle<E, T> {
   return elementResourceStore(blueprint);
-}
-
-function createElementResource<E extends Element, T>(
-  blueprint: ElementResourceBlueprint<E, T>,
-  element: E,
-): ResourceState<T> {
-  const [scope, resource] = pushingScope(() =>
-    setupResource(blueprint(element)),
-  );
-
-  return {
-    scope,
-    sync: resource.sync,
-    value: resource.value,
-  };
 }

--- a/packages/universal/renderer/index.ts
+++ b/packages/universal/renderer/index.ts
@@ -18,6 +18,10 @@ export {
   runHandlers,
 } from "./src/renderer.js";
 
-// Resource conversion.
-export type { IntoResourceBlueprint } from "./src/resource.js";
-export { intoResourceBlueprint } from "./src/resource.js";
+// Resource conversion and element-backed resource setup.
+export type {
+  ElementResourceBlueprint,
+  ElementResourceInstance,
+  IntoResourceBlueprint,
+} from "./src/resource.js";
+export { intoResourceBlueprint, setupElementResource } from "./src/resource.js";

--- a/packages/universal/renderer/src/resource.ts
+++ b/packages/universal/renderer/src/resource.ts
@@ -1,7 +1,11 @@
 import type {
   ResourceBlueprint,
   ResourceConstructor,
+  SyncFn,
 } from "@starbeam/resource";
+import { setupResource } from "@starbeam/resource";
+import { pushingScope } from "@starbeam/runtime";
+import { finalize } from "@starbeam/shared";
 
 export type IntoResourceBlueprint<T> =
   | ResourceBlueprint<T>
@@ -11,4 +15,29 @@ export function intoResourceBlueprint<T>(
   intoBlueprint: IntoResourceBlueprint<T>,
 ): ResourceBlueprint<T> {
   return typeof intoBlueprint === "function" ? intoBlueprint() : intoBlueprint;
+}
+
+export type ElementResourceBlueprint<E extends Element, T> = (
+  element: E,
+) => IntoResourceBlueprint<T>;
+
+export interface ElementResourceInstance<T> {
+  readonly sync: SyncFn<void>;
+  readonly value: T;
+  readonly finalize: () => void;
+}
+
+export function setupElementResource<E extends Element, T>(
+  blueprint: ElementResourceBlueprint<E, T>,
+  element: E,
+): ElementResourceInstance<T> {
+  const [scope, resource] = pushingScope(() =>
+    setupResource(blueprint(element)),
+  );
+
+  return {
+    sync: resource.sync,
+    value: resource.value,
+    finalize: () => finalize(scope),
+  };
 }

--- a/packages/universal/renderer/src/resource.ts
+++ b/packages/universal/renderer/src/resource.ts
@@ -17,7 +17,7 @@ export function intoResourceBlueprint<T>(
   return typeof intoBlueprint === "function" ? intoBlueprint() : intoBlueprint;
 }
 
-export type ElementResourceBlueprint<E extends Element, T> = (
+export type ElementResourceBlueprint<E extends object, T> = (
   element: E,
 ) => IntoResourceBlueprint<T>;
 
@@ -27,7 +27,7 @@ export interface ElementResourceInstance<T> {
   readonly finalize: () => void;
 }
 
-export function setupElementResource<E extends Element, T>(
+export function setupElementResource<E extends object, T>(
   blueprint: ElementResourceBlueprint<E, T>,
   element: E,
 ): ElementResourceInstance<T> {

--- a/packages/universal/renderer/tests/element-resource.spec.ts
+++ b/packages/universal/renderer/tests/element-resource.spec.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { Cell, Marker } from "@starbeam/reactive";
+import { setupElementResource } from "@starbeam/renderer";
+import { Resource } from "@starbeam/resource";
+import { describe, RecordedEvents, test } from "@starbeam-workspace/test-utils";
+
+const INITIAL_WIDTH = 0;
+
+function ElementSizeForTest(
+  element: HTMLElement,
+  events: RecordedEvents,
+  marker: ReturnType<typeof Marker>,
+) {
+  return Resource(({ on }) => {
+    const width = Cell(INITIAL_WIDTH);
+
+    events.record("size:attached");
+
+    on.sync(() => {
+      events.record("size:sync");
+      marker.read();
+      width.set(Number(element.dataset["width"] ?? INITIAL_WIDTH));
+    });
+
+    on.finalize(() => {
+      events.record("size:finalize");
+    });
+
+    return {
+      get width() {
+        return width.current;
+      },
+    };
+  });
+}
+
+describe("setupElementResource", () => {
+  test("sets up an element-backed resource and leaves scheduling to the caller", () => {
+    const events = new RecordedEvents();
+    const marker = Marker();
+    const element = document.createElement("div");
+    element.dataset["width"] = "100";
+
+    const resource = setupElementResource(
+      (element: HTMLElement) => ElementSizeForTest(element, events, marker),
+      element,
+    );
+
+    events.expect("size:attached");
+    resource.sync();
+    events.expect("size:sync");
+
+    element.dataset["width"] = "101";
+    marker.mark();
+    events.expect();
+
+    resource.sync();
+    events.expect("size:sync");
+
+    resource.finalize();
+    events.expect("size:finalize");
+  });
+});

--- a/packages/vue/vue/src/resource.ts
+++ b/packages/vue/vue/src/resource.ts
@@ -1,23 +1,20 @@
 import type { ReadValue } from "@starbeam/reactive";
-import type { UseReactive } from "@starbeam/renderer";
+import type { ElementResourceBlueprint, UseReactive } from "@starbeam/renderer";
 import {
   managerSetupReactive,
   managerSetupResource,
   managerSetupService,
+  setupElementResource,
 } from "@starbeam/renderer";
 import type { IntoResourceBlueprint } from "@starbeam/resource";
-import { setupResource as setupStarbeamResource } from "@starbeam/resource";
-import { pushingScope, RUNTIME } from "@starbeam/runtime";
-import { finalize } from "@starbeam/shared";
+import { RUNTIME } from "@starbeam/runtime";
 import type { Directive, Ref, ShallowRef } from "vue";
 import { nextTick, shallowRef, triggerRef } from "vue";
 
 import { MANAGER } from "./renderer.js";
 import { useReactive } from "./setup.js";
 
-export type ElementResourceBlueprint<E extends Element, T> = (
-  element: E,
-) => IntoResourceBlueprint<T>;
+export type { ElementResourceBlueprint } from "@starbeam/renderer";
 
 export interface ElementResourceDirectiveOptions<T> {
   readonly into?: Ref<T | null> | undefined;
@@ -66,9 +63,7 @@ export function elementResourceDirective<E extends Element, T>(
     mounted(element) {
       cleanups.get(element)?.();
 
-      const [scope, resource] = pushingScope(() =>
-        setupStarbeamResource(blueprint(element)),
-      );
+      const resource = setupElementResource(blueprint, element);
 
       resource.sync();
       publish(resource.value);
@@ -92,7 +87,7 @@ export function elementResourceDirective<E extends Element, T>(
       cleanups.set(element, () => {
         active = false;
         if (unsubscribe) unsubscribe();
-        finalize(scope);
+        resource.finalize();
         publish(null);
       });
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,6 +579,9 @@ importers:
       '@starbeam/reactive':
         specifier: workspace:^
         version: link:../../universal/reactive
+      '@starbeam/renderer':
+        specifier: workspace:^
+        version: link:../../universal/renderer
       '@starbeam/resource':
         specifier: workspace:^
         version: link:../../universal/resource

--- a/workspace/dev-compile/src/rollup/plugins/typescript.ts
+++ b/workspace/dev-compile/src/rollup/plugins/typescript.ts
@@ -124,6 +124,7 @@ export default function typescript(
           reserved: [
             "attach",
             "directive",
+            "finalize",
             "install",
             "into",
             "mounted",


### PR DESCRIPTION
## Summary

- Adds `setupElementResource()` to `@starbeam/renderer` as the framework-neutral element-resource setup/finalization primitive.
- Refactors Vue and Svelte element-resource implementations to share that primitive while keeping scheduling, `RUNTIME.subscribe`, publication, and element delivery adapter-local.
- Adds focused renderer coverage for manual sync/finalize behavior.
- Adds `@starbeam/renderer` as a Svelte runtime dependency.
- Preserves the public `finalize` property in production builds so `ElementResourceInstance` matches generated declarations.

## Validation

- `pnpm --filter @starbeam/renderer test:types`
- `pnpm --filter @starbeam/vue test:types`
- `pnpm --filter @starbeam/svelte test:types`
- `pnpm --filter @starbeam/renderer test:specs`
- `pnpm vitest --project vue --run packages/vue/vue/tests/element-resource.spec.ts`
- `pnpm vitest --project svelte --run packages/svelte/svelte/tests/element-resource.spec.ts`
- `pnpm --filter @starbeam-dev/compile build`
- `pnpm --filter @starbeam/renderer build`
- `pnpm --filter @starbeam/vue build`
- `pnpm --filter @starbeam/svelte build`
- Verified production renderer output preserves `finalize` and Vue/Svelte production outputs call `.finalize()`
- `pnpm test:workspace:pack`
- pre-commit: `pnpm test:workspace:types`
- pre-commit: `pnpm test:workspace:lint`

## Notes

The full pre-push `pnpm build` hook was still progressing after several minutes and was killed to avoid blocking the session. The targeted builds and package-surface checks above passed.

The existing local renderer reflow edits are intentionally unstaged and not part of this PR.