### PR TITLE
Document renderer element resource setup boundary

### DIFF
--- a/docs/DOM-ATTACHMENT-BOUNDARY.md
+++ b/docs/DOM-ATTACHMENT-BOUNDARY.md
@@ -13,9 +13,9 @@ new shared public package boundary.
 - Svelte exposes an experimental attachment API for element resources.
 - `@starbeam/modifier` stays internal. Its current `ElementPlaceholder` is
   historical kernel evidence, not the public contract.
-- `@starbeam/renderer` remains the best future home for adapter-author
-  vocabulary if official or third-party adapters need shared DOM attachment
-  types.
+- `@starbeam/renderer` owns the shared adapter-author setup/finalization
+  primitive for element-backed resources. Adapters still own element delivery,
+  scheduling, runtime subscription, and publication.
 - `@starbeam/universal` may eventually document framework-neutral element
   resources for app and library authors, but should not expose ref, directive,
   or modifier-shaped APIs in 0.9.
@@ -24,6 +24,13 @@ Future code moves should be driven by adapter duplication or concrete framework
 evidence, not by the existence of the old modifier package name. The current
 ergonomics evidence is reviewed in
 [DOM Attachment Ergonomics Review](./DOM-ATTACHMENT-ERGONOMICS.md).
+
+After the Vue and Svelte experiments, `@starbeam/renderer` exposes
+`setupElementResource()` for the framework-neutral part of element resources:
+constructing a Starbeam resource from an element and returning its `value`,
+`sync`, and `finalize` handles. Vue and Svelte use that primitive. Their
+framework adapters still decide when to subscribe, when to schedule `sync()`, how
+to publish `T | null`, and how the framework supplies the element.
 
 ## What is stable
 
@@ -186,14 +193,14 @@ attachable/readable object for Svelte authors.
 
 ## Boundary matrix
 
-| Boundary              | Audience                                 | Fits                                                                    | Problems                                                                 | 0.9 decision                       |
-| --------------------- | ---------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------- |
-| Official adapters     | App authors using React, Preact, Vue     | Idiomatic framework leaves; already proven for React/Preact             | Duplicated local vocabulary                                              | Keep                               |
-| `@starbeam/renderer`  | Adapter authors                          | Existing adapter-author kit; already owns lifecycle/resource vocabulary | Premature if only official adapters need it                              | Best future shared type home       |
-| `@starbeam/universal` | App and library authors                  | Framework-neutral package; good home for prose concepts                 | Ref/directive/modifier APIs are not framework-neutral                    | Document concept later, no 0.9 API |
-| `@starbeam/modifier`  | Internal DOM attachment kernel candidate | Historical name and `ElementPlaceholder` evidence                       | Current API is not resource-shaped; package name pulls toward old design | Keep internal                      |
-| New package           | Independent DOM attachment authors       | Clean boundary if concept becomes installable                           | No independent audience yet                                              | Do not create                      |
-| No public boundary    | Official adapters only                   | Lowest surface area; matches current evidence                           | Duplicates types until pressure appears                                  | Current 0.9 default                |
+| Boundary              | Audience                                     | Fits                                                                   | Problems                                                                 | 0.9 decision                       |
+| --------------------- | -------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------- |
+| Official adapters     | App authors using React, Preact, Vue, Svelte | Idiomatic framework leaves; already proven for React/Preact            | Duplicated local result shapes                                           | Keep                               |
+| `@starbeam/renderer`  | Adapter authors                              | Existing adapter-author kit; owns shared setup/finalization vocabulary | Scheduling and publication are still adapter-specific                    | Owns the shared setup primitive    |
+| `@starbeam/universal` | App and library authors                      | Framework-neutral package; good home for prose concepts                | Ref/directive/modifier APIs are not framework-neutral                    | Document concept later, no 0.9 API |
+| `@starbeam/modifier`  | Internal DOM attachment kernel candidate     | Historical name and `ElementPlaceholder` evidence                      | Current API is not resource-shaped; package name pulls toward old design | Keep internal                      |
+| New package           | Independent DOM attachment authors           | Clean boundary if concept becomes installable                          | No independent audience yet                                              | Do not create                      |
+| No public boundary    | Official adapters only                       | Lowest surface area; matches current evidence                          | Duplicates types until pressure appears                                  | Current 0.9 default                |
 
 ## Why not promote `@starbeam/modifier` now
 
@@ -216,13 +223,15 @@ PER proves the right kernel shape.
 
 ## Future triggers
 
-Move shared vocabulary into `@starbeam/renderer` if any of these become true:
+`@starbeam/renderer` now owns the minimal shared setup/finalization primitive.
+Only move more vocabulary into `@starbeam/renderer` if any of these become true:
 
-- React, Preact, and Vue all need the same adapter-author helper types.
-- A Svelte probe converges on the same helper types.
+- React, Preact, Vue, and Svelte need the same adapter-author result shapes.
 - A third-party adapter needs to implement DOM attachment.
-- Official adapters start duplicating non-trivial setup/sync/finalize logic.
-- The Vue public API needs a shared helper that is not Vue-specific.
+- Official adapters start duplicating scheduling or publication logic that is
+  not actually framework-specific.
+- Vue and Svelte converge beyond setup/finalization on shared publication or
+  handle vocabulary.
 
 Expose framework-neutral vocabulary through `@starbeam/universal` only if app or
 library authors need to name element resources outside a specific framework

--- a/docs/DOM-ATTACHMENT-ERGONOMICS.md
+++ b/docs/DOM-ATTACHMENT-ERGONOMICS.md
@@ -166,8 +166,11 @@ without exposing Starbeam storage.
 
 ## API direction
 
-The next implementation work should test modifier-shaped ergonomics, not promote
-the old modifier package.
+The first Vue/Svelte modifier-shaped experiments have landed. Svelte now exposes
+a readable store augmented with `attach`, and Vue exposes a Vue ref augmented
+with `directive`. Vue and Svelte also share `@starbeam/renderer`'s
+`setupElementResource()` primitive for the framework-neutral setup and
+finalization path.
 
 For now:
 
@@ -178,6 +181,8 @@ For now:
   the element.
 - Treat “modifier-shaped” as an ergonomic target: a reusable element-backed
   value that is attachable and readable.
+- Keep scheduling, `RUNTIME.subscribe`, and publication adapter-local unless
+  future evidence proves a broader shared contract.
 - Do not expose `ElementPlaceholder` as the public contract.
 - Do not create a public `@starbeam/modifier` package until a code Prepare /
   Execute / Review (PER) cycle proves the kernel shape.
@@ -185,16 +190,17 @@ For now:
 The old `@starbeam/modifier` name is historical evidence. The adapter probes are
 the source of truth.
 
-## What would justify shared vocabulary
+## What would justify more shared vocabulary
 
-Move shared vocabulary out of adapter-local code only when there is concrete
+The minimal shared setup/finalization primitive now lives in `@starbeam/renderer`.
+Move more vocabulary out of adapter-local code only when there is concrete
 pressure, such as:
 
-- repeated non-trivial helper duplication across adapters;
 - a third-party adapter needing the same DOM attachment contract;
-- Svelte and Vue converging on the same attachable/readable handle shape;
-- a code PER cycle proving a kernel that owns setup, sync, cleanup, element
-  replacement, and value publication;
+- React, Preact, Vue, and Svelte converging on the same adapter-author result
+  shape;
+- a code PER cycle proving scheduling or publication is generic rather than
+  framework-local;
 - adapter-author docs needing a stable name that cannot live in a single
   framework package.
 
@@ -209,5 +215,6 @@ This review does not:
 - rename React, Preact, Vue, or Svelte adapter APIs;
 - choose the final Svelte API;
 - bless the Vue handle spelling as final;
-- move shared types into `@starbeam/renderer` or `@starbeam/universal`;
+- move scheduling or publication into `@starbeam/renderer` or
+  `@starbeam/universal`;
 - change package manifests, generated artifacts, or tests.

--- a/docs/PACKAGE-SURFACE-TRIAGE.md
+++ b/docs/PACKAGE-SURFACE-TRIAGE.md
@@ -48,12 +48,14 @@ Direct imports of `@starbeam/modifier` are not the decision heuristic. The
 question is whether Starbeam has a public DOM attachment concept that should be
 stable, documented, and shared across adapters.
 
-Current leading hypothesis: **public concept, internal kernel**. The public
-concept is element attachment for framework reactivity: a framework obtains an
-element, Starbeam runs resource-backed work for that element, and cleanup follows
-the framework's element/component lifetime. `@starbeam/modifier` and
-`@domtree/*` remain internal unless a later PER finds a stable adapter-author
-contract that needs those package boundaries directly.
+Current decision: **public concept, renderer setup primitive, adapter-local
+dialects**. The public concept is element attachment for framework reactivity: a
+framework obtains an element, Starbeam runs resource-backed work for that element,
+and cleanup follows the framework's element/component lifetime. `@starbeam/renderer`
+now owns the shared adapter-author setup/finalization primitive for Vue/Svelte
+style element-first lifetimes. `@starbeam/modifier` and `@domtree/*` remain
+internal unless a later PER finds a stable adapter-author contract that needs
+those package boundaries directly.
 
 Other live possibilities:
 
@@ -70,12 +72,13 @@ Current evidence: `@starbeam/react` and `@starbeam/preact` both expose
 `IntoResourceBlueprint<T>`, plus a `pending | attached` result that always
 carries the framework callback ref. Vue adds the non-hooks version of that
 evidence: `@starbeam/vue` exposes `elementResourceDirective`, whose custom
-directive owns the resource scope for an element, subscribes to runtime
+directive owns the resource lifetime for an element, subscribes to runtime
 invalidations, schedules sync through Vue, and finalizes when the element
-unmounts. This is stronger evidence for a shared Starbeam DOM
-attachment concept than the earlier React-only probe. `@starbeam/modifier`
-still only exposes `ElementPlaceholder`, which models element availability but
-not the resource-shaped public contract.
+unmounts. Svelte adds the attachment dialect and now shares the renderer setup
+primitive with Vue. This is stronger evidence for a shared Starbeam DOM
+attachment concept than the earlier React-only probe. `@starbeam/modifier` still
+only exposes `ElementPlaceholder`, which models element availability but not the
+resource-shaped public contract.
 
 #### DOM attachment contract sketch
 
@@ -162,8 +165,8 @@ React and Preact now independently expose the same leaf API shape:
 
 This supports the hypothesis that Starbeam has a universal resource-shaped DOM
 attachment concept. It does not yet prove that `@starbeam/modifier` should be
-public. The duplicated adapter-local types may be the right short-term state
-until the owning package boundary is clear.
+public. React and Preact keep their adapter-local result shapes because their
+timing is hook/resource-lifecycle specific.
 
 **Vue directive findings from #211 and #215**
 
@@ -185,6 +188,22 @@ The directive probe also shows that the component-centered `@starbeam/vue`
 Directive hooks do not have setup-time `getCurrentInstance()` context, so a Vue
 element-attachment API needs a directive-owned lifetime path rather than the
 component setup path.
+
+**Renderer setup primitive after #223**
+
+Vue and Svelte now share `@starbeam/renderer`'s `setupElementResource()` helper.
+The helper owns only the Starbeam setup/finalization kernel: it turns an element
+and `ElementResourceBlueprint` into `{ value, sync, finalize }`. Vue and Svelte
+still own their framework-local concerns:
+
+- element delivery (`directive` vs. `{@attach}`);
+- runtime invalidation subscription;
+- sync scheduling (`nextTick` vs. `queueMicrotask`);
+- publication (`ShallowRef`/`triggerRef`, callback sinks, or Svelte stores);
+- cleanup timing and element replacement semantics.
+
+This closes the basic package-boundary question for Vue/Svelte setup without
+promoting `@starbeam/modifier` or forcing React/Preact onto the same helper.
 
 **`ElementPlaceholder` reconciliation**
 
@@ -240,11 +259,11 @@ bounded change, then review the result against the prediction.
 4. Modifier / DOM attachment reconciliation. Done so far: React + Preact
    convergence, the `ElementPlaceholder` comparison, the Vue directive probe,
    the [DOM attachment boundary decision](./DOM-ATTACHMENT-BOUNDARY.md), the
-   Svelte attachment experiment, and the Vue handle experiment. Keep official
-   adapter APIs as the 0.9 public surface. Use the
-   [DOM attachment ergonomics review](./DOM-ATTACHMENT-ERGONOMICS.md) to drive
-   the next modifier-shaped API experiment. Move shared vocabulary only if
-   adapter-author pressure justifies it.
+   Svelte attachment experiment, the Vue handle experiment, and the renderer
+   setup primitive. Keep official adapter APIs as the 0.9 public surface. The
+   [DOM attachment ergonomics review](./DOM-ATTACHMENT-ERGONOMICS.md) now frames
+   remaining work as API polish and future expansion beyond setup/finalization,
+   not basic boundary discovery.
 5. Low-level surface consolidation: make `@starbeam/universal` the umbrella,
    split public `@starbeam/reactive` primitives from runtime wiring, place
    service intentionally, and target interfaces/tags/runtime as internal unless


### PR DESCRIPTION
## Summary

This closes out the docs side of the element-resource kernel work after #223.

- Update the DOM attachment boundary decision to say `@starbeam/renderer` now owns the shared `setupElementResource()` setup/finalization primitive.
- Clarify that Vue and Svelte share setup/finalization, while element delivery, `RUNTIME.subscribe`, sync scheduling, and value publication remain adapter-local.
- Keep React/Preact on their local hook/resource machinery.
- Keep `@starbeam/modifier` internal as historical kernel evidence, not the public contract.
- Update package-surface triage so remaining DOM attachment work is API polish and possible future expansion beyond setup/finalization, not basic boundary discovery.

## Validation

- `pnpm exec prettier --check docs/DOM-ATTACHMENT-BOUNDARY.md docs/DOM-ATTACHMENT-ERGONOMICS.md docs/PACKAGE-SURFACE-TRIAGE.md`
- `git diff --check -- docs/DOM-ATTACHMENT-BOUNDARY.md docs/DOM-ATTACHMENT-ERGONOMICS.md docs/PACKAGE-SURFACE-TRIAGE.md`
- Grep confirmed the removed stale phrases are gone.
- pre-commit: `pnpm test:workspace:types`
- pre-commit: `pnpm test:workspace:lint`

## Notes

Docs-only. The existing local renderer reflow edits are intentionally unstaged and not part of this PR.