### PR TITLE
Reserve public object property keys

### DIFF
--- a/docs/PACKAGE-SURFACE.md
+++ b/docs/PACKAGE-SURFACE.md
@@ -96,6 +96,20 @@ Production stripping is not enough. The release surface is about published
 manifests, default/development JavaScript, and declarations as well as
 production bundles.
 
+## Public object property names
+
+Public runtime object-contract property names are part of the release surface.
+If a framework, adapter, app, or separately built package accesses a property by
+name, production property mangling must preserve that name.
+
+Examples include framework interop keys such as Vue plugin and directive hooks,
+adapter handle keys such as `attach` and `directive`, and shared renderer
+instance keys such as `sync`, `value`, and `finalize`.
+
+The build configuration reserves these names from production property mangling,
+and `pnpm test:workspace:pack` verifies the relevant production artifacts keep
+the expected public keys.
+
 When a private package provides development-only behavior, preserve the public
 behavior through a public package boundary before making the implementation
 private. For example, `@starbeam/debug` is internal, but `@starbeam/universal`

--- a/workspace/dev-compile/src/rollup/plugins/typescript.ts
+++ b/workspace/dev-compile/src/rollup/plugins/typescript.ts
@@ -12,6 +12,18 @@ const require = createRequire(import.meta.url);
 const rollupTS =
   require("rollup-plugin-ts") as typeof import("rollup-plugin-ts").default;
 
+export const PUBLIC_OBJECT_PROPERTY_KEYS = [
+  "attach",
+  "directive",
+  "finalize",
+  "install",
+  "into",
+  "mounted",
+  "sync",
+  "unmounted",
+  "value",
+] as const;
+
 /**
  * Build a library with TypeScript in the specified mode.
  *
@@ -121,16 +133,7 @@ export default function typescript(
         toplevel: true,
         properties: {
           builtins: false,
-          reserved: [
-            "attach",
-            "directive",
-            "finalize",
-            "install",
-            "into",
-            "mounted",
-            "unmounted",
-            "value",
-          ],
+          reserved: [...PUBLIC_OBJECT_PROPERTY_KEYS],
         },
       },
       module: true,

--- a/workspace/scripts/verify-packed-public-packages.js
+++ b/workspace/scripts/verify-packed-public-packages.js
@@ -54,11 +54,48 @@ const privatePackageNames = new Set(
     .map(({ manifest }) => manifest.name),
 );
 
+const publicObjectPropertyContracts = [
+  {
+    packageName: "@starbeam/renderer",
+    file: "dist/index.production.js",
+    properties: [
+      { key: "sync", pattern: /\bsync\s*:/u },
+      { key: "value", pattern: /\bvalue\s*:/u },
+      { key: "finalize", pattern: /\bfinalize\s*:/u },
+    ],
+  },
+  {
+    packageName: "@starbeam/svelte",
+    file: "dist/index.production.js",
+    properties: [
+      { key: "attach", pattern: /\battach\s*:/u },
+      { key: "into", pattern: /\binto\s*:/u },
+    ],
+  },
+  {
+    packageName: "@starbeam/vue",
+    file: "dist/index.production.js",
+    properties: [
+      { key: "directive", pattern: /\bdirective\s*:/u },
+      { key: "into", pattern: /(?:\binto\s*:|\.into\b)/u },
+      { key: "mounted", pattern: /\bmounted\s*(?::|=|\()/u },
+      { key: "unmounted", pattern: /\bunmounted\s*(?::|=|\()/u },
+      { key: "value", pattern: /(?:\bvalue\s*:|\.value\b)/u },
+    ],
+  },
+  {
+    packageName: "@starbeam/vue",
+    file: "dist/setup.production.js",
+    properties: [{ key: "install", pattern: /\binstall\s*:/u }],
+  },
+];
+
 let errors = [];
 
 for (let pkg of publicPackages) {
   validateManifest(pkg);
   validateArtifacts(pkg);
+  validatePublicObjectProperties(pkg);
 }
 
 if (errors.length > 0) {
@@ -147,6 +184,37 @@ function validateArtifacts(pkg) {
   for (let file of findRootDeclarations(pkg)) {
     scanFileForPrivateReferences(pkg, file, scannedFiles);
     validateDeclarationMap(pkg, file);
+  }
+}
+
+function validatePublicObjectProperties(pkg) {
+  for (let contract of publicObjectPropertyContracts) {
+    if (contract.packageName !== pkg.manifest.name) {
+      continue;
+    }
+
+    let file = resolve(pkg.dir, contract.file);
+
+    if (!existsSync(file)) {
+      fail(
+        pkg,
+        `public object property contract artifact is missing: ${contract.file}`,
+        file,
+      );
+      continue;
+    }
+
+    let content = readFileSync(file, "utf8");
+
+    for (let { key, pattern } of contract.properties) {
+      if (!pattern.test(content)) {
+        fail(
+          pkg,
+          `production artifact does not preserve public object property ${key}`,
+          file,
+        );
+      }
+    }
   }
 }
 

--- a/workspace/scripts/verify-packed-public-packages.js
+++ b/workspace/scripts/verify-packed-public-packages.js
@@ -8,6 +8,7 @@ import { globby, globbySync } from "globby";
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const root = resolve(currentDir, "../..");
 const rootTypesDir = resolve(root, "dist/types");
+const publicObjectPropertyKeys = readPublicObjectPropertyKeys();
 
 const packageJsonPaths = await globby("**/package.json", {
   cwd: root,
@@ -112,6 +113,26 @@ if (errors.length > 0) {
 
 console.info(`Verified ${publicPackages.length} publishable packages.`);
 
+function readPublicObjectPropertyKeys() {
+  let file = resolve(
+    root,
+    "workspace/dev-compile/src/rollup/plugins/typescript.ts",
+  );
+  let content = readFileSync(file, "utf8");
+  let match =
+    /PUBLIC_OBJECT_PROPERTY_KEYS\s*=\s*\[([\s\S]*?)\]\s*as const/u.exec(
+      content,
+    );
+
+  if (!match) {
+    throw new Error(
+      "Could not find PUBLIC_OBJECT_PROPERTY_KEYS in build config",
+    );
+  }
+
+  return new Set([...match[1].matchAll(/"([^"]+)"/gu)].map(([, key]) => key));
+}
+
 function validateManifest(pkg) {
   let { manifest } = pkg;
 
@@ -207,6 +228,14 @@ function validatePublicObjectProperties(pkg) {
     let content = readFileSync(file, "utf8");
 
     for (let { key, pattern } of contract.properties) {
+      if (!publicObjectPropertyKeys.has(key)) {
+        fail(
+          pkg,
+          `public object property ${key} is verified but not reserved from production property mangling`,
+          file,
+        );
+      }
+
       if (!pattern.test(content)) {
         fail(
           pkg,


### PR DESCRIPTION
## Summary

This treats public runtime object-contract property names as package release surface.

- Extracts the SWC property-mangling reserved list to `PUBLIC_OBJECT_PROPERTY_KEYS`.
- Adds `sync` to the reserved list so renderer resource instances keep their public contract in production artifacts.
- Adds packed-package verification for public object property keys in renderer, Svelte, and Vue production artifacts.
- Documents the policy in the package surface guide.

## Validation

- `pnpm exec prettier --check workspace/scripts/verify-packed-public-packages.js workspace/dev-compile/src/rollup/plugins/typescript.ts docs/PACKAGE-SURFACE.md`
- `git diff --check -- workspace/scripts/verify-packed-public-packages.js workspace/dev-compile/src/rollup/plugins/typescript.ts docs/PACKAGE-SURFACE.md`
- `node workspace/scripts/verify-packed-public-packages.js`
- `node workspace/scripts/build-verify.js`
- `pnpm test:workspace:pack`
- `pnpm --filter @starbeam-dev/compile test:types`
- pre-commit: `pnpm test:workspace:types`
- pre-commit: `pnpm test:workspace:lint`
- pre-push full suite completed successfully during push

## Negative check

Temporarily changed the renderer `sync` verifier pattern to an impossible key and confirmed `node workspace/scripts/verify-packed-public-packages.js` failed for `@starbeam/renderer`, then restored the verifier and re-ran verification successfully.

## Notes

The existing local edits in `.vscode/extensions.json` and `packages/universal/renderer/tests/smoke.spec.ts` are intentionally unstaged and not part of this PR.