### PR TITLE
docs(svelte): promote elementResource as primary attachment API

### DIFF
--- a/docs/DOM-ATTACHMENT-BOUNDARY.md
+++ b/docs/DOM-ATTACHMENT-BOUNDARY.md
@@ -10,7 +10,9 @@ new shared public package boundary.
 
 - React and Preact keep their idiomatic `useElementResource` leaves.
 - Vue exposes `elementResourceDirective` for directive-owned element resources.
-- Svelte exposes an experimental attachment API for element resources.
+- Svelte exposes `elementResource()` for Svelte 5 attachment-backed element
+  resources, with `elementResourceAttachment()` as the lower-level attachment
+  primitive.
 - `@starbeam/modifier` stays internal. Its current `ElementPlaceholder` is
   historical kernel evidence, not the public contract.
 - `@starbeam/renderer` owns the shared adapter-author setup/finalization
@@ -92,12 +94,12 @@ primitive or an adapter result slot such as React's attached resource value.
 Refs, directives, and modifiers are framework dialects for delivering the
 element. They are not the stable Starbeam contract name.
 
-| Framework | Dialect          | Proven API or evidence      | Current status            |
-| --------- | ---------------- | --------------------------- | ------------------------- |
-| React     | callback ref     | `useElementResource`        | Public adapter leaf       |
-| Preact    | callback ref     | `useElementResource`        | Public adapter leaf       |
-| Vue       | custom directive | `elementResourceDirective`  | Public adapter leaf       |
-| Svelte    | `{@attach ...}`  | `elementResourceAttachment` | Experimental adapter leaf |
+| Framework | Dialect          | Proven API or evidence     | Current status      |
+| --------- | ---------------- | -------------------------- | ------------------- |
+| React     | callback ref     | `useElementResource`       | Public adapter leaf |
+| Preact    | callback ref     | `useElementResource`       | Public adapter leaf |
+| Vue       | custom directive | `elementResourceDirective` | Public adapter leaf |
+| Svelte    | `{@attach ...}`  | `elementResource`          | Public adapter leaf |
 
 ### React and Preact
 
@@ -144,13 +146,12 @@ cleanup function. Svelte reruns an attachment when state read by the attachment
 expression changes, and it calls cleanup before rerun or after the element is
 removed.
 
-The Svelte probe now exists as an experimental adapter leaf. It validates
-attachment-owned lifetime and compares callback-sink and store-sink publication
-styles:
+The Svelte adapter uses `elementResource()` as the primary authoring API for
+Svelte 5 attachments. It returns a Svelte-readable value that is also attachable:
 
 ```svelte
 <script lang="ts">
-  import { elementResourceAttachment } from "@starbeam/svelte";
+  import { elementResource } from "@starbeam/svelte";
   import type { IntoResourceBlueprint } from "@starbeam/resource";
 
   interface Size {
@@ -164,19 +165,16 @@ styles:
 
   declare const ElementSize: ElementResourceBlueprint<HTMLElement, Size>;
 
-  let size = $state<Size | null>(null);
-
-  const attachSize = elementResourceAttachment(ElementSize, {
-    into(value) {
-      size = value;
-    },
-  });
+  const size = elementResource(ElementSize);
 </script>
 
-<section {@attach attachSize}>
-  {size ? `${size.width} × ${size.height}` : "Measuring…"}
+<section {@attach size.attach}>
+  {$size ? `${$size.width} × ${$size.height}` : "Measuring…"}
 </section>
 ```
+
+`elementResourceAttachment()` remains available as the lower-level attachment
+primitive when authors want to publish the resource value into state they own.
 
 Svelte actions (`use:`) remain available, but Svelte's docs say attachments
 supersede actions in Svelte 5.29 and newer. Actions are therefore a fallback for
@@ -187,9 +185,9 @@ attachments. That may matter for library-author ergonomics, but it should follow
 the basic attachment probe.
 
 The open Svelte question is no longer whether Svelte can deliver an element and
-cleanup lifetime. It can. The open question is which publication style should be
-primary and whether the store-shaped experiment is the right reusable
-attachable/readable object for Svelte authors.
+cleanup lifetime, or which current spelling is primary. The remaining question
+is whether future Svelte-specific ergonomics should go beyond the store-readable
+shape.
 
 ## Boundary matrix
 

--- a/docs/DOM-ATTACHMENT-ERGONOMICS.md
+++ b/docs/DOM-ATTACHMENT-ERGONOMICS.md
@@ -129,13 +129,14 @@ form publishes the resource value into author-owned state:
 </section>
 ```
 
-This matches Svelte runes well enough to prove the lifecycle, but it has the
-same split as Vue's `into` form: one value attaches, another value is read.
+This is the lower-level Svelte attachment form. It matches Svelte runes well
+enough to prove the lifecycle, but it has the same split as Vue's `into` form:
+one value attaches, another value is read.
 
 ### Svelte element resource
 
-The Svelte primary-name experiment uses `elementResource()` for the strongest
-modifier-shaped evidence so far:
+`elementResource()` is the primary Svelte authoring API for the current Svelte 5
+attachment path:
 
 ```svelte
 <script lang="ts">
@@ -149,10 +150,10 @@ modifier-shaped evidence so far:
 
 The same object is attachable through `size.attach` and readable through
 Svelte's store syntax. `elementResourceStore()` remains available as the
-explicit store-shaped spelling while this naming experiment is evaluated. This
-does not settle the final Svelte API, but it makes the cross-framework ergonomic
-target concrete: an element-backed value should be attachable and readable
-without exposing Starbeam storage.
+explicit store-shaped spelling, and `elementResourceAttachment()` remains the
+lower-level attachment/callback-sink primitive. Future Svelte-specific
+ergonomics may still be revisited, but the current supported authoring shape is
+`elementResource()`.
 
 ## Ergonomic comparison
 

--- a/packages/svelte/svelte/README.md
+++ b/packages/svelte/svelte/README.md
@@ -1,9 +1,13 @@
 # @starbeam/svelte
 
-Experimental Svelte adapter for Starbeam element-backed resources.
+Svelte adapter for Starbeam element-backed resources.
 
-This package currently exists to compare Svelte DOM attachment ergonomics. The
-stable creator shape is the same one used by the React, Preact, and Vue leaves:
+`elementResource()` is the primary authoring API for Svelte 5 attachments. It
+returns one Svelte-readable object that is also attachable. Attach it with
+`size.attach`; read the published value with Svelte's store syntax.
+
+The stable creator shape is the same one used by the React, Preact, and Vue
+leaves:
 
 ```ts
 type ElementResourceBlueprint<E extends Element, T> = (
@@ -11,7 +15,34 @@ type ElementResourceBlueprint<E extends Element, T> = (
 ) => IntoResourceBlueprint<T>;
 ```
 
-## Callback sink
+## Element resource
+
+```svelte
+<script lang="ts">
+  import { elementResource } from "@starbeam/svelte";
+  import { ElementSize } from "./element-size";
+
+  const size = elementResource(ElementSize);
+</script>
+
+<section {@attach size.attach}>
+  {$size ? `${$size.width} × ${$size.height}` : "Measuring…"}
+</section>
+```
+
+## Store sink
+
+`elementResourceStore()` is the explicit store-shaped spelling. It returns the
+same attachable/readable shape as `elementResource()`.
+
+```ts
+const size = elementResourceStore(ElementSize);
+```
+
+## Attachment sink
+
+`elementResourceAttachment()` is the lower-level attachment spelling. Use it when
+you want to publish the resource value into state that you own.
 
 ```svelte
 <script lang="ts">
@@ -32,33 +63,7 @@ type ElementResourceBlueprint<E extends Element, T> = (
 </section>
 ```
 
-## Element resource
-
-```svelte
-<script lang="ts">
-  import { elementResource } from "@starbeam/svelte";
-  import { ElementSize } from "./element-size";
-
-  const size = elementResource(ElementSize);
-</script>
-
-<section {@attach size.attach}>
-  {$size ? `${$size.width} × ${$size.height}` : "Measuring…"}
-</section>
-```
-
-`elementResource()` returns one Svelte-readable object that is also attachable.
-Attach it with `size.attach`; read the published value with Svelte's store
-syntax.
-
-## Store sink
-
-`elementResourceStore()` is the explicit store-shaped spelling. It returns the
-same attachable/readable shape as `elementResource()`.
-
-```ts
-const size = elementResourceStore(ElementSize);
-```
-
-Both forms keep cells private. Consumers read domain-shaped values through
-Svelte's store syntax, such as `$size.width`, not `$size.width.current`.
+All forms keep cells private. `elementResource()` and `elementResourceStore()`
+read domain-shaped values through Svelte's store syntax, such as `$size.width`,
+not `$size.width.current`. `elementResourceAttachment()` publishes the same
+domain-shaped value into state the author owns.


### PR DESCRIPTION
## Summary

- Promotes `elementResource()` as the primary Svelte 5 attachment authoring API.
- Keeps `elementResourceStore()` documented as the explicit store-shaped spelling.
- Keeps `elementResourceAttachment()` documented as the lower-level attachment/callback-sink primitive.
- Updates the DOM attachment decision docs to reflect current Svelte API confidence while preserving the caveat that future Svelte-specific ergonomics may still evolve.

## Validation

- `pnpm exec prettier --check packages/svelte/svelte/README.md docs/DOM-ATTACHMENT-ERGONOMICS.md docs/DOM-ATTACHMENT-BOUNDARY.md`
- `git diff --check -- packages/svelte/svelte/README.md docs/DOM-ATTACHMENT-ERGONOMICS.md docs/DOM-ATTACHMENT-BOUNDARY.md`
- `pnpm --filter @starbeam/svelte test:types`
- `pnpm vitest --project svelte --run packages/svelte/svelte/tests/element-resource.spec.ts`
- pre-commit: `pnpm test:workspace:types`
- pre-commit: `pnpm test:workspace:lint`

## Notes

Docs-only. Existing local edits in `.vscode/extensions.json` and `packages/universal/renderer/tests/smoke.spec.ts` are intentionally unstaged and not part of this PR.