### PR TITLE
docs(vue): clarify template element resource ergonomics

### DIFF
--- a/docs/DOM-ATTACHMENT-ERGONOMICS.md
+++ b/docs/DOM-ATTACHMENT-ERGONOMICS.md
@@ -93,17 +93,19 @@ const vSize = size.directive;
 
 That mirrors the modifier-shaped idea: one object is both attachable and
 readable, even though Vue template syntax still needs a directive alias.
+The handle spelling is still experimental.
 
-In Vue templates, the top-level ref unwraps:
-
-```vue
-{{ size ? size.width : "Measuring…" }}
-```
-
-In scripts and render functions, the same handle reads through Vue's ref slot:
+Current tests cover directive lifetime and script/render-function reads through
+Vue's ref slot:
 
 ```ts
 size.value ? `width=${size.value.width}` : "pending";
+```
+
+Template `size.width` relies on Vue's standard top-level ref unwrapping:
+
+```vue
+{{ size ? size.width : "Measuring…" }}
 ```
 
 ### Svelte callback sink

--- a/packages/vue/vue/README.md
+++ b/packages/vue/vue/README.md
@@ -89,6 +89,9 @@ const size = elementResource(ElementSize);
 const vSize = size.directive;
 ```
 
+The template below uses Vue Single-File Component syntax. In templates, Vue
+unwraps top-level refs, so the resource reads as `size.width`.
+
 ```vue
 <template>
   <section v-size>
@@ -98,9 +101,8 @@ const vSize = size.directive;
 ```
 
 This keeps the directive naming (`vSize`) separate from the readable value
-(`size`), while avoiding an explicit `into` ref. In templates, Vue unwraps the
-ref, so the resource reads as `size.width`. In scripts or render functions, read
-through Vue's ref slot: `size.value?.width`.
+(`size`), while avoiding an explicit `into` ref. In scripts or render functions,
+read through Vue's ref slot: `size.value?.width`.
 
 ## Timing model
 


### PR DESCRIPTION
## Summary

- Clarifies that the Vue handle example uses Single-File Component template syntax.
- Separates what current tests prove from what relies on Vue standard template ref unwrapping.
- Keeps scripts and render functions on the explicit `size.value?.width` spelling.
- Records that the Vue handle spelling remains experimental.

## Validation

- `pnpm exec prettier --check packages/vue/vue/README.md docs/DOM-ATTACHMENT-ERGONOMICS.md`
- `git diff --check -- packages/vue/vue/README.md docs/DOM-ATTACHMENT-ERGONOMICS.md`
- `pnpm --filter @starbeam-tests/vue test:types`
- `pnpm --filter @starbeam/vue test:types`
- `pnpm vitest --project vue --run packages/vue/vue/tests/element-resource.spec.ts`
- pre-commit: `pnpm test:workspace:types`
- pre-commit: `pnpm test:workspace:lint`

## Notes

Prepare / Execute / Review (PER) 4 concluded this should stay docs-only for now. A real `.vue` SFC fixture would require Vue SFC test/typecheck infrastructure and is deferred. Existing local edits in `.vscode/extensions.json` and `packages/universal/renderer/tests/smoke.spec.ts` are intentionally unstaged and not part of this PR.