### PR TITLE
docs(react): clarify element resource hook boundary

### DIFF
--- a/docs/DOM-ATTACHMENT-BOUNDARY.md
+++ b/docs/DOM-ATTACHMENT-BOUNDARY.md
@@ -118,6 +118,12 @@ type ElementResource<T, E extends Element> =
 The `ref` is the framework delivery mechanism. The `pending | attached` state is
 an adapter result shape, not the shared creator contract.
 
+React and Preact keep this hook-facing leaf because the element arrives through
+callback ref timing. Vue and Svelte can use `setupElementResource()` inside their
+directive or attachment implementations because those callbacks already receive
+the element. This does not mean Preact lacks `setup*` APIs generally; the DOM
+element resource leaf uses hooks and callback refs.
+
 `attached` means Starbeam has created the element-backed resource value. It does
 not mean `on.sync` has run, and it should not grow a public `ready` or `synced`
 state without new evidence.

--- a/packages/react/react/README.md
+++ b/packages/react/react/README.md
@@ -22,8 +22,14 @@ instead of passing `[]`.
 ## Element resources
 
 `useElementResource()` is the React API for element-backed Starbeam resources.
-It handles React's callback-ref timing and gives the resource a real DOM element
+It handles React's callback ref timing and gives the resource a real DOM element
 only after React has created it.
+
+This API is intentionally hook-facing rather than a direct
+`setupElementResource()` export. React delivers the element after render through
+a callback ref. Public React integration points that call hooks need `use*`
+names so React Compiler preserves them as hooks. The shared contract is still
+the element resource blueprint you pass to the hook.
 
 The hook returns a discriminated result:
 


### PR DESCRIPTION
## Summary

- Clarifies that React keeps `useElementResource()` hook-facing because elements arrive through callback-ref timing.
- Explains that public React integration points that call hooks need `use*` names for React Compiler hook preservation.
- Records the React/Preact versus Vue/Svelte split in the DOM attachment boundary doc.
- Preserves the Preact nuance: Preact has `setup*` APIs generally, but the DOM element resource leaf is hook/callback-ref-shaped.

## Validation

- `pnpm exec prettier --check packages/react/react/README.md docs/DOM-ATTACHMENT-BOUNDARY.md`
- `git diff --check -- packages/react/react/README.md docs/DOM-ATTACHMENT-BOUNDARY.md`
- pre-commit: `pnpm test:workspace:types`
- pre-commit: `pnpm test:workspace:lint`

## Notes

Prepare / Execute / Review (PER) 5 concluded this should stay docs-only. Existing local edits in `.vscode/extensions.json` and `packages/universal/renderer/tests/smoke.spec.ts` are intentionally unstaged and not part of this PR.