### PR TITLE
docs(resource): align README with current lifecycle API

### DIFF
--- a/docs/PACKAGE-SURFACE-TRIAGE.md
+++ b/docs/PACKAGE-SURFACE-TRIAGE.md
@@ -57,8 +57,8 @@ not settle final public/private status.
 
 Current conflicts to preserve for later PERs:
 
-- `@starbeam/resource` is public and active, but its README still documents old
-  `use` and resource-run vocabulary.
+- `@starbeam/resource` README conflict resolved in PER6b: docs now describe the
+  current `Resource()` / `setupResource()` API and sync/finalization semantics.
 - `@starbeam/service` is public and active, but its README is stale and
   `@starbeam/universal` docs mention a `service` export that universal does not
   currently provide.

--- a/packages/universal/resource/README.md
+++ b/packages/universal/resource/README.md
@@ -1,299 +1,157 @@
-# Resources
+# @starbeam/resource
 
-A resource is a reactive constructor function with support for cleanup.
+`@starbeam/resource` defines framework-agnostic resources: stable values with a
+caller-scheduled sync phase and finalization cleanup.
+
+The primary audience is resource authors and framework-agnostic library authors.
+App authors use this package when they are authoring reusable resources. Adapter
+authors may use the low-level setup contract, but `@starbeam/renderer` owns the
+shared adapter story.
+
+## Quick example
 
 ```ts
-import { Resource, use } from "@starbeam/resource";
-import { LIFETIME } from "@starbeam/runtime";
+import { Cell } from "@starbeam/reactive";
+import { Resource } from "@starbeam/resource";
 
-const Stopwatch = Resource(({ on }) => {
+export const Stopwatch = Resource(({ on }) => {
   const now = Cell(Date.now());
 
-  on.setup(() => {
+  on.sync(() => {
     const timer = setInterval(() => {
       now.set(Date.now());
     }, 1000);
 
-    on.cleanup(() => {
-      clearInterval(timer);
-    });
-  });
-
-  return Formula(() => {
-    return new Intl.DateTimeFormat().format(now.current);
-  });
-});
-
-const lifetime = {};
-const stopwatch = use(Stopwatch, { within: lifetime });
-
-// later, when the lifetime is finalized...
-LIFETIME.finalize(lifetime);
-// the timer is cleared and `stopwatch` will stop updating
-```
-
-The `Resource` function takes a _resource constructor_ function and returns a
-_resource blueprint_. A resource blueprint is instantiated with a _lifetime_ and
-returns a _resource instance_.
-
-The resource constructor function is called with a _resource run_ object that
-allows the resource constructor to register cleanup functions and create child
-resources.
-
-The return value of the resource constructor is called the resource's _instance
-value_.
-
-In this case, the resource instance (`stopwatch`) is a reactive value that
-evaluates to the current time, formatted using `Intl.DateTimeFormat`.
-
-## Terms
-
-<dl>
-  <dt>resource blueprint</dt>
-  <dd>The resource blueprint is instantiated with the `use` function and returns a <em>resource instance</em></dd>
-  <dt>resource instance</dt>
-  <dd>An instance of a resource blueprint is called its <em>resource instance</em>.</dd>
-  <dt>instance value</dt>
-  <dd>The value returned by the resource constructor is called the <em>instance value</em>.</dd>
-  <dt>resource constructor</dt>
-  <dd>The function passed to the <code>Resource</code> function is called the <em>resource constructor</em>.</dd>
-  <dt>resource run</dt>
-  <dd>Each time the resource constructor runs for a given resource instance, it is called a <em>resource run</em>. The constructor is called with an instance of the resource run, which allows the constructor to register cleanup functions and create child resources.</dd>
-</dl>
-
-## Assimilation
-
-A resource instance is always a stable reactive value. Its current value is the
-most recent return value of its resource constructor.
-
-If a resource constructor returns a reactive value, the resource instance will
-_assimilate_ that value. This means that the evaluated value of the resource
-instance will be the same as the evaluated value of the returned reactive value.
-
-```ts
-const Stopwatch = Resource(({ on }) => {
-  const now = Cell(Date.now());
-
-  const timer = setInterval(() => {
-    now.set(Date.now());
-  }, 1000);
-
-  on.cleanup(() => {
-    clearInterval(timer);
-  });
-
-  return Formula(() => {
-    return new Intl.DateTimeFormat().format(now.current);
-  });
-});
-```
-
-In this case, the _resource run_ has no reactive dependencies, but the
-_instance value_ is a formulaa that depends on the `now` cell.
-
-This means that instances of `Stopwatch` will be reactive values that evaluate
-to the current time, formatted using `Intl.DateTimeFormat`, but the resource
-constructor will only be evaluated once.
-
-### Regular Formulas Wouldn't Work
-
-Let's see what would happen if you tried to model this as a single formula:
-
-```ts
-const now = Cell(Date.now());
-let timer: number;
-
-const Stopwatch = Formula(() => {
-  if (timer) clearInterval(timer);
-
-  timer = setInterval(() => {
-    now.set(Date.now());
-  }, 1000);
-
-  return new Intl.DateTimeFormat().format(now.current);
-});
-```
-
-Since the code that sets up the interval and the code that uses it is inside the
-same formula, the formula invalidates every time the interval ticks, and the
-interval will be cleaned up and recreated on every tick. Definitely not what we
-wanted!
-
-## Resource Metadata
-
-In addition to state that's associated with each resource run, a resource can
-have metadata that is shared across all resource runs.
-
-```ts
-interface CounterMetadata {
-  interval: Reactive<number>;
-  count: number;
-}
-
-const Counter = Resource(({ on }, { metadata }: CounterMetadata)) => {
-  const count = Cell(metadata.count);
-
-  const interval = setInterval(() => {
-    count.set(++metadata.count);
-  }, metadata.interval.current);
-
-  on.cleanup(() => {
-    clearInterval(interval);
-  });
-
-  return count;
-};
-```
-
-When a resource has metadata, the initial value of the metadata is passed to the
-`use` function as the second argument:
-
-```ts
-const interval = Cell(1000);
-const counter = use(Counter, {
-  within: lifetime,
-  metadata: {
-    interval,
-    count: 0,
-  },
-});
-```
-
-Now, whenever the `interval` cell changes, the resource constructor will be
-re-evaluated, but the `count` will be preserved.
-
-> In general, it's a good idea to avoid trying to maintain state across resource
-> runs. It's sometimes necessary, but it maakes it possible to create resources
-> with incoherent values, so you should try to think of an alternative if
-> possible.
-
-## Semantics Summary
-
-1. A resource blueprint is instantiated with a _lifetime_ and returns a
-   _resource instance_.
-2. When a resource run is evaluated:
-   1. The previous resource run, if it exists, is finalized.
-   2. Its constructor is evaluated as a formula, and its dependencies are the
-      dependencies of that formula.
-3. When a resource instance's lifetime is finalized:
-   1. Its current resource run is finalized.
-   2. Any instance finalizers are run.
-4. Whenever a resource instance is evaluated (i.e. its value is read):
-   1. Its current resource run is validated.
-      1. If it is invalid, a new resource run is created and the resource's
-         constructor is evaluated.
-   2. If the instance value is a reactive value, the resource instance
-      is evaluated to the current value of that reactive value.
-
-### Instance Value
-
-While assimilation is often useful, a resource's instance value does not
-**need** to be a reactive value. For example, it could be an instance of an
-object that stores a cell and exposes reactive getters:
-
-This is the usual shape for public APIs backed by reactive storage: keep the
-cell private, and expose domain properties or methods that read the cell. See
-the public API guidance in
-[Starbeam Invariants](https://github.com/starbeamjs/starbeam/blob/main/docs/INVARIANTS.md#public-apis-expose-domain-concepts-not-reactive-storage).
-
-```ts
-const Stopwatch = Resource(({ on }) => {
-  const now = Cell(Date.now());
-
-  const timer = setInterval(() => {
-    now.set(Date.now());
-  }, 1000);
-
-  on.cleanup(() => {
-    clearInterval(timer);
+    return () => clearInterval(timer);
   });
 
   return {
-    get now() {
+    get formatted() {
       return new Intl.DateTimeFormat().format(now.current);
     },
   };
 });
 ```
 
-Instances of `Stopwatch` are methods with a reactive `now` property which will
-change when the interval ticks.
+Return domain-shaped values from resources. Keep cells and formulas private, and
+expose getters or methods that read them.
 
-## Resource Runs in More Detail
+## Consuming resources
 
-A resource _instance_ is a long-lived reactive value that exists until the
-resource is finalized. A resource instance has a number of _resource runs_ over
-its lifetime.
+Framework adapters own component scheduling and finalization. Use the adapter
+API for your framework:
 
-A resource is a reactive value that evaluates to its _current value_.
+- React and Preact: pass a resource blueprint to `useResource()` from the
+  framework adapter.
+- Vue: pass a resource blueprint to `setupResource()` from `@starbeam/vue`.
 
-### Evaluating the Constructor
-
-The steps for evaluating the constructor are:
-
-1. Evaluate the resource's constructor formula. Evaluating the formula:
-   1. Collects the run's reactive dependencies.
-   2. Collects a list of the run's cleanup functions.
-   3. Links any resources created within the run to the run's lifetime. If the
-      same resource instance was used in a previous run, this _adopts_ the
-      resource.
-
-2. Run finalizers for the previous resource run.
-   1. Run its cleanup functions.
-   2. Finalize any child resources that were not adopted by the new run.
-
-## Evaluating a Resource
-
-A resource's dependencies are the combination of:
-
-- The dependencies of the resource's instance formula.
-- The dependencies of the current resource run (its constructor).
-
-This means that a resource will invalidate if its instance formula invalidates
-_or_ if its constructor invalidates.
-
-Evaluating a resource:
-
-1. Validate the resource run. If the resource run is invalid, [evaluate the
-   constructor](#evaluating-the-constructor).
-2. Evaluate the resource's instance formula.
-
-## Composing Resources
-
-The `use` method makes it possible for a resource to instantiate other
-resources within the lifetime of the parent resource.
-
-There are several aspects of the design that make it easier to compose
-resources.
-
-### Creating a Child Resource With `use`
+The low-level `setupResource()` export from `@starbeam/resource` is for manual
+or adapter-facing setup:
 
 ```ts
-const Channel = Resource(({ use }) => {
-  const socket = use(Socket);
+import { setupResource } from "@starbeam/resource";
+
+const { value: stopwatch, sync } = setupResource(Stopwatch);
+
+sync();
+stopwatch.formatted;
+```
+
+Manual callers must arrange finalization with Starbeam runtime scopes. Most app
+code should use a framework adapter instead.
+
+## API reference
+
+### `Resource(constructor)`
+
+Creates a resource blueprint.
+
+```ts
+const blueprint = Resource((resource) => {
+  resource.on.sync(() => {
+    // run in the sync phase
+    return () => {
+      // cleanup for this sync
+    };
+  });
+
+  return value;
 });
 ```
 
-In this case, the Socket constructor is evaluated during `Channel`'s
-constructor, and its instance is linked to the current run. Whenever the current
-run is finalized, the Socket instance is finalized as well.
+The constructor runs during setup and returns the stable resource value. It
+receives a resource definition object with `on` hooks and `use()`.
 
-This `use` works just like the imported `use` function, except that you don't
-specify a lifetime. Instead, the lifetime is the current resource run.
+### `resource.use(childBlueprint)`
 
-### Reusing a Resource
+Sets up a child resource under the current resource and returns the child value.
+When the parent syncs, child resources sync after the parent.
+
+### `resource.on.sync(handler)`
+
+Registers the sync handler for the resource. The caller or framework schedules
+`sync`; creating a resource does not run sync work by itself.
+
+If the handler returns a cleanup function, Starbeam runs it before the next sync
+and when the owning scope finalizes.
+
+### `resource.on.finalize(handler)`
+
+Registers cleanup for the resource's owning scope. Finalizers run when that
+scope finalizes.
+
+### `setupResource(intoBlueprint)`
+
+Low-level setup for adapter and manual integration code. It accepts a resource
+blueprint or a function that returns one, and returns:
 
 ```ts
-const socket = use(Socket, { within: owner });
+{
+  value: T;
+  sync: () => void;
+}
+```
 
-const Channel = Resource(({ use }) => {
-  const socket = use(socket);
+`value` is stable. `sync` is a reactive formula function that runs the resource
+sync phase when called.
+
+### `ResourceList(list, options)`
+
+Creates a keyed list of child resources from an iterable.
+
+```ts
+ResourceList(items, {
+  key: (item) => item.id,
+  map: (item) => ItemResource(item),
 });
 ```
 
-In this case, `socket`'s lifetime is linked to the current run. Whenever the
-current run is finalized, the Socket instance is finalized as well _unless_ it
-was adopted by the next run.
+The list resource keeps child resources stable by key, syncs the list shape, and
+then syncs the child resources.
 
-> `ResourceList` uses this feature to dynamically create child resources that are
-> automatically cleaned up when they aren't used anymore.
+### `SyncTo(constructor)`
+
+Creates a lower-level sync blueprint with `on.sync()` and `on.finalize()` but no
+child-resource helper. Prefer `Resource()` for resource authoring.
+
+### `PrimitiveSyncTo(define)`
+
+Lowest-level sync primitive. It is useful for integration code that needs to
+define setup, sync, optional finalization, and a stable value directly.
+
+## Semantics
+
+- Setup creates the stable resource value.
+- Sync work is scheduled by the caller or framework adapter.
+- A sync cleanup runs before the next sync and when the owning scope finalizes.
+- Child resources created with `resource.use()` sync after the parent resource.
+- Finalizers run when the owning scope finalizes.
+
+## What this package does not do
+
+- It does not own React, Preact, or Vue scheduling. Use the framework adapters.
+- It does not replace adapter APIs such as React/Preact `useResource()` or Vue
+  `setupResource()`.
+- It does not provide the old `use(blueprint, { within })` API.
+- It does not accept resource metadata objects.
+- It does not provide `Resource.withArgs()`.

--- a/packages/universal/resource/README2.md
+++ b/packages/universal/resource/README2.md
@@ -1,30 +1,4 @@
-# Resource Lifecycle
+# Obsolete
 
-## A Resource Blueprint
-
-```ts
-const Stopwatch = Resource(({ on }) => {
-  const now = Cell(Date.now());
-
-  on.setup(() => {
-    const timer = setInterval(() => {
-      now.set(Date.now());
-    });
-
-    return () => {
-      clearInterval(timer);
-    };
-  });
-
-  return now;
-});
-
-const FormattedNow = Resource.withArgs((locale: Reactive<string>) => {
-  const now = use(Stopwatch);
-  const formatter = CachedFormula(
-    () => new Intl.DateTimeFormat(locale.current)
-  );
-
-  return Formula(() => formatter().format(now()));
-});
-```
+This file is obsolete. The current `@starbeam/resource` API is documented in
+[README.md](./README.md).


### PR DESCRIPTION
## Summary

- Rewrites the `@starbeam/resource` README around the current lifecycle API.
- Documents the resource audience: resource authors and framework-agnostic library authors first, app authors when authoring reusable resources, adapter authors at the low-level setup boundary.
- Replaces stale `use`, `{ within }`, `on.setup`, and `on.cleanup` examples with current `Resource()`, `on.sync()`, `on.finalize()`, `resource.use()`, and `setupResource()` vocabulary.
- Replaces `README2.md` with an obsolete stub pointing to the canonical README.
- Marks the resource README conflict as resolved in the package-surface triage doc.

## Validation

- `pnpm exec prettier --check packages/universal/resource/README.md packages/universal/resource/README2.md docs/PACKAGE-SURFACE-TRIAGE.md`
- `git diff --check -- packages/universal/resource/README.md packages/universal/resource/README2.md docs/PACKAGE-SURFACE-TRIAGE.md`
- stale vocabulary grep for old resource docs terms
- `pnpm vitest --run packages/universal/resource/tests`
- pre-commit: `pnpm test:workspace:types`
- pre-commit: `pnpm test:workspace:lint`

## Notes

Prepare / Execute / Review (PER) 6b is docs-only. Existing local edits in `.vscode/extensions.json` and `packages/universal/renderer/tests/smoke.spec.ts` are intentionally unstaged and not part of this PR.