### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Why
+
+<!-- What problem does this solve? What decision or context should reviewers know first? -->
+
+## What changed
+
+<!-- Briefly summarize the change. -->
+
+## Reviewer notes (optional)
+
+<!-- Optional. Delete this section if there is nothing specific reviewers should know. -->
+
+## User-facing changes (optional)
+
+<!-- Optional. Delete this section unless this PR changes user-visible behavior, APIs, docs, or migration guidance. -->


### PR DESCRIPTION
## Why

Give PR authors a lightweight default structure that starts with the rationale instead of validation details.

## What changed

- Adds `.github/pull_request_template.md`.
- Puts `Why` first.
- Includes `What changed`.
- Marks `Reviewer notes` and `User-facing changes` as optional in the headings.
- Tells authors to delete optional sections when they do not apply.
- Does not include a validation section.

## Reviewer notes

Existing local edits in `.vscode/extensions.json` and `packages/universal/renderer/tests/smoke.spec.ts` are intentionally unstaged and not part of this PR.