### PR TITLE
docs(renderer): confirm adapter-author boundary

### DIFF
--- a/docs/PACKAGE-SURFACE-PER-ROADMAP.md
+++ b/docs/PACKAGE-SURFACE-PER-ROADMAP.md
@@ -177,8 +177,12 @@ every public lifecycle API. Renderer is the adapter-author kit that now owns
 - **6e. Modifier cleanup:** completed docs-only. `@starbeam/modifier` stays
   internal historical evidence. Repo removal and npm deprecation are separate
   follow-ups and were not performed in this PER.
-- **6f. Renderer confirmation:** confirm renderer's adapter-author boundary now
-  that element-resource setup moved there.
+- **6f. Renderer confirmation:** completed docs-only. `@starbeam/renderer`
+  remains the public adapter-author kit. `setupElementResource()` is the shared
+  setup/finalization primitive for element-backed resources, while framework
+  adapters still own element delivery, scheduling, runtime subscription, value
+  publication, and replacement/unmount timing. No export, manifest, API, or
+  artifact change was made.
 
 **Possible outcomes:**
 
@@ -204,8 +208,16 @@ registry changes. `@starbeam/modifier` is internal historical evidence, and
 package is a later code cleanup. Deprecating the historical npm package is a
 separate release-owner action.
 
-**Validation:** docs diff for PER6a/PER6c/PER6d/PER6e. Package-surface checks
-only if a later sub-arc changes manifests, exports, or generated artifacts.
+**PER6f conclusion:** The renderer boundary is confirmed without package surface
+changes. `@starbeam/renderer` stays public for framework adapter authors, not app
+code. The current exports already match that story: manager/lifecycle vocabulary,
+shared manager helpers, resource conversion, and `setupElementResource()`. Vue
+and Svelte use `setupElementResource()` for direct element-delivery APIs; React
+and Preact keep element-resource setup inside hook/resource machinery.
+
+**Validation:** docs diff for PER6a/PER6c/PER6d/PER6e/PER6f. Package-surface
+checks only if a later sub-arc changes manifests, exports, or generated
+artifacts.
 
 ## 7. Public primitive split: `@starbeam/reactive`
 

--- a/docs/PACKAGE-SURFACE-TRIAGE.md
+++ b/docs/PACKAGE-SURFACE-TRIAGE.md
@@ -53,7 +53,7 @@ not settle final public/private status.
 | `@starbeam/service`   | Low-level direct API; adapter APIs preferred | Low-level app-scoped API       | Used by renderer/adapter lifetimes   | Not primary                    | Adapter support and lifecycle wiring  | PER6c/PER6d: keep public low-level kernel; no universal re-export now.              |
 | `@starbeam/modifier`  | No direct API currently                      | No direct API currently        | Historical element-attachment kernel | Not primary                    | Cleanup/deprecation candidate         | PER6e: internal historical evidence; repo cleanup and npm deprecation are separate. |
 | `@starbeam/universal` | App/library authoring umbrella               | App/library authoring umbrella | May re-export shared concepts        | Should not expose raw protocol | Own public framework-agnostic story   | PER6d: umbrella over framework-neutral authoring concepts; export completion later. |
-| `@starbeam/renderer`  | Not direct API                               | Not direct API                 | Primary adapter-author kit           | Possible implementor boundary  | Own shared setup/finalization kernels | Confirm adapter-author boundary in 6f.                                              |
+| `@starbeam/renderer`  | Not direct API                               | Not direct API                 | Primary adapter-author kit           | Possible implementor boundary  | Own shared setup/finalization kernels | PER6f: adapter-author boundary confirmed; no package surface change.                |
 
 Current conflicts to preserve for later PERs:
 
@@ -73,12 +73,15 @@ Current conflicts to preserve for later PERs:
   `ResourceList`, `SyncTo`, and `PrimitiveSyncTo` stay direct
   `@starbeam/resource` imports pending a later export-completion PER.
 - `@starbeam/renderer` is the adapter-author kit. It should not become the
-  app/library umbrella to resolve lifecycle package placement.
+  app/library umbrella to resolve lifecycle package placement. PER6f confirms
+  the current exports already match that story: manager/lifecycle vocabulary,
+  shared manager helpers, resource conversion, and `setupElementResource()`.
 
-**What PER6a/PER6c/PER6d/PER6e do not decide:** final package deprecations,
-export moves, manifest changes, generated artifact changes, or package README
-rewrites. Those belong in later PER6 sub-arcs after the audience, service
-placement, umbrella shape, and modifier cleanup policy are explicit.
+**What PER6a/PER6c/PER6d/PER6e/PER6f do not decide:** final package
+deprecations, export moves, manifest changes, generated artifact changes, or
+package README rewrites. Those belong in later PER6 sub-arcs after the audience,
+service placement, umbrella shape, modifier cleanup policy, and renderer boundary
+are explicit.
 
 ### Modifier / DOM attachment decision frame
 


### PR DESCRIPTION
## Why

PER6f closes the lifecycle package disposition arc by confirming that `@starbeam/renderer` already has the right public audience: framework adapter authors, not app code.

## What changed

- Marks PER6f completed as docs-only.
- Records `@starbeam/renderer` as the public adapter-author kit.
- Confirms `setupElementResource()` as shared setup/finalization vocabulary for element-backed resources.
- Records that framework adapters still own element delivery, scheduling, runtime subscription, value publication, and replacement/unmount timing.
- Records that no export, manifest, API, or artifact change was made.

## Reviewer notes (optional)

Prepare / Execute / Review (PER) 6f is docs-only. Existing local edits in `.vscode/extensions.json` and `packages/universal/renderer/tests/smoke.spec.ts` are intentionally unstaged and not part of this PR.