### PR TITLE
docs(reactive): classify public primitive surface

### DIFF
--- a/docs/PACKAGE-SURFACE-PER-ROADMAP.md
+++ b/docs/PACKAGE-SURFACE-PER-ROADMAP.md
@@ -227,6 +227,11 @@ wiring, debug, and tracking-frame internals?
 **Current evidence:** `@starbeam/reactive` is useful public surface area, but it
 also exports low-level substrate.
 
+PER7 classifies the current surface before moving exports. The package stays
+public for primitive reactive values. Tracking-frame exports, runtime
+registration, protocol helpers, and debug wiring remain exported for now because
+current adapters, runtime packages, and debug setup import them directly.
+
 **Prepare should classify:**
 
 - app/library-facing primitives;
@@ -240,7 +245,17 @@ also exports low-level substrate.
 - export cleanup plan;
 - package split proposal such as `@starbeam/reactivity`.
 
-**Validation:** declaration and artifact inspection before any export move.
+**PER7 conclusion:** The primitive split is recorded as a taxonomy, with no
+manifest, export, generated artifact, or runtime behavior change. The
+app/library-facing primitive surface is `Cell`, `Marker`, `Formula`,
+`CachedFormula`, `Static`, `read`, and primitive helper types. Runtime
+registration, tracking frames, tag/protocol guards, and debug setup are not
+app/library primitives, but they cannot be hidden until their adapter/runtime
+callers have a replacement import path. A package split such as
+`@starbeam/reactivity` is not justified by the current evidence.
+
+**Validation:** docs diff for the taxonomy. Declaration and artifact inspection
+before any later export move.
 
 ## 8. Protocol surfaces and compatibility policy
 

--- a/docs/PACKAGE-SURFACE-TRIAGE.md
+++ b/docs/PACKAGE-SURFACE-TRIAGE.md
@@ -83,6 +83,44 @@ package README rewrites. Those belong in later PER6 sub-arcs after the audience,
 service placement, umbrella shape, modifier cleanup policy, and renderer boundary
 are explicit.
 
+### Reactive primitive split
+
+PER7 classifies `@starbeam/reactive` without moving exports. The package
+remains public because primitive reactive values are direct library-author
+building blocks. Its current root export is broader than that app/library
+primitive story: framework adapters, runtime setup, debug setup, and protocol
+code also import from it today.
+
+**App/library primitive surface:** keep `Cell`, `Marker`, `Formula`, and
+`CachedFormula` public. These are the documented reactive values.
+
+**Primitive helpers and authoring types:** keep `Static`, `read`,
+`CellOptions`, `Equality`, `FormulaFn`, and `ReadValue` public for now. `Static`
+and `read` are already part of the umbrella surface, and the helper types support
+public APIs.
+
+**Ambiguous helper surface:** keep `isReactive`, `intoReactive`, and
+`isFormulaFn` exported for now. Decide later whether each is author-facing
+convenience or adapter/runtime helper.
+
+**Adapter/runtime tracking-frame substrate:** `startFrame`, `finishFrame`,
+`TrackingFrame`, `StartTrackingFrame`, and the related frame types are not
+app/library primitives. Do not hide them until Vue and Preact have replacement
+import paths.
+
+**Runtime/protocol wiring:** `defineRuntime` and `isTagged` are not app/library
+primitives. Keep them until runtime/protocol ownership is settled.
+
+**Debug wiring:** `DEBUG`, `defineDebug`, and `UNKNOWN_REACTIVE_VALUE` are not
+primitive authoring API. Keep `DEBUG` under review because it is re-exported
+through `@starbeam/universal`.
+
+This is a taxonomy result, not an export cleanup. Later work may move
+tracking-frame APIs toward an adapter-author or runtime-owned surface, move
+debug setup behind debug/runtime initialization, or tighten `@starbeam/universal`
+re-exports. Those changes need declaration and artifact inspection because
+published JavaScript and generated declarations are part of the package surface.
+
 ### Modifier / DOM attachment decision frame
 
 Direct imports of `@starbeam/modifier` are not the decision heuristic. The

--- a/packages/universal/reactive/README.md
+++ b/packages/universal/reactive/README.md
@@ -1,5 +1,16 @@
 This package contains the implementations of the reactive primitives.
 
+## Package surface status
+
+`@starbeam/reactive` is public for primitive reactive values such as `Cell`,
+`Marker`, `Formula`, and `CachedFormula`.
+
+The package currently also exports lower-level tracking-frame, runtime setup,
+protocol, and debug helpers used by Starbeam adapters and runtime packages.
+Those exports are not the app/library primitive surface described in this
+README. They remain exported for compatibility while their long-term package
+home is decided.
+
 Reactive primitives must be used with an implementation of `Runtime`, which
 basically means that they must be used together with `@starbeam/runtime`.
 


### PR DESCRIPTION
## Why

`@starbeam/reactive` is public for primitive reactive values, but its current root export also includes tracking-frame, runtime/protocol, and debug wiring used by Starbeam internals and adapters. PER7 needs to record that split before any export movement.

## What changed

- Records the Prepare / Execute / Review (PER) 7 conclusion in the package-surface roadmap.
- Adds a reactive export-family taxonomy to the package-surface triage doc.
- Notes in the `@starbeam/reactive` README that lower-level exports are compatibility surface for now, not the app/library primitive API described by the README.
- Makes no manifest, export, generated artifact, or runtime behavior changes.

## Reviewer notes (optional)

Docs-only. Checked Prettier and whitespace for the changed docs. Pre-commit also ran workspace typecheck and lint.

Existing local edits in `.vscode/extensions.json` and `packages/universal/renderer/tests/smoke.spec.ts` are intentionally unstaged and not part of this PR.