### PR TITLE
docs(surface): document protocol surface policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![npm version](https://badge.fury.io/js/@starbeam%2Fcore.svg)](https://badge.fury.io/js/@starbeam%2Fcore)
+[![npm version](https://badge.fury.io/js/@starbeam%2Funiversal.svg)](https://badge.fury.io/js/@starbeam%2Funiversal)
 
 Starbeam is a new kind of reactive library. It makes reactive programming simple and fun, and **it works with your existing JavaScript framework.**
 
@@ -19,7 +19,12 @@ The package READMEs have additional implementor-focused documentation:
 
 - [@starbeam/shared]: Primitive Starbeam fundamentals. This package enables multiple
   copies of Starbeam to interoperate, including across major versions of Starbeam.
-- [@starbeam/tags]: The core of Starbeam's demand-driven validation system.
+- [@starbeam/runtime]: Runtime coordination for Starbeam adapters and library
+  implementors.
+- [@starbeam/tags]: The core of Starbeam's demand-driven validation system for
+  primitive and renderer implementors.
+- [@starbeam/interfaces]: Type-only protocol substrate for Starbeam packages and
+  implementors.
 - [@starbeam/reactive]: The implementation of Starbeam's fundamental reactive
   values (cells and formulas).
 - [@starbeam/collections]: Starbeam's reactive collections: reactive
@@ -29,6 +34,8 @@ The package READMEs have additional implementor-focused documentation:
 More READMEs are coming.
 
 [@starbeam/shared]: ./packages/universal/shared/README.md
+[@starbeam/runtime]: ./packages/universal/runtime/README.md
 [@starbeam/tags]: ./packages/universal/tags/README.md
+[@starbeam/interfaces]: ./packages/universal/interfaces/README.md
 [@starbeam/reactive]: ./packages/universal/reactive/README.md
 [@starbeam/collections]: ./packages/universal/collections/README.md

--- a/docs/PACKAGE-SURFACE-PER-ROADMAP.md
+++ b/docs/PACKAGE-SURFACE-PER-ROADMAP.md
@@ -279,8 +279,22 @@ PER6 matrix and ask only what protocol/core compatibility decisions remain.
 - future `@starbeam/protocol` proposal;
 - explicit 0.9 compatibility policy for `@starbeam/core`.
 
-**Validation:** docs and package artifact inspection until export moves are
-proposed.
+**PER8 conclusion:** The protocol surface is recorded as an audience taxonomy,
+with no manifest, export, generated artifact, or runtime behavior change.
+`@starbeam/runtime` is the clearest adapter/implementor protocol package.
+`@starbeam/tags` is low-level validation substrate for primitive and rendering
+implementors, not normal app code. `@starbeam/interfaces` is published type
+substrate for Starbeam packages and implementors, not a direct app/library API.
+`@starbeam/core` is a deprecated compatibility alias for `@starbeam/universal`,
+retained for old imports while new code uses `@starbeam/universal`.
+
+A future `@starbeam/protocol` package may be clearer, but current evidence does
+not justify creating it in this PER. Export, manifest, artifact, and protocol-key
+policy changes need their own Prepare because published JavaScript and generated
+declarations are part of the release surface.
+
+**Validation:** docs diff for the taxonomy and compatibility policy. Package
+artifact inspection before any later export, manifest, or protocol-key move.
 
 ## Suggested order
 

--- a/docs/PACKAGE-SURFACE-TRIAGE.md
+++ b/docs/PACKAGE-SURFACE-TRIAGE.md
@@ -35,12 +35,12 @@ current package names are the right public surface.
 | ---------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `@starbeam/modifier`   | Internal element-attachment kernel; mandatory post-surface hardening candidate | Represents the ref/directive/modifier part of complete framework reactivity. The basic idea composes resources, element availability, and framework lifetimes. Historically backed React refs and universal element resources. | React and Preact now prove matching `useElementResource` leaves. Vue now proves that a directive can own an element resource lifetime. `@starbeam/modifier` still only exposes `ElementPlaceholder`. | Keep internal. Decide the shared element-resource vocabulary boundary before moving it into any public package.               |
 | `@domtree/*`           | Internal DOM-type substrate; tied to modifier hardening                        | Type-level DOM flavor normalization: write DOM algorithms against minimal structural DOM while preserving browser/JSDOM/range types.                                                                                           | Original DOM renderer is gone; current active leak is mostly through `@starbeam/modifier` and stale manifests.                                                                                       | Keep internal unless modifier/renderer hardening proves public authors need these types directly.                             |
-| `@starbeam/interfaces` | Decision needed / protocol surface                                             | Internal protocol type boundary for runtime/tags/reactive/debug without cycles.                                                                                                                                                | No README, special `library:interfaces`, stale-looking `src/protocol.ts`, stale `@domtree/any` manifest dependency, broad declaration leakage.                                                       | Decide whether protocol types are public. Consider a better public `@starbeam/protocol` surface or re-export strategy.        |
-| `@starbeam/tags`       | Decision needed                                                                | Validation/tag substrate extracted from runtime; core of demand-driven validation.                                                                                                                                             | Low-level implementor API, not normal app-user API.                                                                                                                                                  | Bless as implementor API or hide behind `reactive`/`runtime`.                                                                 |
-| `@starbeam/runtime`    | Decision needed                                                                | Runtime coordination, subscriptions, finalization scopes; intentionally split from reactive primitives.                                                                                                                        | README says stable for libraries but not app code; public exports are low-level.                                                                                                                     | Decide whether runtime/library authors are supported. Refresh docs if public.                                                 |
+| `@starbeam/interfaces` | Published protocol type substrate                                              | Internal protocol type boundary for runtime/tags/reactive/debug without cycles.                                                                                                                                                | Type-only package with special `library:interfaces`; not app-facing; current name is less clear than a future protocol package might be.                                                             | Keep as published type substrate for now. Document audience. Consider a future `@starbeam/protocol` only in a later PER.      |
+| `@starbeam/tags`       | Implementor validation substrate                                               | Validation/tag substrate extracted from runtime; core of demand-driven validation.                                                                                                                                             | Low-level implementor API, not normal app-user API.                                                                                                                                                  | Keep public as implementor-focused substrate for now. Do not treat as app/library API.                                        |
+| `@starbeam/runtime`    | Adapter/implementor protocol surface                                           | Runtime coordination, subscriptions, finalization scopes; intentionally split from reactive primitives.                                                                                                                        | Public exports are low-level and include some implementation-shaped pieces.                                                                                                                          | Keep public for adapters and library implementors. Keep app authors on adapter and universal APIs.                            |
 | `@starbeam/reactive`   | Public primitive surface, needs split                                          | Primitive reactive values are documented and useful to library authors.                                                                                                                                                        | Exports include runtime wiring/debug/tracking-frame substrate, not just public primitives.                                                                                                           | Keep public for primitives. Move/hide runtime wiring and tracking internals behind internal or future author-facing surfaces. |
 | `@starbeam/universal`  | Public app/library umbrella                                                    | Best current framework-agnostic entrypoint over cells, formulas, resources, and common authoring concepts.                                                                                                                     | Current lifecycle exports are intentionally partial. `Resource` is re-exported; service and resource helper exports stay direct pending later export cleanup.                                        | Document as the framework-neutral app/library umbrella. Defer export cleanup/completion to a later PER.                       |
-| `@starbeam/core`       | Compatibility decision                                                         | Deprecated alias over `@starbeam/universal`.                                                                                                                                                                                   | Root badge still points at it, but code is only a warning + re-export.                                                                                                                               | Decide old-import compatibility policy for 0.9.                                                                               |
+| `@starbeam/core`       | Deprecated compatibility alias                                                 | Deprecated alias over `@starbeam/universal`.                                                                                                                                                                                   | Code is only a warning + re-export, and lint rules forbid new imports.                                                                                                                               | Retain for old imports through 0.9 while directing new code to `@starbeam/universal`.                                         |
 
 ### Lifecycle package audience matrix
 
@@ -120,6 +120,37 @@ tracking-frame APIs toward an adapter-author or runtime-owned surface, move
 debug setup behind debug/runtime initialization, or tighten `@starbeam/universal`
 re-exports. Those changes need declaration and artifact inspection because
 published JavaScript and generated declarations are part of the package surface.
+
+### Protocol surfaces and compatibility policy
+
+PER8 classifies protocol-oriented packages without moving exports, changing
+manifests, or regenerating artifacts.
+
+**Adapter/implementor protocol:** `@starbeam/runtime` is the clearest supported
+low-level protocol package. It coordinates rendering, subscriptions, app context,
+and finalization scopes for Starbeam adapters and library implementors. It is not
+the normal app-author API; app authors should use framework adapters,
+`@starbeam/universal`, and package-level APIs such as `@starbeam/resource`.
+
+**Validation substrate:** `@starbeam/tags` is low-level demand-driven validation
+machinery. It is public for people implementing reactive primitives, renderers,
+or other protocol-level integrations, not for ordinary application code.
+
+**Type substrate:** `@starbeam/interfaces` is a published, type-only substrate
+for Starbeam packages and implementors. Its current name and generated
+declaration shape may justify a future `@starbeam/protocol` proposal, but PER8
+does not create that package or move types.
+
+**Compatibility alias:** `@starbeam/core` is a deprecated alias for
+`@starbeam/universal`. It stays available for old imports during the 0.9 line,
+while new code should import from `@starbeam/universal` or a more specific
+package. Lint rules should continue to reject new workspace imports from
+`@starbeam/core`.
+
+This is a compatibility and audience policy, not an artifact cleanup. Later work
+may hide implementation-shaped runtime exports, reserve protocol object keys,
+exclude stale declaration-only modules, or introduce a clearer protocol package.
+Each of those requires a separate Prepare with package artifact inspection.
 
 ### Modifier / DOM attachment decision frame
 

--- a/packages/universal/interfaces/README.md
+++ b/packages/universal/interfaces/README.md
@@ -1,0 +1,17 @@
+# `@starbeam/interfaces`
+
+`@starbeam/interfaces` is a type-only protocol substrate for Starbeam packages
+and implementors.
+
+It contains shared TypeScript interfaces for runtime coordination, reactive
+values, tags, debug descriptions, timestamps, and subscription callbacks. These
+types let Starbeam's packages agree on protocol shapes without introducing
+runtime dependency cycles.
+
+This package is not the normal app-author API. App authors should usually import
+from a framework adapter, `@starbeam/universal`, or a more specific package such
+as `@starbeam/reactive` or `@starbeam/resource`.
+
+The current package name and export shape are compatibility surface. A later
+Prepare / Execute / Review (PER) cycle may decide whether a clearer
+`@starbeam/protocol` package should own these types.

--- a/packages/universal/runtime/README.md
+++ b/packages/universal/runtime/README.md
@@ -4,6 +4,17 @@
 
 `@starbeam/runtime` is part of Starbeam, a library for building and using reactive objects in any framework.
 
+## Package surface status
+
+`@starbeam/runtime` is a public low-level package for Starbeam adapters and
+library implementors. It is not the normal app-author API. App authors should
+usually use a framework adapter, `@starbeam/universal`, or a package-level API
+such as `@starbeam/resource`.
+
+The current public surface is compatibility surface for adapter/runtime code.
+Some exports are implementation-shaped and may move behind clearer protocol
+boundaries in a later Prepare / Execute / Review (PER) cycle.
+
 ## Primitive
 
 `@starbeam/runtime` is stable, with the same [semver policy as Starbeam][starbeam semver policy].
@@ -79,44 +90,16 @@ These steps allow you to implement _framework-agnostic_ [resources] that can cor
 
 **In practice, these considerations are bundled together into the high-level "Stateful Formula" construct provided by [@starbeam/reactive].**
 
-## Timeline
+## Historical timeline model
 
-The `Timeline` in `@starbeam/runtime` coordinates these phases.
+Older Starbeam design notes described a public `Timeline` or `TIMELINE` export.
+That is no longer the current package surface. The current runtime entrypoint is
+the `RUNTIME` object plus focused helpers for rendering, subscriptions,
+finalization scopes, and app context.
 
-It starts out in the _Actions_ phase, which allows free access to the _data universe_. As soon as a _data cell_ in the _data universe_ is mutated, the `Timeline` schedules a _Render_ phase using the configured scheduler. By default, this will schedule a _Render_ phase during a microtask checkpoint, which occurs asynchronously, but before the next paint.
-
-### Scheduling
-
-The `Timeline` can be configured with a `Coordinator` (see [@starbeam/schedule]), which controls the exact details of the timeline's timing.
-
-The default behavior automatically schedules the next _Render_ phase using a microtask checkpoint, which means that it will happen asynchronously, but before the next time the browser paints the page. The purpose of the `Coordinator` is to allow you to make multiple mutations to the _data universe_ before a _Render_ phase occurs.
-
-You can specify a custom `Coordinator` to use an alternative strategy. For example, if you are writing a single-file demo, the entire file will finish running before a microtask checkpoint. You could create an API to use a single-file demo that automatically schedules _Render_ phases at appropriate times.
-
-Finally, you can also explicitly schedule a _Render_ phase, which will supersede the `Coordinator`'s policy and simply wait until you're ready to render.
-
-```ts
-import { TIMELINE } from "@starbeam/runtime";
-import { Cell } from "@starbeam/reactive";
-
-const person = reactive({
-  id: null,
-  name: "@tomdale",
-});
-const name = Cell("Tom");
-const userId = Cell(null);
-
-function multiStepProcess(name, url) {
-  const render = TIMELINE.manualRenderPhase();
-
-  person.name = name;
-
-  fetch(url).then((data) => {
-    person.id = data.id;
-    render();
-  });
-}
-```
+The rest of this document still uses the timeline vocabulary as a conceptual
+model for Starbeam's action/render cycle. Treat it as architecture background,
+not current API reference.
 
 ## Moving Along the Timeline
 
@@ -170,10 +153,10 @@ Starbeam uses the _structured finalizer_ approach to make finalization composabl
 
 ### Example: The Resource Pattern
 
-Let's see how this all fits together. We'll use the resource pattern from `@starbeam/reactive` to create an `ElementSize` resource.
+Let's see how this all fits together. We'll use the resource pattern from `@starbeam/resource` to create an `ElementSize` resource.
 
 ```ts
-import { Resource } from "@starbeam/reactive";
+import { Resource } from "@starbeam/resource";
 
 export function ElementSize(element: Element) {
   return Resource((resource) => {

--- a/packages/universal/tags/README.md
+++ b/packages/universal/tags/README.md
@@ -1,5 +1,15 @@
 This package contains the implementation of "tags".
 
+## Package surface status
+
+`@starbeam/tags` is a low-level package for Starbeam implementors. It supports
+reactive primitives, renderers, and other protocol-level integrations that need
+to inspect or compose validation tags.
+
+It is not the normal app-author API. Most Starbeam code works with reactive
+values such as `Cell`, `Formula`, and `CachedFormula`, and lets those values own
+their tags internally.
+
 All reactive value are tagged values: they represent a JavaScript value and have
 a tag that can be used to composably validate the value.
 


### PR DESCRIPTION
## Why

The package-surface roadmap has classified lifecycle and reactive primitive surfaces. The remaining low-level question is which protocol-oriented packages are supported public API and what compatibility policy applies to old imports.

## What changed

- Records the Prepare / Execute / Review (PER) 8 conclusion in the package-surface roadmap.
- Updates package-surface triage rows for `@starbeam/interfaces`, `@starbeam/tags`, `@starbeam/runtime`, and `@starbeam/core`.
- Adds a protocol-surface taxonomy and 0.9 `@starbeam/core` compatibility policy.
- Adds an `@starbeam/interfaces` README that frames the package as type-only protocol substrate.
- Clarifies `@starbeam/runtime` and `@starbeam/tags` as implementor-focused packages, not normal app-author APIs.
- Updates the root README badge from `@starbeam/core` to `@starbeam/universal` and links implementor-focused READMEs.
- Makes no manifest, export, generated artifact, or runtime behavior changes.

## Reviewer notes (optional)

Docs-only. Checked Prettier and whitespace for the changed docs. Pre-commit also ran workspace typecheck and lint.

Existing local edits in `.vscode/extensions.json` and `packages/universal/renderer/tests/smoke.spec.ts` are intentionally unstaged and not part of this PR.