### PR TITLE
feat(universal): add ResourceList to canonical surface

### DIFF
--- a/.github/instructions/pr-review-comments.instructions.md
+++ b/.github/instructions/pr-review-comments.instructions.md
@@ -1,0 +1,44 @@
+---
+description: "Use when: addressing PR review comments, Copilot comments, inline review threads, or reviewer feedback on a pull request."
+---
+
+# PR Review Comment Practice
+
+When addressing PR review comments, keep the conversation attached to the review
+thread that raised the issue.
+
+## Default workflow
+
+1. Read the actual diff and the unresolved review thread before changing code.
+2. Make the smallest change that addresses the specific comment.
+3. Validate the change locally as needed, but do not turn the validation checklist
+   into PR-description or PR-comment ceremony.
+4. Reply inline on the original review thread when a reply is needed.
+5. Resolve the review thread once the comment has been addressed and you are able
+   to resolve it.
+
+## Inline replies
+
+Respond to Copilot and reviewer comments inline, on the original review thread.
+This keeps the fix, the reasoning, and the reviewer context together.
+
+Do not post a separate top-level PR comment just to say an inline comment was
+addressed. A top-level follow-up is only appropriate when there is something
+holistic for reviewers to know, such as:
+
+- a cross-cutting explanation that applies to multiple threads;
+- a meaningful change in direction from the original PR description;
+- a caveat, failed validation, or remaining reviewer decision that is not local
+  to one thread.
+
+## Resolving threads
+
+After addressing a review thread:
+
+- resolve it if the platform allows you to;
+- do not leave addressed Copilot threads open as a progress log;
+- do not resolve threads that still need reviewer input or where the fix is only
+  partial.
+
+If an inline reply endpoint or resolve action is unavailable, mention that in the
+summary rather than compensating with a routine top-level PR comment.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 
 ## Reviewer notes (optional)
 
-<!-- Optional. Delete this section if there is nothing specific reviewers should know. -->
+<!-- Optional. Delete this section if there is nothing specific reviewers should know. Do not enumerate local validation steps; mention only unexpected failures, caveats, or reviewer-relevant commands. -->
 
 ## User-facing changes (optional)
 

--- a/docs/PACKAGE-SURFACE-PER-ROADMAP.md
+++ b/docs/PACKAGE-SURFACE-PER-ROADMAP.md
@@ -296,6 +296,44 @@ declarations are part of the release surface.
 **Validation:** docs diff for the taxonomy and compatibility policy. Package
 artifact inspection before any later export, manifest, or protocol-key move.
 
+## 9. Universal canonical import surface
+
+**Question:** What should `@starbeam/universal` export as the canonical
+framework-neutral app/library authoring surface?
+
+PER6d classified `@starbeam/universal` as the app/library umbrella, but deferred
+export completion. PER7 and PER8 classified reactive and protocol exports so the
+umbrella can distinguish canonical app/library imports from compatibility
+exports.
+
+**Prepare should classify:**
+
+- canonical reactive/resource exports to teach in app and library examples;
+- resource helpers that belong in the umbrella;
+- service, setup, sync, debug, runtime, and protocol exports that should stay
+  direct-package imports or compatibility-only exports;
+- generated declaration and JavaScript artifact effects of any export change.
+
+**Possible outcomes:**
+
+- docs-only canonical import policy;
+- add missing app/library resource exports;
+- mark lower-level compatibility exports as `@internal` without removing them;
+- defer removal of debug/runtime/protocol exports to later protocol cleanup.
+
+**PER9 conclusion:** `@starbeam/universal` is the canonical framework-neutral
+app/library authoring surface. It re-exports `ResourceList` alongside
+`Resource`, `Cell`, `Marker`, `Formula`, `CachedFormula`, `Static`, `read`, and
+their authoring types. Low-level setup/sync APIs (`setupResource`, `SyncTo`, and
+`PrimitiveSyncTo`) remain direct `@starbeam/resource` imports. Service APIs stay
+direct `@starbeam/service` imports or framework adapter APIs. Existing
+debug/runtime/protocol exports remain for compatibility and are not taught as
+the app/library surface.
+
+**Validation:** universal/resource/core typechecks, universal build, debug
+bootstrap, package-surface pack verification, and artifact inspection when the
+`ResourceList` export is added.
+
 ## Suggested order
 
 1. Renderer reflow and README closeout.
@@ -306,6 +344,7 @@ artifact inspection before any later export, manifest, or protocol-key move.
 6. Lifecycle package disposition and audience matrix.
 7. `@starbeam/reactive` primitive split.
 8. Protocol surfaces and core compatibility policy.
+9. Universal canonical import surface.
 
 The first five are cleanup and confidence work following the DOM attachment arc.
 The last three reopen the broader package-surface roadmap.

--- a/docs/PACKAGE-SURFACE-TRIAGE.md
+++ b/docs/PACKAGE-SURFACE-TRIAGE.md
@@ -39,7 +39,7 @@ current package names are the right public surface.
 | `@starbeam/tags`       | Implementor validation substrate                                               | Validation/tag substrate extracted from runtime; core of demand-driven validation.                                                                                                                                             | Low-level implementor API, not normal app-user API.                                                                                                                                                  | Keep public as implementor-focused substrate for now. Do not treat as app/library API.                                        |
 | `@starbeam/runtime`    | Adapter/implementor protocol surface                                           | Runtime coordination, subscriptions, finalization scopes; intentionally split from reactive primitives.                                                                                                                        | Public exports are low-level and include some implementation-shaped pieces.                                                                                                                          | Keep public for adapters and library implementors. Keep app authors on adapter and universal APIs.                            |
 | `@starbeam/reactive`   | Public primitive surface, needs split                                          | Primitive reactive values are documented and useful to library authors.                                                                                                                                                        | Exports include runtime wiring/debug/tracking-frame substrate, not just public primitives.                                                                                                           | Keep public for primitives. Move/hide runtime wiring and tracking internals behind internal or future author-facing surfaces. |
-| `@starbeam/universal`  | Public app/library umbrella                                                    | Best current framework-agnostic entrypoint over cells, formulas, resources, and common authoring concepts.                                                                                                                     | Current lifecycle exports are intentionally partial. `Resource` is re-exported; service and resource helper exports stay direct pending later export cleanup.                                        | Document as the framework-neutral app/library umbrella. Defer export cleanup/completion to a later PER.                       |
+| `@starbeam/universal`  | Public app/library umbrella                                                    | Best current framework-agnostic entrypoint over cells, formulas, resources, and common authoring concepts.                                                                                                                     | PER9 adds `ResourceList` and documents compatibility-only lower-level exports. Service and low-level setup/sync helpers stay direct package imports.                                                 | Use as the canonical framework-neutral app/library import surface.                                                            |
 | `@starbeam/core`       | Deprecated compatibility alias                                                 | Deprecated alias over `@starbeam/universal`.                                                                                                                                                                                   | Code is only a warning + re-export, and lint rules forbid new imports.                                                                                                                               | Retain for old imports through 0.9 while directing new code to `@starbeam/universal`.                                         |
 
 ### Lifecycle package audience matrix
@@ -68,10 +68,9 @@ Current conflicts to preserve for later PERs:
   API. Removing the repo package is a later code cleanup. Deprecating the
   historical npm package is a separate release-owner action.
 - `@starbeam/universal` is the app/library umbrella for framework-neutral
-  authoring concepts, but its current lifecycle exports are partial. `Resource`
-  remains the current lifecycle authoring re-export. `setupResource`,
-  `ResourceList`, `SyncTo`, and `PrimitiveSyncTo` stay direct
-  `@starbeam/resource` imports pending a later export-completion PER.
+  authoring concepts. PER9 adds `ResourceList` alongside `Resource` as a
+  resource authoring re-export. `setupResource`, `SyncTo`, and
+  `PrimitiveSyncTo` stay direct `@starbeam/resource` imports.
 - `@starbeam/renderer` is the adapter-author kit. It should not become the
   app/library umbrella to resolve lifecycle package placement. PER6f confirms
   the current exports already match that story: manager/lifecycle vocabulary,
@@ -151,6 +150,30 @@ This is a compatibility and audience policy, not an artifact cleanup. Later work
 may hide implementation-shaped runtime exports, reserve protocol object keys,
 exclude stale declaration-only modules, or introduce a clearer protocol package.
 Each of those requires a separate Prepare with package artifact inspection.
+
+### Universal canonical import surface
+
+PER9 completes the first pass over `@starbeam/universal` as the canonical
+framework-neutral app/library import surface.
+
+**Canonical app/library exports:** `Cell`, `Marker`, `Formula`,
+`CachedFormula`, `Static`, `read`, `Reactive`, `Equality`, `FormulaFn`,
+`Resource`, `ResourceList`, `ResourceBlueprint`, and `IntoResourceBlueprint` are
+the imports to teach in framework-neutral examples.
+
+**Higher-level helper exports:** `FormulaList`, `Freshness`, and `Variants`
+remain exported from `@starbeam/universal`. They need fuller public docs before
+the documentation website treats them as primary concepts.
+
+**Direct package imports:** `setupResource`, `SyncTo`, and `PrimitiveSyncTo`
+remain direct `@starbeam/resource` imports. `service`, `Service`, and
+`getServiceFormula` remain direct `@starbeam/service` imports or framework
+adapter APIs.
+
+**Compatibility exports:** `DEBUG`, `DEBUG_RENDERER`, `CONTEXT`, `RUNTIME`, and
+`TAG` remain exported for existing integrations, but they are not the canonical
+app/library authoring surface. Compatibility exports may be marked `@internal`
+or moved in a later protocol/debug cleanup, but PER9 does not remove them.
 
 ### Modifier / DOM attachment decision frame
 

--- a/packages/universal/universal/CONCEPTS.md
+++ b/packages/universal/universal/CONCEPTS.md
@@ -5,7 +5,8 @@
 > APIs are the framework adapter APIs (`useService` in React/Preact,
 > `setupService` in Preact/Vue) or the low-level `@starbeam/service` package.
 > PER6d decided not to re-export service from `@starbeam/universal` now. The
-> examples below are not rewritten here.
+> examples below are not rewritten here. See [README.md](./README.md) for the
+> current canonical `@starbeam/universal` import surface.
 
 ## Factories
 

--- a/packages/universal/universal/README.md
+++ b/packages/universal/universal/README.md
@@ -1,0 +1,66 @@
+# `@starbeam/universal`
+
+`@starbeam/universal` is the framework-neutral app and library authoring
+surface for Starbeam.
+
+Use it for examples and reusable code that are not tied to a specific framework
+adapter.
+
+## Canonical imports
+
+Import Starbeam's common authoring primitives from `@starbeam/universal`:
+
+```ts
+import {
+  CachedFormula,
+  Cell,
+  Formula,
+  Marker,
+  read,
+  Resource,
+  ResourceList,
+} from "@starbeam/universal";
+```
+
+The canonical app/library surface includes:
+
+- reactive values: `Cell`, `Marker`, `Formula`, `CachedFormula`, `Static`, and
+  `read`;
+- reactive authoring types: `Reactive`, `Equality`, and `FormulaFn`;
+- resource authoring APIs: `Resource`, `ResourceList`, `ResourceBlueprint`, and
+  `IntoResourceBlueprint`;
+- higher-level reactive helpers currently exported from this package:
+  `FormulaList`, `Freshness`, and `Variants`.
+
+## Direct package imports
+
+Some public APIs are intentionally not part of the universal umbrella.
+
+Import low-level resource setup and sync helpers directly from
+`@starbeam/resource`:
+
+```ts
+import { PrimitiveSyncTo, setupResource, SyncTo } from "@starbeam/resource";
+```
+
+Import app-scoped service machinery directly from `@starbeam/service`, or prefer
+the framework adapter service APIs when writing app code:
+
+```ts
+import { getServiceFormula, service } from "@starbeam/service";
+```
+
+`@starbeam/universal` does not re-export service APIs today.
+
+## Compatibility exports
+
+`@starbeam/universal` still exports a few lower-level values for compatibility
+with existing packages and integrations. These are not the app/library authoring
+surface to teach in new examples:
+
+- debug wiring: `DEBUG`, `DEBUG_RENDERER`;
+- runtime/protocol wiring: `CONTEXT`, `RUNTIME`, `TAG`.
+
+Prefer direct package imports or adapter APIs when writing new low-level code.
+These compatibility exports may move behind clearer protocol/debug boundaries in
+a later Prepare / Execute / Review (PER) cycle.

--- a/packages/universal/universal/index.ts
+++ b/packages/universal/universal/index.ts
@@ -4,6 +4,7 @@ if (import.meta.env.DEV) {
   await setupDebug();
 }
 
+/** @internal Compatibility export for existing debug integrations. */
 export { DEBUG_RENDERER } from "./src/debug-renderer.js";
 export { FormulaList } from "./src/reactive-core/higher-level/formula-list.js";
 export { Freshness } from "./src/reactive-core/higher-level/freshness.js";
@@ -17,7 +18,6 @@ export type { Reactive } from "@starbeam/interfaces";
 export {
   CachedFormula,
   Cell,
-  DEBUG,
   type Equality,
   Formula,
   type FormulaFn,
@@ -25,9 +25,13 @@ export {
   read,
   Static,
 } from "@starbeam/reactive";
+/** @internal Compatibility export for existing debug integrations. */
+export { DEBUG } from "@starbeam/reactive";
 export {
   type IntoResourceBlueprint,
   Resource,
   type ResourceBlueprint,
+  ResourceList,
 } from "@starbeam/resource";
+/** @internal Compatibility export for existing low-level integrations. */
 export { CONTEXT, RUNTIME, TAG } from "@starbeam/runtime";

--- a/packages/universal/universal/tests/package.json
+++ b/packages/universal/universal/tests/package.json
@@ -16,6 +16,7 @@
     "@starbeam/debug": "workspace:^",
     "@starbeam/resource": "workspace:^",
     "@starbeam/runtime": "workspace:^",
+    "@starbeam/shared": "workspace:^",
     "@starbeam/universal": "workspace:^"
   },
   "devDependencies": {

--- a/packages/universal/universal/tests/resource-list.spec.ts
+++ b/packages/universal/universal/tests/resource-list.spec.ts
@@ -15,15 +15,17 @@ interface Item {
   location: string;
 }
 
-const TOM_ID = 1;
-const CHIRAG_ID = 2;
-const JOHN_ID = 3;
+enum Id {
+  Tom = 1,
+  Chirag = 2,
+  John = 3,
+}
 
 describe("ResourceList", () => {
   test("is exported from the universal authoring surface", () => {
     const items: Item[] = reactive.array([
-      { id: TOM_ID, name: "Tom", location: "NYC" },
-      { id: CHIRAG_ID, name: "Chirag", location: "NYC" },
+      { id: Id.Tom, name: "Tom", location: "NYC" },
+      { id: Id.Chirag, name: "Chirag", location: "NYC" },
     ]);
 
     const List = ResourceList(items, {
@@ -56,7 +58,7 @@ describe("ResourceList", () => {
       { active: true, label: "Chirag (NYC)" },
     ]);
 
-    items.push({ id: JOHN_ID, name: "John", location: "LA" });
+    items.push({ id: Id.John, name: "John", location: "LA" });
     sync();
 
     expect(list.current.map((item) => item.current)).toEqual([

--- a/packages/universal/universal/tests/resource-list.spec.ts
+++ b/packages/universal/universal/tests/resource-list.spec.ts
@@ -1,0 +1,76 @@
+import { reactive } from "@starbeam/collections";
+import { pushingScope } from "@starbeam/runtime";
+import { finalize } from "@starbeam/shared";
+import {
+  CachedFormula,
+  Cell,
+  Resource,
+  ResourceList,
+} from "@starbeam/universal";
+import { describe, expect, test } from "vitest";
+
+interface Item {
+  id: number;
+  name: string;
+  location: string;
+}
+
+const TOM_ID = 1;
+const CHIRAG_ID = 2;
+const JOHN_ID = 3;
+
+describe("ResourceList", () => {
+  test("is exported from the universal authoring surface", () => {
+    const items: Item[] = reactive.array([
+      { id: TOM_ID, name: "Tom", location: "NYC" },
+      { id: CHIRAG_ID, name: "Chirag", location: "NYC" },
+    ]);
+
+    const List = ResourceList(items, {
+      key: (item) => item.id,
+      map: (item) =>
+        Resource(({ on }) => {
+          const active = Cell(false);
+
+          on.sync(() => {
+            active.set(true);
+          });
+
+          on.finalize(() => {
+            active.set(false);
+          });
+
+          return CachedFormula(() => ({
+            active: active.current,
+            label: `${item.name} (${item.location})`,
+          }));
+        }),
+    });
+
+    const [scope, { sync, value: list }] = pushingScope(() => List.setup());
+
+    sync();
+
+    expect(list.current.map((item) => item.current)).toEqual([
+      { active: true, label: "Tom (NYC)" },
+      { active: true, label: "Chirag (NYC)" },
+    ]);
+
+    items.push({ id: JOHN_ID, name: "John", location: "LA" });
+    sync();
+
+    expect(list.current.map((item) => item.current)).toEqual([
+      { active: true, label: "Tom (NYC)" },
+      { active: true, label: "Chirag (NYC)" },
+      { active: true, label: "John (LA)" },
+    ]);
+
+    finalize(scope);
+
+    expect(list.current.map((item) => item.current)).toEqual([
+      { active: false, label: "Tom (NYC)" },
+      { active: false, label: "Chirag (NYC)" },
+      { active: false, label: "John (LA)" },
+    ]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1183,6 +1183,9 @@ importers:
       '@starbeam/runtime':
         specifier: workspace:^
         version: link:../../runtime
+      '@starbeam/shared':
+        specifier: workspace:^
+        version: link:../../shared
       '@starbeam/universal':
         specifier: workspace:^
         version: link:..


### PR DESCRIPTION
## Why

`@starbeam/universal` is the framework-neutral app/library umbrella, but the surface was still missing the high-level `ResourceList` resource-authoring helper and lacked canonical import guidance. This needs to be settled before writing broader Starbeam docs.

## What changed

- Re-exports `ResourceList` from `@starbeam/universal`.
- Adds a focused `ResourceList` smoke test through the universal package.
- Adds an `@starbeam/universal` README that defines canonical app/library imports, direct package imports, and compatibility exports.
- Points the historical universal concepts doc to the new README.
- Records the Prepare / Execute / Review (PER) 9 conclusion in package-surface roadmap and triage docs.
- Marks existing debug/runtime/protocol compatibility exports with `@internal` comments without removing them.

## Reviewer notes

This intentionally does not re-export `setupResource`, `SyncTo`, `PrimitiveSyncTo`, or any service APIs. Those remain direct package imports or framework adapter APIs.

Artifact inspection confirmed `ResourceList` appears in the universal JS/declaration surface and service/setup/sync exports remain absent.
