### PR TITLE
chore(vscode): update rewrap recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,6 @@
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
     "editorconfig.editorconfig",
-    "stkb.rewrap"
+    "dnut.rewrap-revived"
   ]
 }


### PR DESCRIPTION
## Why

The previous VS Code Rewrap extension recommendation points at the old extension. This updates the workspace recommendation to the maintained revived extension.

## What changed

- Replaces `stkb.rewrap` with `dnut.rewrap-revived` in VS Code extension recommendations.

## Reviewer notes

The unrelated renderer smoke test formatting churn was discarded before this PR.