### PR TITLE
docs: polish website UI

### DIFF
--- a/workspace/docs/astro.config.mjs
+++ b/workspace/docs/astro.config.mjs
@@ -8,7 +8,8 @@ export default defineConfig({
   integrations: [
     starlight({
       title: "Starbeam",
-      description: "Starbeam is a joyful reactivity engine for JavaScript applications.",
+      description:
+        "Starbeam is a joyful reactivity engine for JavaScript applications.",
       customCss: ["./src/styles/starlight.css"],
       social: [
         {

--- a/workspace/docs/src/components/BrandHero.astro
+++ b/workspace/docs/src/components/BrandHero.astro
@@ -216,8 +216,8 @@ import StarMark from "./StarMark.astro";
 
   .hero__rail {
     align-items: center;
-    background: rgb(255 255 255 / 72%);
-    border: 1px solid rgb(255 255 255 / 82%);
+    background: var(--starbeam-glass-rail);
+    border: 1px solid var(--starbeam-glass-border);
     border-radius: 1.35rem;
     box-shadow: 0 18px 55px rgb(30 36 54 / 8%);
     display: grid;

--- a/workspace/docs/src/pages/index.astro
+++ b/workspace/docs/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import BrandHero from "../components/BrandHero.astro";
+import StarMark from "../components/StarMark.astro";
 import "../styles/tokens.css";
 ---
 
@@ -16,7 +17,7 @@ import "../styles/tokens.css";
   <body>
     <header class="topbar">
       <a class="brand" href="/" aria-label="Starbeam home">
-        <span class="brand__spark" aria-hidden="true">✦</span>
+        <StarMark class="brand__mark" />
         <span>Starbeam</span>
       </a>
       <nav aria-label="Primary navigation">
@@ -97,10 +98,9 @@ import "../styles/tokens.css";
     text-transform: uppercase;
   }
 
-  .brand__spark {
-    color: var(--starbeam-beam);
-    font-size: 1.5rem;
-    letter-spacing: 0;
+  .brand__mark {
+    filter: drop-shadow(0 8px 14px rgb(30 36 54 / 10%));
+    --star-mark-size: 2.35rem;
   }
 
   nav {
@@ -151,19 +151,16 @@ import "../styles/tokens.css";
 
   .principle-grid {
     display: grid;
-    gap: 0;
+    gap: clamp(0.85rem, 2vw, 1.25rem);
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   article {
-    background: linear-gradient(180deg, rgb(255 255 255 / 60%), rgb(255 255 255 / 28%));
-    border-block-start: 1px solid rgb(30 36 54 / 10%);
-    padding: clamp(1.2rem, 3vw, 2rem) clamp(1rem, 3vw, 2rem) clamp(1.2rem, 3vw, 2rem) 0;
-  }
-
-  article + article {
-    border-inline-start: 1px solid rgb(30 36 54 / 9%);
-    padding-inline-start: clamp(1rem, 3vw, 2rem);
+    background: var(--starbeam-glass-rail);
+    border: 1px solid var(--starbeam-glass-border);
+    border-radius: var(--starbeam-radius-lg);
+    box-shadow: var(--starbeam-shadow-soft);
+    padding: clamp(1.2rem, 3vw, 2rem);
   }
 
   article span {
@@ -199,11 +196,6 @@ import "../styles/tokens.css";
 
     .principle-grid {
       grid-template-columns: 1fr;
-    }
-
-    article + article {
-      border-inline-start: 0;
-      padding-inline-start: 0;
     }
   }
 </style>

--- a/workspace/docs/src/styles/starlight.css
+++ b/workspace/docs/src/styles/starlight.css
@@ -203,6 +203,18 @@ starlight-theme-select {
   border-radius: var(--starbeam-radius-lg);
   color: var(--starbeam-muted);
   box-shadow: var(--starbeam-shadow-soft);
+  min-width: 0;
+  text-align: start;
+}
+
+.pagination-links a[rel="next"] {
+  flex-direction: row;
+  justify-content: flex-start;
+  text-align: start;
+}
+
+.pagination-links a > span {
+  min-width: 0;
 }
 
 .pagination-links a:hover {
@@ -213,8 +225,10 @@ starlight-theme-select {
 .pagination-links .link-title {
   color: var(--starbeam-ink);
   font-family: var(--starbeam-font-display);
+  font-size: clamp(1.35rem, 5vw, 2rem);
   font-weight: 500;
-  letter-spacing: -0.035em;
+  letter-spacing: -0.025em;
+  overflow-wrap: anywhere;
 }
 
 .sl-markdown-content .starlight-aside {
@@ -226,6 +240,12 @@ starlight-theme-select {
 
 .sl-markdown-content .starlight-aside__title {
   color: var(--starbeam-ink);
+}
+
+.sl-markdown-content blockquote:not(:where(.not-content *)) {
+  border-inline-start: 0.2rem solid var(--starbeam-beam);
+  color: var(--starbeam-ink);
+  font-weight: 750;
 }
 
 @media (max-width: 49.999rem) {

--- a/workspace/docs/src/styles/tokens.css
+++ b/workspace/docs/src/styles/tokens.css
@@ -22,6 +22,8 @@
   --starbeam-docs-panel: rgb(255 255 255 / 74%);
   --starbeam-docs-panel-border: rgb(30 36 54 / 10%);
   --starbeam-docs-accent-soft: rgb(0 194 179 / 12%);
+  --starbeam-glass-rail: rgb(255 255 255 / 72%);
+  --starbeam-glass-border: rgb(255 255 255 / 82%);
 
   --starbeam-radius-sm: 0.5rem;
   --starbeam-radius-md: 0.875rem;


### PR DESCRIPTION
## Summary

- bring the homepage topbar closer to the style guide lockup by using the Starbeam mark
- reuse shared glass rail tokens for the hero rail and principle cards
- add a guide-style Beam accent to docs blockquotes
- fix mobile pagination card alignment so the next-page label stays readable

## Notes

This is a bounded UI polish pass after the homepage and Starlight interior PRs. It keeps the existing IA, content, dependencies, and asset pipeline unchanged.