### PR TITLE
docs: update website positioning copy

### DIFF
--- a/workspace/docs/astro.config.mjs
+++ b/workspace/docs/astro.config.mjs
@@ -9,7 +9,7 @@ export default defineConfig({
     starlight({
       title: "Starbeam",
       description:
-        "Starbeam is a joyful reactivity engine for JavaScript applications.",
+        "Starbeam is reactivity that stays JavaScript.",
       customCss: ["./src/styles/starlight.css"],
       social: [
         {

--- a/workspace/docs/src/components/BrandHero.astro
+++ b/workspace/docs/src/components/BrandHero.astro
@@ -9,17 +9,20 @@ import StarMark from "./StarMark.astro";
       <StarMark class="hero__lockup-mark" size={56} />
       <span>Starbeam</span>
     </div>
-    <h1>Mark root state. Keep the rest JavaScript.</h1>
+    <h1>Reactivity that stays JavaScript.</h1>
     <p class="lede">
-      Starbeam is a joyful reactivity engine for building domain-shaped state,
-      lifecycle-aware resources, and framework-native experiences.
+      Mark the root state that changes, then build domain-shaped functions,
+      classes, getters, collections, and resources around it as ordinary
+      JavaScript.
     </p>
     <div class="hero__rule" aria-hidden="true">
       <span></span>
       <strong>✦</strong>
       <span></span>
     </div>
-    <p class="hero__signal"><strong>Reactive by nature.</strong> Built for developers.</p>
+    <p class="hero__signal">
+      <strong>Compositional reactivity.</strong> No exotic application code.
+    </p>
     <div class="hero__actions" aria-label="Primary actions">
       <a class="button button--primary" href="/start/introduction/">Start reading</a>
       <a class="button button--secondary" href="https://github.com/starbeamjs/starbeam">View on GitHub</a>
@@ -29,9 +32,9 @@ import StarMark from "./StarMark.astro";
     <StarMark class="hero__star" size={520} />
   </div>
   <div class="hero__rail" aria-label="Starbeam strengths">
-    <p><span aria-hidden="true">◎</span> Universal reactivity</p>
-    <p><span aria-hidden="true">✣</span> Works with your framework</p>
-    <p><span aria-hidden="true">JS</span> Made for JavaScript</p>
+    <p><span aria-hidden="true">◎</span> Root state marks the boundary</p>
+    <p><span aria-hidden="true">JS</span> Ordinary JavaScript above it</p>
+    <p><span aria-hidden="true">✣</span> Resources add lifecycle</p>
   </div>
 </section>
 

--- a/workspace/docs/src/content/docs/concepts/overview.md
+++ b/workspace/docs/src/content/docs/concepts/overview.md
@@ -1,17 +1,60 @@
 ---
 title: Core concepts
-description: Placeholder for Starbeam's public concept docs.
+description: "A map of Starbeam's reactive model: root state, derived reads, resources, services, and framework integration."
 ---
 
-# Core concepts
+Starbeam makes reactivity compositional without making application code exotic.
+The mechanism is reactive; your application model can keep the shape of ordinary
+JavaScript.
 
-This section will turn the invariants into public tutorial prose.
+## Root state
 
-## Planned pages
+Root state is the storage Starbeam tracks directly: cells, markers, and reactive
+collections. This is where you mark the boundary between changing data and the
+ordinary JavaScript that reads it.
 
-- Reactive storage
-- Derived reads
-- Resources and cleanup
-- Collections
-- Services and app lifetime
-- DOM attachment and element resources
+## Reactive values
+
+A reactive value is any value whose result depends on reactive storage. It might
+be a `Cell`, a `Formula`, a resource, or a domain object with getters and methods
+that read root state internally.
+
+The public shape can still look like your app:
+
+- `session.user`;
+- `cart.total`;
+- `form.isValid`;
+- `size.width`.
+
+## Derived reads
+
+Derived reads are ordinary functions, getters, and formulas that read reactive
+state. Starbeam records what they read when they run, then uses that read trace
+to validate cached work or update framework renderers.
+
+You do not have to maintain a userland dependency graph.
+
+## Resources
+
+Resources model state with a lifetime. Use them when reactive state needs setup,
+sync, or cleanup: subscriptions, external handles, element work, and other values
+that should start and stop with an owner.
+
+## Services and app lifetime
+
+Services are resource-backed state with an app-scoped lifetime. They are useful
+for shared application concerns that should live as long as the app or framework
+root lives.
+
+## Element resources
+
+Element resources attach resource work to DOM elements supplied by a framework.
+They let Starbeam model setup, sync, and cleanup for element-backed behavior
+without turning Starbeam into a framework replacement.
+
+## Advanced details
+
+The low-level mechanisms explain how the model works. They belong in advanced
+docs. The first-run model is smaller:
+
+> Mark root state. Keep the rest JavaScript.

--- a/workspace/docs/src/content/docs/frameworks/overview.md
+++ b/workspace/docs/src/content/docs/frameworks/overview.md
@@ -1,15 +1,35 @@
 ---
 title: Framework guides
-description: Placeholder for framework-native Starbeam docs.
+description: "Starbeam's framework adapters connect the same reactive model to React, Preact, Vue, and Svelte as each adapter matures."
 ---
 
-# Framework guides
+Starbeam's state model is framework-neutral. Framework adapters make it feel
+native by connecting Starbeam's reactive model to each framework's rendering and
+lifecycle rules.
 
-React, Preact, Vue, and Svelte are first-class framework targets in Starbeam's public posture.
+The goal is not one framework with incidental ports. React, Preact, Vue, and
+Svelte are first-class targets for the public docs.
+
+## Same model, native edges
+
+The core model stays the same in every framework:
+
+1. Mark root state reactive.
+2. Build ordinary JavaScript abstractions above it.
+3. Use resources when state needs setup, sync, or cleanup.
+4. Let the adapter connect reads and resources to the framework.
+
+The framework-specific layer should feel small. It is the bridge between
+Starbeam's model and the framework's rendering and lifecycle rules.
 
 ## Planned guides
 
-- React
-- Preact
-- Vue
-- Svelte
+- **React**: hooks for reactive reads, resources, services, and element resources.
+- **Preact**: Preact-native bindings for the same Starbeam model.
+- **Vue**: setup helpers and directives for reactive state and element resources.
+- **Svelte**: element-resource attachments first, with the broader adapter story
+  still maturing.
+
+Some guide details may mature at different speeds. The top-level posture stays
+the same: Starbeam is designed to make the same domain-shaped reactive model work
+across modern JavaScript frameworks.

--- a/workspace/docs/src/content/docs/start/introduction.md
+++ b/workspace/docs/src/content/docs/start/introduction.md
@@ -1,18 +1,71 @@
 ---
-title: Introduction
-description: Start here for the first public Starbeam docs path.
+title: Mark root state. Keep the rest JavaScript.
+description: "Learn Starbeam's first idea: mark the storage that changes, then keep the rest of your model ordinary JavaScript."
 ---
 
-Starbeam's first-run docs will start here.
+Starbeam starts with a small boundary: mark the storage that changes.
+Everything above that storage can stay ordinary JavaScript.
 
-The scaffold keeps this page intentionally small. Real content should follow the positioning memo:
+Cells, markers, and reactive collections are the root state Starbeam tracks.
+Functions, classes, getters, methods, closures, and domain objects can read that
+state without becoming special reactive types themselves.
 
-> Mark root state. The rest is just JavaScript.
+```ts
+import { Cell } from "@starbeam/universal";
 
-## Planned content
+interface User {
+  name: string;
+}
 
-- What Starbeam is
-- Which package to install
-- First reactive value
-- First resource
-- Framework next steps
+class Session {
+  #user = Cell<User | null>(null);
+
+  get user() {
+    return this.#user.current;
+  }
+
+  get isLoggedIn() {
+    return this.user !== null;
+  }
+}
+```
+
+The class exposes domain-shaped JavaScript: `session.user` and
+`session.isLoggedIn`. The abstraction becomes reactive because it reads reactive
+storage internally, not because every layer has to carry a wrapper.
+
+## Derived reads stay ordinary
+
+A derived value can be a function, getter, method, or cached formula. Starbeam
+tracks what the read touched when it ran, so users do not have to register a
+separate dependency graph.
+
+That means you can start with the shape your app wants:
+
+- `cart.total`, not `cart.total.current`;
+- `size.width`, not `size.width.value`;
+- `form.isValid`, not `form.validSignal.get()`.
+
+## Resources add lifecycle
+
+Some state needs more than a value. It needs setup, sync, and cleanup.
+
+Resources attach that lifecycle to the same reactive model. Use ordinary reactive
+state first; reach for a resource when the thing you are modeling has a lifetime.
+
+## Legible to humans and agents
+
+Starbeam does not ask an AI agent to translate every domain idea into a reactive
+DSL before the code can become reactive. The important abstractions stay local,
+inspectable JavaScript: modules, classes, methods, getters, collections, and
+explicit lifecycle setup, sync, and cleanup.
+
+The developer still owns the design. Starbeam keeps the reactive boundary small
+enough that both the human and the agent can reason about the rest of the system
+as JavaScript.
+
+## Next steps
+
+- Read [Core concepts](/concepts/overview/) for the map of Starbeam's model.
+- Read [Framework guides](/frameworks/overview/) to see how adapters connect this
+  model to React, Preact, Vue, and Svelte.

--- a/workspace/docs/src/pages/index.astro
+++ b/workspace/docs/src/pages/index.astro
@@ -11,7 +11,7 @@ import "../styles/tokens.css";
     <title>Starbeam</title>
     <meta
       name="description"
-      content="Starbeam is a joyful reactivity engine for JavaScript applications."
+      content="Starbeam is reactivity that stays JavaScript."
     />
   </head>
   <body>
@@ -33,23 +33,23 @@ import "../styles/tokens.css";
       <section class="principles" aria-labelledby="principles-heading">
         <div>
           <p class="section-label">Why Starbeam?</p>
-          <h2 id="principles-heading">Reactive by nature. Built for developers.</h2>
+          <h2 id="principles-heading">Keep the reactive boundary small.</h2>
         </div>
         <div class="principle-grid">
           <article>
             <span aria-hidden="true">◈</span>
-            <h3>Universal reactivity</h3>
-            <p>Mark root state once, then build with ordinary JavaScript.</p>
+            <h3>Mark root state</h3>
+            <p>Cells and reactive collections hold the state Starbeam tracks.</p>
           </article>
           <article>
             <span aria-hidden="true">✦</span>
-            <h3>Lifecycle-aware</h3>
-            <p>Resources add setup, sync, and cleanup when state needs a lifetime.</p>
+            <h3>Build domain-shaped APIs</h3>
+            <p>Expose values like <code>session.user</code> and <code>form.isValid</code>.</p>
           </article>
           <article>
             <span aria-hidden="true">&lt;/&gt;</span>
-            <h3>Framework-native</h3>
-            <p>Adapters connect the model to React, Preact, Vue, and Svelte.</p>
+            <h3>Stay legible together</h3>
+            <p>Humans and agents can both work with stable JavaScript structure.</p>
           </article>
         </div>
       </section>
@@ -177,6 +177,15 @@ import "../styles/tokens.css";
     color: var(--starbeam-muted);
     line-height: 1.6;
     margin: 0;
+  }
+
+  article code {
+    background: var(--starbeam-code-background);
+    border-radius: var(--starbeam-radius-sm);
+    color: var(--starbeam-indigo);
+    font-family: var(--starbeam-font-mono);
+    font-size: 0.9em;
+    padding: 0.1rem 0.24rem;
   }
 
   @media (max-width: 760px) {


### PR DESCRIPTION
## Summary

- update the homepage headline and support copy to use the revised positioning
- move “Mark root state. Keep the rest JavaScript.” into the Start introduction
- replace placeholder Start, Core concepts, and Framework guides pages with first-pass public copy
- add careful AI-assisted development framing around collaborative legibility

## Notes

This is a bounded content pass following the positioning memo update. It does not migrate the full docs set or change package/API claims beyond the scaffold overview pages.