### PR TITLE
docs: configure Vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "buildCommand": "pnpm --filter @starbeam-workspace/docs build",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "outputDirectory": "workspace/docs/dist",
+  "framework": "astro"
+}

--- a/workspace/docs/astro.config.mjs
+++ b/workspace/docs/astro.config.mjs
@@ -2,6 +2,7 @@ import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 
 export default defineConfig({
+  site: "https://starbeamjs.com",
   devToolbar: {
     enabled: false,
   },


### PR DESCRIPTION
## Summary

- add root Vercel configuration for the docs site
- build the private docs workspace package with pnpm
- set the Astro `site` URL so sitemap generation is configured

## Notes

The Vercel output directory is `workspace/docs/dist`, produced by `pnpm --filter @starbeam-workspace/docs build`.
