### PR TITLE
docs: align overview pages with collections-first start

### DIFF
--- a/workspace/docs/src/content/docs/concepts/overview.md
+++ b/workspace/docs/src/content/docs/concepts/overview.md
@@ -9,9 +9,33 @@ JavaScript.
 
 ## Root state
 
-Root state is the storage Starbeam tracks directly: cells, markers, and reactive
-collections. This is where you mark the boundary between changing data and the
-ordinary JavaScript that reads it.
+Root state is the storage Starbeam tracks directly. Most app models should start
+with the shape of the data: use `@starbeam/collections` when the state is
+collection-shaped, and use `Cell` from `@starbeam/universal` for scalar state.
+
+```ts
+import { reactive } from "@starbeam/collections";
+
+interface LineItem {
+  readonly quantity: number;
+}
+
+class Cart {
+  #items = reactive.Map<string, LineItem>();
+
+  get items(): readonly LineItem[] {
+    return [...this.#items.values()];
+  }
+
+  get itemCount(): number {
+    return this.items.reduce((total, item) => total + item.quantity, 0);
+  }
+}
+```
+
+The private `Map` is the root state. The public reads are ordinary JavaScript.
+This is where you mark the boundary between changing data and the domain code
+that reads it.
 
 ## Reactive values
 
@@ -28,9 +52,10 @@ The public shape can still look like your app:
 
 ## Derived reads
 
-Derived reads are ordinary functions, getters, and formulas that read reactive
-state. Starbeam records what they read when they run, then uses that read trace
-to validate cached work or update framework renderers.
+Derived reads are ordinary functions, getters, methods, and formulas that read
+reactive state. In the cart example, `items` and `itemCount` are just getters
+above the private collection. Starbeam records what they read when they run,
+then uses that read trace to validate cached work or update framework renderers.
 
 You do not have to maintain a userland dependency graph.
 

--- a/workspace/docs/src/content/docs/frameworks/overview.md
+++ b/workspace/docs/src/content/docs/frameworks/overview.md
@@ -14,13 +14,16 @@ Svelte are first-class targets for the public docs.
 
 The core model stays the same in every framework:
 
-1. Mark root state reactive.
+1. Mark root state reactive. Use `@starbeam/collections` for collection-shaped
+   state and `@starbeam/universal` for scalar state and lifecycle APIs.
 2. Build ordinary JavaScript abstractions above it.
 3. Use resources when state needs setup, sync, or cleanup.
 4. Let the adapter connect reads and resources to the framework.
 
 The framework-specific layer should feel small. It is the bridge between
-Starbeam's model and the framework's rendering and lifecycle rules.
+Starbeam's model and the framework's rendering and lifecycle rules. Your domain
+model can still expose normal getters, methods, and objects; the adapter is the
+place that connects those reads and resources to React, Preact, Vue, or Svelte.
 
 ## Planned guides
 

--- a/workspace/docs/src/content/docs/reference/overview.md
+++ b/workspace/docs/src/content/docs/reference/overview.md
@@ -1,15 +1,33 @@
 ---
 title: Reference
-description: Placeholder for Starbeam public API reference docs.
+description: Starbeam's public package surface at a glance.
 ---
 
-This section will document the public Starbeam package surface.
+This section maps the public Starbeam package surface. It is an overview, not a
+complete API reference.
 
-## Planned reference
+## Starter and app-facing packages
 
-- `@starbeam/universal`
-- `@starbeam/resource`
-- `@starbeam/service`
-- `@starbeam/reactive`
-- Framework adapters
-- `@starbeam/core` compatibility
+- `@starbeam/collections`: reactive `Map`, `Set`, array, and object helpers for
+  collection-shaped root state.
+- `@starbeam/universal`: framework-neutral scalar state and lifecycle APIs such
+  as `Cell` and `Resource`.
+- Framework adapters: `@starbeam/react`, `@starbeam/preact`, `@starbeam/vue`, and
+  `@starbeam/svelte` connect reactive reads and resources to each framework.
+
+## Lifecycle and composition packages
+
+- `@starbeam/resource`: resource APIs for reusable setup, sync, and cleanup
+  abstractions. App code often reaches resources through `@starbeam/universal`
+  or a framework adapter first.
+- `@starbeam/service`: app-lifetime resource composition. Use it for shared
+  state that should live with the app or framework root.
+
+## Lower-level and compatibility packages
+
+- `@starbeam/reactive`: primitive reactive values such as `Cell`, `Marker`,
+  `Formula`, and `CachedFormula`. It is public for library authors, but most app
+  code should start with `@starbeam/collections` and `@starbeam/universal`.
+- `@starbeam/core`: deprecated compatibility alias for `@starbeam/universal`.
+  Existing code can keep using it during the compatibility window; new code
+  should not start there.


### PR DESCRIPTION
## Summary

This follow-up aligns the overview docs with the Start walkthrough after it moved to a collections-first root-state example.

- expands Core concepts so collection-shaped root state leads with `@starbeam/collections`
- maps the public package surface in Reference, including `@starbeam/collections`, `@starbeam/universal`, lifecycle packages, and compatibility/lower-level packages
- updates Framework guides to explain that adapters connect the same collection/scalar/resource model to framework rendering and lifecycle

## Prepare / Execute / Review (PER)

Prepare predicted this should be a small docs-only alignment PR touching the Concepts, Reference, and Framework overview pages only. Execute matched that scope. Review found no material divergence; the only correction was keeping `@starbeam/reactive` framed as public primitive surface for library authors, while `@starbeam/core` is the deprecated compatibility alias.

## Validation

- `pnpm --filter @starbeam-workspace/docs test:types`
- `pnpm --filter @starbeam-workspace/docs build`
- `pnpm --filter @starbeam-workspace/docs test:lint`
- `git diff --check`
- pre-commit `test:workspace:lint`
- pre-commit `test:workspace:types`
