### PR TITLE
chore: clarify optional PR template sections

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,10 +6,10 @@
 
 <!-- Briefly summarize the change. -->
 
-## Reviewer notes (optional)
+## Reviewer notes
 
 <!-- Optional. Delete this section if there is nothing specific reviewers should know. Do not enumerate local validation steps; mention only unexpected failures, caveats, or reviewer-relevant commands. -->
 
-## User-facing changes (optional)
+## User-facing changes
 
 <!-- Optional. Delete this section unless this PR changes user-visible behavior, APIs, docs, or migration guidance. -->


### PR DESCRIPTION
## Why

The PR template marked optional sections in the headings themselves. That makes it easy to accidentally leave `(optional)` in submitted PR bodies instead of either using the section or deleting it.

## What changed

- Removes `(optional)` from the `Reviewer notes` heading.
- Removes `(optional)` from the `User-facing changes` heading.
- Keeps the template comments that explain when those sections should be deleted.

## Reviewer notes

Tiny workflow polish only.

## User-facing changes

None.
