### PR TITLE
docs: add Preact framework guide

### DIFF
--- a/workspace/docs/astro.config.mjs
+++ b/workspace/docs/astro.config.mjs
@@ -32,6 +32,7 @@ export default defineConfig({
           items: [
             { label: "Overview", link: "/frameworks/overview/" },
             { label: "React", link: "/frameworks/react/" },
+            { label: "Preact", link: "/frameworks/preact/" },
           ],
         },
         {

--- a/workspace/docs/src/content/docs/frameworks/overview.md
+++ b/workspace/docs/src/content/docs/frameworks/overview.md
@@ -29,7 +29,8 @@ place that connects those reads and resources to React, Preact, Vue, or Svelte.
 
 - [**React**](/frameworks/react/): hooks for reactive reads, resources,
   services, and element resources.
-- **Preact** (planned): Preact-native bindings for the same Starbeam model.
+- [**Preact**](/frameworks/preact/): adapter installation, reactive reads,
+  resources, services, and element resources.
 - **Vue** (planned): setup helpers and directives for reactive state and element
   resources.
 - **Svelte** (planned): element-resource attachments first, with the broader

--- a/workspace/docs/src/content/docs/frameworks/preact.md
+++ b/workspace/docs/src/content/docs/frameworks/preact.md
@@ -1,0 +1,267 @@
+---
+title: Preact
+description: "The Preact adapter connects Starbeam reads and resources to Preact rendering and lifecycle."
+---
+
+Preact render is the output boundary for a Starbeam model. Your state can stay
+ordinary JavaScript: classes, getters, methods, maps, and resources. The Preact
+adapter connects Starbeam reads and resources to Preact rendering and lifecycle.
+
+Install the adapter once into Preact `options`. After that, Preact render is the
+output boundary for Starbeam reads.
+
+## Install
+
+Install the Preact adapter with the framework-neutral Starbeam packages you will
+use for root state and resources:
+
+```sh
+pnpm add @starbeam/preact @starbeam/universal @starbeam/collections
+```
+
+## Install the adapter
+
+Install Starbeam into Preact before rendering the app.
+
+```tsx
+import { install } from "@starbeam/preact";
+import { options, render } from "preact";
+
+import { App } from "./app.js";
+
+install(options);
+
+render(<App />, document.getElementById("root")!);
+```
+
+There is no Starbeam provider component for Preact. The adapter hooks into
+Preact through `install(options)`, so reads during render are tracked by the
+component that rendered them.
+
+## Keep the model ordinary JavaScript
+
+Start by marking the storage that changes. The rest of the model can be normal
+domain code.
+
+```ts
+import { reactive } from "@starbeam/collections";
+
+interface LineItem {
+  readonly id: string;
+  readonly name: string;
+  readonly priceCents: number;
+  readonly quantity: number;
+}
+
+interface ProductInput {
+  readonly name: string;
+  readonly priceCents: number;
+}
+
+export class Cart {
+  #items = reactive.Map<string, LineItem>();
+  #nextItemId = 1;
+
+  get items(): readonly LineItem[] {
+    return [...this.#items.values()];
+  }
+
+  get itemCount(): number {
+    return this.items.reduce((total, item) => total + item.quantity, 0);
+  }
+
+  get totalCents(): number {
+    return this.items.reduce(
+      (sum, item) => sum + item.priceCents * item.quantity,
+      0,
+    );
+  }
+
+  add(product: ProductInput): void {
+    const id = `item-${this.#nextItemId++}`;
+
+    this.#items.set(id, {
+      id,
+      name: product.name,
+      priceCents: product.priceCents,
+      quantity: 1,
+    });
+  }
+}
+```
+
+`#items` is the reactive root state. `itemCount`, `totalCents`, and `add()` are
+ordinary JavaScript above it.
+
+## Read the model during render
+
+After `install(options)`, ordinary Preact render is the output boundary. Read the
+Starbeam model directly where the component renders UI, and Starbeam tracks those
+reads for that component.
+
+```tsx
+import type { VNode } from "preact";
+
+import { Cart } from "./cart.js";
+
+const cart = new Cart();
+
+export function CartSummary(): VNode {
+  return (
+    <section>
+      <p>{cart.itemCount} items</p>
+      <p>${(cart.totalCents / 100).toFixed(2)}</p>
+
+      <button
+        type="button"
+        onClick={() => cart.add({ name: "Tea", priceCents: 500 })}
+      >
+        Add tea
+      </button>
+    </section>
+  );
+}
+```
+
+You do not list the Starbeam data the component reads. `cart.itemCount` and
+`cart.totalCents` are tracked automatically when the component renders.
+
+`useReactive()` also exists for explicit reactive values, but it is not the main
+Preact render path. In Preact, the installed adapter can track the whole render.
+
+## Add lifecycle with `useResource()`
+
+Use a `Resource` when state needs setup, sync, or cleanup. `useResource()` gives
+the resource a Preact component lifetime. Render can read the resource's returned
+value directly.
+
+```tsx
+import { useResource } from "@starbeam/preact";
+import { Cell, Resource } from "@starbeam/universal";
+import type { VNode } from "preact";
+
+const Clock = Resource(({ on }) => {
+  const now = Cell(new Date());
+
+  on.sync(() => {
+    const timer = setInterval(() => {
+      now.set(new Date());
+    }, 1000);
+
+    return () => clearInterval(timer);
+  });
+
+  return {
+    get now(): Date {
+      return now.current;
+    },
+  };
+});
+
+export function ClockLabel(): VNode {
+  const clock = useResource(Clock);
+
+  return <time>{clock.now.toLocaleTimeString()}</time>;
+}
+```
+
+`useResource()` also accepts optional dependencies when the resource blueprint
+depends on changing Preact values.
+
+## DOM element resources
+
+Use `useElementResource()` when a resource needs a DOM element from Preact. It
+returns a callback ref plus a pending or attached result.
+
+```tsx
+import { useElementResource } from "@starbeam/preact";
+import { Cell, Resource } from "@starbeam/universal";
+import type { VNode } from "preact";
+
+function ElementSize(element: HTMLElement) {
+  return Resource(({ on }) => {
+    const width = Cell(0);
+    const height = Cell(0);
+
+    on.sync(() => {
+      const observer = new ResizeObserver(([entry]) => {
+        if (!entry) return;
+
+        width.set(entry.contentRect.width);
+        height.set(entry.contentRect.height);
+      });
+
+      observer.observe(element);
+
+      return () => observer.disconnect();
+    });
+
+    return {
+      get width(): number {
+        return width.current;
+      },
+
+      get height(): number {
+        return height.current;
+      },
+    };
+  });
+}
+
+export function MeasuredPanel(): VNode {
+  const size = useElementResource((element: HTMLElement) =>
+    ElementSize(element),
+  );
+
+  const label =
+    size.status === "pending"
+      ? "Measuring…"
+      : `${Math.round(size.current.width)} × ${Math.round(size.current.height)}`;
+
+  return <section ref={size.ref}>{label}</section>;
+}
+```
+
+The element comes from Preact. The resource work still lives in Starbeam.
+
+## App-scoped services
+
+Use `useService()` for shared resource-backed state under the installed Preact
+root. Keep services for app-level concerns whose lifetime should follow the
+Preact app.
+
+```tsx
+import { useService } from "@starbeam/preact";
+import { Cell, Resource } from "@starbeam/universal";
+import type { VNode } from "preact";
+
+const SessionService = Resource(() => {
+  const userName = Cell("Guest");
+
+  return {
+    get userName(): string {
+      return userName.current;
+    },
+  };
+});
+
+export function CurrentUser(): VNode {
+  const session = useService(SessionService);
+
+  return <p>{session.userName}</p>;
+}
+```
+
+## Lower-level APIs
+
+`setup()`, `setupReactive()`, `setupResource()`, `setupService()`, `setupSync()`,
+and `createCell()` are public lower-level APIs. `ElementResource` and
+`ElementResourceBlueprint` are public types for element-resource wrappers. Start
+with render reads for UI, `useResource()` for component-lifetime resources,
+`useElementResource()` for element-backed resources, and `useService()` for
+shared services.
+
+## Next steps
+
+- [Core concepts](/concepts/overview/): the framework-neutral Starbeam model.
+- [Reference](/reference/overview/): the public package surface at a glance.


### PR DESCRIPTION
## Why

The framework docs now have a React guide, but Preact still appeared as planned-only. Preact is a first-class target, and its adapter has an important difference from React: after `install(options)`, ordinary Preact render is the output boundary for Starbeam reads.

## What changed

- Adds `/frameworks/preact/` with a Preact guide.
- Shows how to install the adapter into Preact `options`.
- Documents direct render reads for Starbeam state instead of React-style `useReactive()` wrappers.
- Previews `useResource()`, `useElementResource()`, `useService()`, and lower-level Preact APIs.
- Adds the Preact guide to the Framework guides sidebar and overview page.

## Reviewer notes

This was done as a Prepare / Execute / Review (PER) pass. Prepare checked the current `@starbeam/preact` exports, implementation, and tests. Review corrected the first draft away from React-shaped `useReactive()` examples because Preact tracks reads during render after `install(options)`.

## User-facing changes

Docs-only. Adds the first Preact framework guide to the Starlight site.
