### PR TITLE
feat(svelte): add fromStarbeam read bridge

### DIFF
--- a/docs/SVELTE-FIRST-CLASS-ADAPTER.md
+++ b/docs/SVELTE-FIRST-CLASS-ADAPTER.md
@@ -5,17 +5,22 @@ adapter beyond element-backed resources.
 
 ## Status
 
-Proposed. This records the result of the Svelte implementation Prepare pass. It
-should guide the next implementation PER, but it does not itself change the
-public package surface.
+Accepted for the first implementation slice. PR
+[#260](https://github.com/starbeamjs/starbeam/pull/260) adds `fromStarbeam()` as
+an experimental Svelte 5 read bridge. Deeper integration work is tracked in
+[#261](https://github.com/starbeamjs/starbeam/issues/261).
 
 ## Decision summary
 
 Svelte should get a Svelte 5-native Starbeam read boundary before we document a
 full framework guide.
 
-The first implementation slice should prove a single primitive. The name is
-still open, but the shape is:
+`fromStarbeam()` is that first boundary. It is intentionally explicit while we
+investigate whether signals interop, userspace Svelte-reactive wrappers, or a
+future public Svelte hook can make Starbeam reads visible with fewer explicit
+output boundaries.
+
+The first implementation slice proves a single primitive:
 
 ```ts
 const total = fromStarbeam(() => cart.totalCents);
@@ -39,14 +44,13 @@ The implementation should use Svelte's `createSubscriber` plus Starbeam's
 This keeps the Svelte API modern: no Svelte 4 action story, no React-style
 dependency arrays, and no store-first primary API.
 
-The naming question should be settled with Svelte-facing feedback before the
-implementation PR. This record uses `fromStarbeam()` as the leading candidate
-because it describes an external-reactivity conversion and avoids colliding with
+`fromStarbeam()` is the experimental public name for the first slice. It
+describes an external-reactivity conversion and avoids colliding with
 `@starbeam/collections`.
 
 ## Current state
 
-`@starbeam/svelte` is currently an element-resource adapter.
+Before PR #260, `@starbeam/svelte` was an element-resource adapter.
 
 It exposes:
 
@@ -176,11 +180,11 @@ should therefore compute synchronously on the server and establish no runtime
 subscription. On the client, reading `.current` inside a tracked Svelte context
 should establish the Starbeam subscription.
 
-The first implementation PER should include an SSR smoke test for this behavior.
+The first implementation includes an SSR smoke test for this behavior.
 
 ## Naming
 
-The public name is not settled. Current leading candidate: `fromStarbeam()`.
+The first public name is `fromStarbeam()`.
 
 Why:
 

--- a/packages/svelte/svelte/README.md
+++ b/packages/svelte/svelte/README.md
@@ -1,6 +1,30 @@
 # @starbeam/svelte
 
-Svelte adapter for Starbeam element-backed resources.
+Svelte adapter for Starbeam reactive reads and element-backed resources.
+
+## Reactive reads
+
+> Experimental: `fromStarbeam()` is the current tested Svelte 5 read bridge.
+> We are investigating deeper integration so Svelte can see Starbeam reads with
+> fewer explicit output boundaries. Track that work in
+> [starbeamjs/starbeam#261](https://github.com/starbeamjs/starbeam/issues/261).
+
+Use `fromStarbeam()` to expose a Starbeam read to Svelte 5 templates,
+`$derived`, and effects:
+
+```svelte
+<script lang="ts">
+  import { fromStarbeam } from "@starbeam/svelte";
+
+  const total = fromStarbeam(() => cart.totalCents);
+</script>
+
+<p>{total.current}</p>
+```
+
+`fromStarbeam()` returns a readonly `current` getter. Keep Starbeam cells and
+collections private inside your domain objects; expose domain-shaped getters and
+wrap those reads at the Svelte boundary.
 
 `elementResource()` is the primary authoring API for Svelte 5 attachments. It
 returns one Svelte-readable object that is also attachable. Attach it with

--- a/packages/svelte/svelte/index.ts
+++ b/packages/svelte/svelte/index.ts
@@ -7,3 +7,4 @@ export {
   type ElementResourceSink,
   elementResourceStore,
 } from "./src/element-resource.js";
+export { fromStarbeam, type StarbeamValue } from "./src/reactive.js";

--- a/packages/svelte/svelte/src/reactive.ts
+++ b/packages/svelte/svelte/src/reactive.ts
@@ -1,0 +1,21 @@
+import { Formula } from "@starbeam/reactive";
+import { RUNTIME } from "@starbeam/runtime";
+import { createSubscriber } from "svelte/reactivity";
+
+export interface StarbeamValue<T> {
+  readonly current: T;
+}
+
+export function fromStarbeam<T>(compute: () => T): StarbeamValue<T> {
+  const formula = Formula(compute);
+  const subscribe = createSubscriber((update) => {
+    return RUNTIME.subscribe(formula, update);
+  });
+
+  return {
+    get current(): T {
+      subscribe();
+      return formula.current;
+    },
+  };
+}

--- a/packages/svelte/svelte/tests/fixtures/FromStarbeamBasic.svelte
+++ b/packages/svelte/svelte/tests/fixtures/FromStarbeamBasic.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { fromStarbeam } from "@starbeam/svelte";
+  import type { Cell } from "@starbeam/universal";
+
+  let { count }: { count: Cell<number> } = $props();
+
+  const doubled = fromStarbeam(() => count.current * 2);
+
+  function increment() {
+    count.current++;
+  }
+</script>
+
+<p>{doubled.current}</p>
+<button onclick={increment}>increment</button>

--- a/packages/svelte/svelte/tests/fixtures/FromStarbeamCleanup.svelte
+++ b/packages/svelte/svelte/tests/fixtures/FromStarbeamCleanup.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { fromStarbeam } from "@starbeam/svelte";
+  import type { Cell } from "@starbeam/universal";
+  import type { RecordedEvents } from "@starbeam-workspace/test-utils";
+
+  let {
+    count,
+    events,
+  }: { count: Cell<number>; events: RecordedEvents } = $props();
+
+  const value = fromStarbeam(() => {
+    events.record("compute");
+    return count.current;
+  });
+</script>
+
+<p>{value.current}</p>

--- a/packages/svelte/svelte/tests/fixtures/FromStarbeamConsumer.svelte
+++ b/packages/svelte/svelte/tests/fixtures/FromStarbeamConsumer.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import type { StarbeamValue } from "@starbeam/svelte";
+
+  let { label, value }: { label: string; value: StarbeamValue<number> } =
+    $props();
+</script>
+
+<p>{label}={value.current}</p>

--- a/packages/svelte/svelte/tests/fixtures/FromStarbeamDerived.svelte
+++ b/packages/svelte/svelte/tests/fixtures/FromStarbeamDerived.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { fromStarbeam } from "@starbeam/svelte";
+  import type { Cell } from "@starbeam/universal";
+
+  let { count }: { count: Cell<number> } = $props();
+
+  const value = fromStarbeam(() => count.current);
+  const doubled = $derived(value.current * 2);
+
+  function increment() {
+    count.current++;
+  }
+</script>
+
+<p>{doubled}</p>
+<button onclick={increment}>increment</button>

--- a/packages/svelte/svelte/tests/fixtures/FromStarbeamDomainGetter.svelte
+++ b/packages/svelte/svelte/tests/fixtures/FromStarbeamDomainGetter.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { reactive as reactiveCollections } from "@starbeam/collections";
+  import { fromStarbeam } from "@starbeam/svelte";
+
+  interface LineItem {
+    readonly quantity: number;
+    readonly unitCents: number;
+  }
+
+  class Cart {
+    readonly #items = reactiveCollections.Map<string, LineItem>();
+
+    get totalCents(): number {
+      return [...this.#items.values()].reduce(
+        (total, item) => total + item.quantity * item.unitCents,
+        0,
+      );
+    }
+
+    add(id: string, item: LineItem): void {
+      this.#items.set(id, item);
+    }
+  }
+
+  const cart = new Cart();
+  cart.add("coffee", { quantity: 1, unitCents: 300 });
+
+  const total = fromStarbeam(() => cart.totalCents);
+
+  function addBagel() {
+    cart.add("bagel", { quantity: 2, unitCents: 250 });
+  }
+</script>
+
+<p>{total.current}</p>
+<button onclick={addBagel}>add bagel</button>

--- a/packages/svelte/svelte/tests/fixtures/FromStarbeamDynamicDependency.svelte
+++ b/packages/svelte/svelte/tests/fixtures/FromStarbeamDynamicDependency.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { fromStarbeam } from "@starbeam/svelte";
+  import type { Cell } from "@starbeam/universal";
+
+  let { left, right }: { left: Cell<number>; right: Cell<number> } = $props();
+
+  let side = $state<"left" | "right">("left");
+  const selected = fromStarbeam(() =>
+    side === "left" ? `left=${left.current}` : `right=${right.current}`,
+  );
+
+  function chooseRight() {
+    side = "right";
+  }
+
+  function bumpLeft() {
+    left.current++;
+  }
+
+  function bumpRight() {
+    right.current++;
+  }
+</script>
+
+<p>{selected.current}</p>
+<button onclick={chooseRight}>choose right</button>
+<button onclick={bumpLeft}>bump left</button>
+<button onclick={bumpRight}>bump right</button>

--- a/packages/svelte/svelte/tests/fixtures/FromStarbeamEffect.svelte
+++ b/packages/svelte/svelte/tests/fixtures/FromStarbeamEffect.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { fromStarbeam } from "@starbeam/svelte";
+  import type { Cell } from "@starbeam/universal";
+  import type { RecordedEvents } from "@starbeam-workspace/test-utils";
+
+  let {
+    count,
+    events,
+  }: { count: Cell<number>; events: RecordedEvents } = $props();
+
+  let observed = $state(0);
+  const doubled = fromStarbeam(() => count.current * 2);
+
+  $effect(() => {
+    const value = doubled.current;
+    observed = value;
+    events.record(`effect:${value}`);
+  });
+
+  function increment() {
+    count.current++;
+  }
+</script>
+
+<p>{observed}</p>
+<button onclick={increment}>increment</button>

--- a/packages/svelte/svelte/tests/fixtures/FromStarbeamMixedState.svelte
+++ b/packages/svelte/svelte/tests/fixtures/FromStarbeamMixedState.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { fromStarbeam } from "@starbeam/svelte";
+  import type { Cell } from "@starbeam/universal";
+
+  let { count }: { count: Cell<number> } = $props();
+
+  let multiplier = $state(2);
+  const scaled = fromStarbeam(() => count.current * multiplier);
+
+  function incrementCount() {
+    count.current++;
+  }
+
+  function triple() {
+    multiplier = 3;
+  }
+</script>
+
+<p>{scaled.current}</p>
+<button onclick={incrementCount}>increment count</button>
+<button onclick={triple}>triple</button>

--- a/packages/svelte/svelte/tests/fixtures/FromStarbeamMultipleConsumers.svelte
+++ b/packages/svelte/svelte/tests/fixtures/FromStarbeamMultipleConsumers.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { fromStarbeam } from "@starbeam/svelte";
+  import type { Cell } from "@starbeam/universal";
+  import type { RecordedEvents } from "@starbeam-workspace/test-utils";
+
+  import Consumer from "./FromStarbeamConsumer.svelte";
+
+  let {
+    count,
+    events,
+  }: { count: Cell<number>; events: RecordedEvents } = $props();
+
+  let first = $state(true);
+  let second = $state(true);
+
+  const value = fromStarbeam(() => {
+    events.record("compute");
+    return count.current;
+  });
+
+  function hideFirst() {
+    first = false;
+  }
+
+  function hideSecond() {
+    second = false;
+  }
+
+  function increment() {
+    count.current++;
+  }
+</script>
+
+<button onclick={hideFirst}>hide first</button>
+<button onclick={hideSecond}>hide second</button>
+<button onclick={increment}>increment</button>
+{#if first}
+  <Consumer label="first" {value} />
+{/if}
+{#if second}
+  <Consumer label="second" {value} />
+{/if}

--- a/packages/svelte/svelte/tests/fixtures/FromStarbeamSSR.svelte
+++ b/packages/svelte/svelte/tests/fixtures/FromStarbeamSSR.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { fromStarbeam } from "@starbeam/svelte";
+  import type { Cell } from "@starbeam/universal";
+  import type { RecordedEvents } from "@starbeam-workspace/test-utils";
+
+  let {
+    count,
+    events,
+  }: { count: Cell<number>; events: RecordedEvents } = $props();
+
+  const doubled = fromStarbeam(() => {
+    events.record("compute");
+    return count.current * 2;
+  });
+</script>
+
+<p>{doubled.current}</p>

--- a/packages/svelte/svelte/tests/fixtures/FromStarbeamZeroDependency.svelte
+++ b/packages/svelte/svelte/tests/fixtures/FromStarbeamZeroDependency.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { fromStarbeam } from "@starbeam/svelte";
+  import type { Cell } from "@starbeam/universal";
+
+  let { count }: { count: Cell<number> } = $props();
+
+  let enabled = $state(false);
+  const value = fromStarbeam(() => (enabled ? `on=${count.current}` : "off"));
+
+  function enable() {
+    enabled = true;
+  }
+
+  function increment() {
+    count.current++;
+  }
+</script>
+
+<p>{value.current}</p>
+<button onclick={enable}>enable</button>
+<button onclick={increment}>increment</button>

--- a/packages/svelte/svelte/tests/from-starbeam-ssr.spec.ts
+++ b/packages/svelte/svelte/tests/from-starbeam-ssr.spec.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+
+import { Cell } from "@starbeam/universal";
+import {
+  describe,
+  expect,
+  RecordedEvents,
+  test,
+} from "@starbeam-workspace/test-utils";
+import { render as renderServer } from "svelte/server";
+
+import FromStarbeamSSR from "./fixtures/FromStarbeamSSR.svelte";
+
+describe("fromStarbeam SSR", () => {
+  test("computes synchronously during server render", () => {
+    const count = Cell(3);
+    const events = new RecordedEvents();
+    const result = renderServer(FromStarbeamSSR, { props: { count, events } });
+
+    expect(result.body).toBe("<!--[--><p>6</p><!--]-->");
+    events.expect("compute");
+  });
+});

--- a/packages/svelte/svelte/tests/from-starbeam.spec.ts
+++ b/packages/svelte/svelte/tests/from-starbeam.spec.ts
@@ -1,0 +1,242 @@
+// @vitest-environment jsdom
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+
+import { Cell } from "@starbeam/universal";
+import {
+  describe,
+  expect,
+  RecordedEvents,
+  test,
+} from "@starbeam-workspace/test-utils";
+import { fireEvent, render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+import FromStarbeamBasic from "./fixtures/FromStarbeamBasic.svelte";
+import FromStarbeamCleanup from "./fixtures/FromStarbeamCleanup.svelte";
+import FromStarbeamDerived from "./fixtures/FromStarbeamDerived.svelte";
+import FromStarbeamDomainGetter from "./fixtures/FromStarbeamDomainGetter.svelte";
+import FromStarbeamDynamicDependency from "./fixtures/FromStarbeamDynamicDependency.svelte";
+import FromStarbeamEffect from "./fixtures/FromStarbeamEffect.svelte";
+import FromStarbeamMixedState from "./fixtures/FromStarbeamMixedState.svelte";
+import FromStarbeamMultipleConsumers from "./fixtures/FromStarbeamMultipleConsumers.svelte";
+import FromStarbeamZeroDependency from "./fixtures/FromStarbeamZeroDependency.svelte";
+
+function html(element: Element): string {
+  return element.innerHTML.replace(/>\s+</g, "><");
+}
+
+describe("fromStarbeam", () => {
+  test("updates a template read when Starbeam state changes", async () => {
+    const count = Cell(1);
+    const result = render(FromStarbeamBasic, { props: { count } });
+
+    expect(html(result.container)).toBe("<p>2</p><button>increment</button>");
+
+    await fireEvent.click(result.getByRole("button", { name: "increment" }));
+    await tick();
+
+    expect(html(result.container)).toBe("<p>4</p><button>increment</button>");
+
+    result.unmount();
+  });
+
+  test("reads a domain-shaped getter over private Starbeam storage", async () => {
+    const result = render(FromStarbeamDomainGetter);
+
+    expect(html(result.container)).toBe("<p>300</p><button>add bagel</button>");
+
+    await fireEvent.click(result.getByRole("button", { name: "add bagel" }));
+    await tick();
+
+    expect(html(result.container)).toBe("<p>800</p><button>add bagel</button>");
+
+    result.unmount();
+  });
+
+  test("updates when Svelte state used by the Starbeam compute changes", async () => {
+    const count = Cell(2);
+    const result = render(FromStarbeamMixedState, { props: { count } });
+
+    expect(html(result.container)).toBe(
+      "<p>4</p><button>increment count</button><button>triple</button>",
+    );
+
+    await fireEvent.click(result.getByRole("button", { name: "triple" }));
+    await tick();
+
+    expect(html(result.container)).toBe(
+      "<p>6</p><button>increment count</button><button>triple</button>",
+    );
+
+    await fireEvent.click(
+      result.getByRole("button", { name: "increment count" }),
+    );
+    await tick();
+
+    expect(html(result.container)).toBe(
+      "<p>9</p><button>increment count</button><button>triple</button>",
+    );
+
+    result.unmount();
+  });
+
+  test("refreshes dynamic Starbeam dependencies", async () => {
+    const left = Cell(1);
+    const right = Cell(10);
+    const result = render(FromStarbeamDynamicDependency, {
+      props: { left, right },
+    });
+
+    expect(html(result.container)).toBe(
+      "<p>left=1</p><button>choose right</button><button>bump left</button><button>bump right</button>",
+    );
+
+    await fireEvent.click(result.getByRole("button", { name: "choose right" }));
+    await tick();
+
+    expect(html(result.container)).toBe(
+      "<p>right=10</p><button>choose right</button><button>bump left</button><button>bump right</button>",
+    );
+
+    await fireEvent.click(result.getByRole("button", { name: "bump left" }));
+    await tick();
+
+    expect(html(result.container)).toBe(
+      "<p>right=10</p><button>choose right</button><button>bump left</button><button>bump right</button>",
+    );
+
+    await fireEvent.click(result.getByRole("button", { name: "bump right" }));
+    await tick();
+
+    expect(html(result.container)).toBe(
+      "<p>right=11</p><button>choose right</button><button>bump left</button><button>bump right</button>",
+    );
+
+    result.unmount();
+  });
+
+  test("can gain its first Starbeam dependency after initial render", async () => {
+    const count = Cell(1);
+    const result = render(FromStarbeamZeroDependency, { props: { count } });
+
+    expect(html(result.container)).toBe(
+      "<p>off</p><button>enable</button><button>increment</button>",
+    );
+
+    await fireEvent.click(result.getByRole("button", { name: "enable" }));
+    await tick();
+
+    expect(html(result.container)).toBe(
+      "<p>on=1</p><button>enable</button><button>increment</button>",
+    );
+
+    await fireEvent.click(result.getByRole("button", { name: "increment" }));
+    await tick();
+
+    expect(html(result.container)).toBe(
+      "<p>on=2</p><button>enable</button><button>increment</button>",
+    );
+
+    result.unmount();
+  });
+
+  test("stops recomputing after unmount", async () => {
+    const count = Cell(1);
+    const events = new RecordedEvents();
+    const result = render(FromStarbeamCleanup, { props: { count, events } });
+
+    expect(html(result.container)).toBe("<p>1</p>");
+    events.expect("compute");
+
+    count.current++;
+    await tick();
+
+    expect(html(result.container)).toBe("<p>2</p>");
+    events.expect("compute");
+
+    result.unmount();
+    await tick();
+
+    count.current++;
+    await tick();
+
+    events.expect();
+  });
+
+  test("keeps a shared bridge live until the last consumer unmounts", async () => {
+    const count = Cell(1);
+    const events = new RecordedEvents();
+    const result = render(FromStarbeamMultipleConsumers, {
+      props: { count, events },
+    });
+
+    expect(html(result.container)).toBe(
+      "<button>hide first</button><button>hide second</button><button>increment</button><p>first=1</p><!----><p>second=1</p><!---->",
+    );
+    events.expect("compute", "compute");
+
+    await fireEvent.click(result.getByRole("button", { name: "hide first" }));
+    await tick();
+
+    expect(html(result.container)).toBe(
+      "<button>hide first</button><button>hide second</button><button>increment</button><!----><p>second=1</p><!---->",
+    );
+    events.expect();
+
+    await fireEvent.click(result.getByRole("button", { name: "increment" }));
+    await tick();
+
+    expect(html(result.container)).toBe(
+      "<button>hide first</button><button>hide second</button><button>increment</button><!----><p>second=2</p><!---->",
+    );
+    events.expect("compute");
+
+    await fireEvent.click(result.getByRole("button", { name: "hide second" }));
+    await tick();
+
+    expect(html(result.container)).toBe(
+      "<button>hide first</button><button>hide second</button><button>increment</button><!----><!---->",
+    );
+    events.expect();
+
+    await fireEvent.click(result.getByRole("button", { name: "increment" }));
+    await tick();
+
+    events.expect();
+
+    result.unmount();
+  });
+
+  test("updates a Svelte $derived consumer", async () => {
+    const count = Cell(2);
+    const result = render(FromStarbeamDerived, { props: { count } });
+
+    expect(html(result.container)).toBe("<p>4</p><button>increment</button>");
+
+    await fireEvent.click(result.getByRole("button", { name: "increment" }));
+    await tick();
+
+    expect(html(result.container)).toBe("<p>6</p><button>increment</button>");
+
+    result.unmount();
+  });
+
+  test("updates a Svelte $effect consumer", async () => {
+    const count = Cell(2);
+    const events = new RecordedEvents();
+    const result = render(FromStarbeamEffect, { props: { count, events } });
+
+    await tick();
+
+    expect(html(result.container)).toBe("<p>4</p><button>increment</button>");
+    events.expect("effect:4");
+
+    await fireEvent.click(result.getByRole("button", { name: "increment" }));
+    await tick();
+
+    expect(html(result.container)).toBe("<p>6</p><button>increment</button>");
+    events.expect("effect:6");
+
+    result.unmount();
+  });
+});

--- a/packages/svelte/svelte/tests/package.json
+++ b/packages/svelte/svelte/tests/package.json
@@ -12,6 +12,7 @@
     "test:types": "tsc -b"
   },
   "dependencies": {
+    "@starbeam/collections": "workspace:^",
     "@starbeam/reactive": "workspace:^",
     "@starbeam/resource": "workspace:^",
     "@starbeam/svelte": "workspace:^",

--- a/packages/universal/runtime/src/timeline/subscriptions.ts
+++ b/packages/universal/runtime/src/timeline/subscriptions.ts
@@ -71,12 +71,14 @@ export class Subscriptions {
   #subscribe(target: Tag, ready: NotifyReady): void {
     if (isUninitialized(target)) {
       this.#queuedSubscriptions.add(target, ready);
-    } else if (hasDependencies(target)) {
+    } else {
       const subscription = this.#tagSubscriptions.get(target);
 
-      // initialize the subscription with the current target's dependencies
-      for (const cell of target.dependencies()) {
-        this.#cellSubscriptions.add(cell, subscription);
+      if (hasDependencies(target)) {
+        // initialize the subscription with the current target's dependencies
+        for (const cell of target.dependencies()) {
+          this.#cellSubscriptions.add(cell, subscription);
+        }
       }
 
       subscription.subscribe(ready);

--- a/packages/universal/runtime/tests/subscribing.spec.ts
+++ b/packages/universal/runtime/tests/subscribing.spec.ts
@@ -99,6 +99,33 @@ describe("Tagged", () => {
     expect(cell.current).toBe(1);
   });
 
+  test("rendering a formula that gains its first dependency", () => {
+    const cell = Cell(0);
+    let enabled = false;
+
+    const formula = Formula(() => (enabled ? cell.current : "off"));
+
+    let stale = false;
+
+    render(formula, () => {
+      stale = true;
+    });
+
+    expect(formula.current).toBe("off");
+    expect(stale).toBe(false);
+
+    enabled = true;
+    expect(formula.current).toBe(0);
+    expect(stale).toBe(false);
+
+    cell.current++;
+
+    expect(stale).toBe(true);
+    stale = false;
+
+    expect(formula.current).toBe(1);
+  });
+
   test("rendering a formula before initialization lazily subscribes once read", () => {
     const cell = Cell(0);
     const formula = CachedFormula(() => cell.current);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -610,6 +610,9 @@ importers:
       '@starbeam-workspace/test-utils':
         specifier: workspace:^
         version: link:../../../../workspace/test-utils
+      '@starbeam/collections':
+        specifier: workspace:^
+        version: link:../../../universal/collections
       '@starbeam/reactive':
         specifier: workspace:^
         version: link:../../../universal/reactive

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,13 @@
     "types": ["node", "./packages/env.d.ts", "vite"],
     "noEmit": true
   },
-  "exclude": ["dist/**/*", "**/dist/**/*", "**/node_modules/**"]
+  "exclude": [
+    "dist/**/*",
+    "**/dist/**/*",
+    "**/node_modules/**",
+    "**/.astro/**/*",
+    "**/.vite/**/*",
+    "coverage/**/*",
+    ".scratch/**/*"
+  ]
 }


### PR DESCRIPTION
## Why

The Svelte first-class adapter decision record identified the first missing piece: a Svelte 5-native read bridge for ordinary Starbeam values. This PR implements that smallest slice so Svelte templates, `$derived`, and `$effect` can consume Starbeam-backed domain reads without React-style dependency arrays or Svelte 4 actions.

## What changed

- Adds `fromStarbeam(() => value)` to `@starbeam/svelte`.
- Exposes a readonly `.current` getter backed by Svelte `createSubscriber`, Starbeam `Formula`, and `RUNTIME.subscribe()`.
- Fixes runtime subscriptions for formulas that initially have no dependencies but gain dependencies later.
- Adds Svelte tests for template reads, domain-shaped getters over private collections, Svelte `$state`, dynamic dependencies, zero-to-first dependencies, cleanup, multiple consumers, `$derived`, `$effect`, and SSR.
- Updates the Svelte package README for the tested read bridge.

## Reviewer notes

This is the first implementation slice from `docs/SVELTE-FIRST-CLASS-ADAPTER.md`. It intentionally does not add Svelte resource or service APIs yet.

A runtime change is included because the zero-dependency test exposed a real subscription gap: subscribed formulas with an initialized-but-empty dependency set still need to retain subscribers so later reads can add dependencies.

## User-facing changes

Adds a new public `@starbeam/svelte` API:

```ts
const total = fromStarbeam(() => cart.totalCents);
```

Svelte components read it as:

```svelte
<p>{total.current}</p>
```
