### PR TITLE
docs: add Svelte framework guide

### DIFF
--- a/workspace/docs/astro.config.mjs
+++ b/workspace/docs/astro.config.mjs
@@ -34,6 +34,7 @@ export default defineConfig({
             { label: "React", link: "/frameworks/react/" },
             { label: "Preact", link: "/frameworks/preact/" },
             { label: "Vue", link: "/frameworks/vue/" },
+            { label: "Svelte", link: "/frameworks/svelte/" },
           ],
         },
         {

--- a/workspace/docs/src/content/docs/frameworks/overview.md
+++ b/workspace/docs/src/content/docs/frameworks/overview.md
@@ -33,8 +33,8 @@ place that connects those reads and resources to React, Preact, Vue, or Svelte.
   resources, services, and element resources.
 - [**Vue**](/frameworks/vue/): setup helpers and directives for reactive state,
   resources, services, and element resources.
-- **Svelte** (planned): element-resource attachments first, with the broader
-  adapter story still maturing.
+- [**Svelte**](/frameworks/svelte/): explicit reactive read values with
+  `fromStarbeam()`, plus Svelte 5 element-resource attachments.
 
 Some guide details may mature at different speeds. The top-level posture stays
 the same: Starbeam is designed to make the same domain-shaped reactive model work

--- a/workspace/docs/src/content/docs/frameworks/svelte.md
+++ b/workspace/docs/src/content/docs/frameworks/svelte.md
@@ -1,0 +1,269 @@
+---
+title: Svelte
+description: "The Svelte adapter connects Starbeam reads and element-backed resources to Svelte 5 components and attachments."
+---
+
+Svelte components are the output boundary for a Starbeam model. Your state can
+stay ordinary JavaScript: classes, getters, methods, maps, and resources.
+
+The current Svelte bridge is explicit. Use `fromStarbeam()` to turn a Starbeam
+read into a Svelte-readable value, then read its `current` getter from markup,
+`$derived`, or `$effect`. Svelte does not yet track a domain getter like
+`cart.totalCents` directly without that boundary.
+
+## Install
+
+Install the Svelte adapter with the framework-neutral Starbeam packages you will
+use for root state and resources:
+
+```sh
+pnpm add @starbeam/svelte @starbeam/universal @starbeam/collections
+```
+
+## Keep the model ordinary JavaScript
+
+Start by marking the storage that changes. The rest of the model can be normal
+domain code.
+
+```ts
+import { reactive } from "@starbeam/collections";
+
+interface LineItem {
+  readonly id: string;
+  readonly name: string;
+  readonly priceCents: number;
+  readonly quantity: number;
+}
+
+interface ProductInput {
+  readonly name: string;
+  readonly priceCents: number;
+}
+
+export class Cart {
+  #items = reactive.Map<string, LineItem>();
+  #nextItemId = 1;
+
+  get items(): readonly LineItem[] {
+    return [...this.#items.values()];
+  }
+
+  get itemCount(): number {
+    return this.items.reduce((total, item) => total + item.quantity, 0);
+  }
+
+  get totalCents(): number {
+    return this.items.reduce(
+      (sum, item) => sum + item.priceCents * item.quantity,
+      0,
+    );
+  }
+
+  add(product: ProductInput): void {
+    const id = `item-${this.#nextItemId++}`;
+
+    this.#items.set(id, {
+      id,
+      name: product.name,
+      priceCents: product.priceCents,
+      quantity: 1,
+    });
+  }
+}
+```
+
+`#items` is the reactive root state. `itemCount`, `totalCents`, and `add()` are
+ordinary JavaScript above it.
+
+## Read the model from Svelte
+
+Use `fromStarbeam()` in the Svelte component. The callback reads ordinary
+Starbeam-backed JavaScript. The returned value has a readonly `current` getter
+that Svelte can read.
+
+```svelte
+<script lang="ts">
+  import { fromStarbeam } from "@starbeam/svelte";
+
+  import { Cart } from "./cart.js";
+
+  const cart = new Cart();
+  const itemCount = fromStarbeam(() => cart.itemCount);
+  const total = fromStarbeam(() => cart.totalCents);
+
+  function addTea() {
+    cart.add({ name: "Tea", priceCents: 500 });
+  }
+</script>
+
+<section>
+  <p>{itemCount.current} items</p>
+  <p>${(total.current / 100).toFixed(2)}</p>
+
+  <button type="button" onclick={addTea}>Add tea</button>
+</section>
+```
+
+The `Cart` shape does not change for Svelte. The adapter boundary is the
+`fromStarbeam(() => cart.totalCents)` call, not a special domain-object shape.
+
+`fromStarbeam()` is experimental. Deeper Svelte integration is tracked in
+[starbeamjs/starbeam#261](https://github.com/starbeamjs/starbeam/issues/261).
+
+## Svelte runes and server render
+
+The current bridge is tested with the Svelte 5 places where a component can read
+state: templates, `$derived`, and `$effect`.
+
+```svelte
+<script lang="ts">
+  import { fromStarbeam } from "@starbeam/svelte";
+  import { Cell } from "@starbeam/universal";
+
+  const count = Cell(1);
+  let multiplier = $state(2);
+
+  const total = fromStarbeam(() => count.current * multiplier);
+  const label = $derived(`total=${total.current}`);
+
+  $effect(() => {
+    document.title = `Cart total: ${total.current}`;
+  });
+
+  function increment() {
+    count.current++;
+  }
+
+  function triple() {
+    multiplier = 3;
+  }
+</script>
+
+<p>{label}</p>
+<button type="button" onclick={increment}>Increment</button>
+<button type="button" onclick={triple}>Triple</button>
+```
+
+The callback may read Starbeam state and Svelte `$state`. It is also tested with
+dynamic Starbeam dependencies, including a callback that gains its first
+Starbeam dependency after the initial render.
+
+On the server, `fromStarbeam()` computes synchronously during render. Browser DOM
+work still belongs in Svelte effects or element resources.
+
+## DOM element resources
+
+Use `elementResource()` when a resource needs a DOM element from Svelte. It
+returns one Svelte-readable store that is also attachable. Attach it with
+`size.attach`; read the resource value with Svelte store syntax.
+
+```ts
+import { Cell, Resource } from "@starbeam/universal";
+
+export interface Size {
+  readonly width: number;
+  readonly height: number;
+}
+
+export function ElementSize(element: HTMLElement) {
+  return Resource(({ on }) => {
+    const width = Cell(0);
+    const height = Cell(0);
+
+    on.sync(() => {
+      const observer = new ResizeObserver(([entry]) => {
+        if (!entry) return;
+
+        width.set(entry.contentRect.width);
+        height.set(entry.contentRect.height);
+      });
+
+      observer.observe(element);
+
+      return () => observer.disconnect();
+    });
+
+    return {
+      get width(): number {
+        return width.current;
+      },
+
+      get height(): number {
+        return height.current;
+      },
+    } satisfies Size;
+  });
+}
+```
+
+```svelte
+<script lang="ts">
+  import { elementResource } from "@starbeam/svelte";
+
+  import { ElementSize } from "./element-size.js";
+
+  const size = elementResource(ElementSize);
+</script>
+
+<section {@attach size.attach}>
+  {$size
+    ? `${Math.round($size.width)} × ${Math.round($size.height)}`
+    : "Measuring…"}
+</section>
+```
+
+The element comes from Svelte. The resource work still lives in Starbeam.
+`elementResource()` and `elementResourceStore()` publish the domain-shaped
+resource value, so the store value is `$size.width`, not `$size.width.current`.
+
+## Lower-level element APIs
+
+`elementResourceStore()` is the explicit store-shaped spelling. It returns the
+same attachable/readable shape as `elementResource()`.
+
+```ts
+const size = elementResourceStore(ElementSize);
+```
+
+`elementResourceAttachment()` is the lower-level attachment spelling. Use it
+when you want to publish the resource value into state you own.
+
+```svelte
+<script lang="ts">
+  import { elementResourceAttachment } from "@starbeam/svelte";
+
+  import { ElementSize, type Size } from "./element-size.js";
+
+  let size = $state<Size | null>(null);
+
+  const attachSize = elementResourceAttachment(ElementSize, {
+    into(value) {
+      size = value;
+    },
+  });
+</script>
+
+<section {@attach attachSize}>
+  {size
+    ? `${Math.round(size.width)} × ${Math.round(size.height)}`
+    : "Measuring…"}
+</section>
+```
+
+The package also exports the public element-resource types:
+`ElementResourceBlueprint`, `ElementResourceAttachment`, `ElementResourceHandle`,
+and `ElementResourceSink`.
+
+## Not available yet
+
+The Svelte adapter does not yet expose component-lifetime `Resource` helpers or
+app-scoped `Service` helpers. Use `fromStarbeam()` for component reads and
+`elementResource()` for DOM element resources today. Track deeper Svelte adapter
+work in [starbeamjs/starbeam#261](https://github.com/starbeamjs/starbeam/issues/261).
+
+## Next steps
+
+- [Core concepts](/concepts/overview/): the framework-neutral Starbeam model.
+- [Framework overview](/frameworks/overview/): how the adapter boundary changes
+  by framework.
+- [Reference](/reference/overview/): the public package surface at a glance.


### PR DESCRIPTION
## Summary

- add the Svelte framework guide with the current `fromStarbeam()` read boundary
- document Svelte 5 element-resource attachments and lower-level element APIs
- link Svelte from the framework overview and sidebar

## Validation

- `pnpm --filter @starbeam-workspace/docs test:lint`
- `pnpm --filter @starbeam-workspace/docs test:types`
- `pnpm --filter @starbeam-workspace/docs build`
- `pnpm exec vitest --run --project svelte --pool forks`
- pre-commit: workspace lint + types

Note: `pnpm --filter @starbeam/svelte test:specs` currently runs from the package cwd and finds no tests. The root Vitest project command above passed for the Svelte specs.

## User-facing changes

Svelte now appears as a first-class framework guide. The guide is explicit that `fromStarbeam()` is experimental and links the deeper integration follow-up in #261.
