### PR TITLE
docs: add lifecycle concepts

### DIFF
--- a/workspace/docs/astro.config.mjs
+++ b/workspace/docs/astro.config.mjs
@@ -25,7 +25,10 @@ export default defineConfig({
         },
         {
           label: "Core concepts",
-          items: [{ label: "Overview", link: "/concepts/overview/" }],
+          items: [
+            { label: "Overview", link: "/concepts/overview/" },
+            { label: "Resources and lifecycle", link: "/concepts/lifecycle/" },
+          ],
         },
         {
           label: "Framework guides",

--- a/workspace/docs/src/content/docs/concepts/lifecycle.md
+++ b/workspace/docs/src/content/docs/concepts/lifecycle.md
@@ -1,0 +1,219 @@
+---
+title: Resources and lifecycle
+description: "How Starbeam resources add setup, sync, and cleanup when reactive work needs a lifetime."
+---
+
+A resource is Starbeam's lifecycle abstraction. Use root state for values that
+only need to be read and updated. Use a resource when the work itself needs to
+start, synchronize, and stop.
+
+That distinction keeps the first idea small:
+
+1. Mark root state.
+2. Keep derived state as ordinary JavaScript.
+3. Reach for resources when the work has a lifetime.
+
+## Root state does not need an owner
+
+Plain root state is reactive as soon as you create it. There is no app
+container, provider, or owner just to make a value reactive.
+
+```ts
+import { reactive } from "@starbeam/collections";
+
+const count = reactive.object({ value: 0 });
+
+count.value++;
+count.value;
+```
+
+The owner appears when the work itself has a lifetime: a timer, subscription,
+socket, observer, DOM element, or shared app service.
+
+## Add a resource when work has a lifetime
+
+A resource wraps lifecycle work while returning the same kind of value your app
+would otherwise use. If the returned value already has the right shape, return a
+reactive object directly.
+
+```ts
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
+
+export const Clock = Resource(({ on }) => {
+  const clock = reactive.object({ now: new Date() });
+
+  on.sync(() => {
+    clock.now = new Date();
+
+    const timer = setInterval(() => {
+      clock.now = new Date();
+    }, 1000);
+
+    return () => clearInterval(timer);
+  });
+
+  return clock;
+});
+```
+
+The resource owns the timer and returns the value the app wants to read:
+`clock.now`. The first sync sets `clock.now` after the framework owner is ready.
+Later timer ticks update the same reactive object.
+
+If the resource needs derived domain values, expose them with ordinary getters
+on the returned object.
+
+## Setup, sync, cleanup, finalize
+
+Resources separate the value you return from the work needed to keep that value
+connected to the outside world.
+
+- **Setup** creates the stable value the resource returns.
+- **Sync** starts or refreshes work after the owner is ready.
+- **Sync cleanup** stops work from the previous sync before the next sync runs.
+- **Finalize** stops work when the owning lifetime ends.
+
+`on.sync()` registers the sync work. Starbeam runs it when the framework adapter
+schedules the resource. If the sync callback returns a function, Starbeam runs
+that cleanup before the next sync and again when the owner finalizes.
+
+That is why the timer cleanup belongs inside `on.sync()`: each sync owns the
+timer it created.
+
+`on.finalize()` is for cleanup that should run once when the owning lifetime
+ends.
+
+```ts
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
+
+const Connection = Resource(({ on }) => {
+  const connection = reactive.object({ status: "connecting" });
+  const socket = new WebSocket("wss://example.com");
+
+  socket.addEventListener("open", () => {
+    connection.status = "open";
+  });
+
+  on.finalize(() => {
+    socket.close();
+    connection.status = "closed";
+  });
+
+  return connection;
+});
+```
+
+Most app code does not call sync or finalize directly. Framework adapters attach
+resources to framework lifetimes and schedule the work for you.
+
+## Framework adapters connect resources to framework lifetimes
+
+The resource definition is framework-neutral. The adapter decides how setup,
+sync, cleanup, and finalize fit into the framework that owns the component.
+
+- [React](/frameworks/react/) uses `useResource()`. The resource belongs to the
+  React component; sync runs in React effect timing after commit, and finalize
+  runs when React unmounts the component.
+- [Preact](/frameworks/preact/) uses `useResource()`. The resource belongs to
+  the Preact component; sync is scheduled through Preact effects, and finalize
+  runs when the component unmounts.
+- [Vue](/frameworks/vue/) uses `setupResource()`. The resource is created from
+  Vue setup, sync is scheduled through Vue's component lifecycle, and finalize
+  runs when Vue unmounts the component.
+- [Svelte](/frameworks/svelte/) supports Starbeam reads and element resources
+  today. It does not expose component-resource or service helpers yet.
+
+This is the reason the framework guides matter. A resource is portable, but the
+owner is framework-specific. The guide for each adapter shows how Starbeam's
+resource phases line up with that framework's words for component work.
+
+## Services are app-scoped resources
+
+A service is resource-backed state with an app lifetime. Use services for shared
+application concerns that should live with the app or framework root, not with a
+single component.
+
+```ts
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
+
+export const Session = Resource(() => {
+  return reactive.object({ userName: "Guest" });
+});
+```
+
+Framework adapters expose service helpers where that app lifetime is available:
+
+- [React](/frameworks/react/) and [Preact](/frameworks/preact/) use
+  `useService()`.
+- [Vue](/frameworks/vue/) uses `setupService()` after installing Starbeam on the
+  Vue app.
+- [Svelte](/frameworks/svelte/) service support is not exposed yet.
+
+## Element resources attach work to DOM elements
+
+Some resources need a DOM element. Element resources let the framework provide
+the element while Starbeam owns the setup, sync, and cleanup work.
+
+```ts
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
+
+interface Size {
+  readonly width: number;
+  readonly height: number;
+}
+
+export function ElementSize(element: Element) {
+  return Resource(({ on }) => {
+    const size = reactive.object({ width: 0, height: 0 }) satisfies Size;
+
+    on.sync(() => {
+      const observer = new ResizeObserver(([entry]) => {
+        if (!entry) return;
+
+        size.width = entry.contentRect.width;
+        size.height = entry.contentRect.height;
+      });
+
+      observer.observe(element);
+
+      return () => observer.disconnect();
+    });
+
+    return size;
+  });
+}
+```
+
+The framework guide for each adapter shows the native attachment shape:
+
+- [React](/frameworks/react/) and [Preact](/frameworks/preact/) use
+  element-resource hooks.
+- [Vue](/frameworks/vue/) uses an element-resource directive.
+- [Svelte](/frameworks/svelte/) uses Svelte 5 attachments.
+
+The concept stays the same: the element comes from the framework, and the value
+you read stays domain-shaped.
+
+## The resource progression
+
+The app-author path is:
+
+1. Mark root state.
+2. Keep derived state as ordinary JavaScript.
+3. Use a resource when work needs setup, sync, or cleanup.
+4. Use a service when resource-backed state should live with the app.
+5. Use an element resource when the resource needs a DOM element from a
+   framework.
+
+You do not need a resource for every reactive value. Use one when the work has a
+lifetime.
+
+## Next steps
+
+- [Framework guides](/frameworks/overview/): connect resource lifetimes to each
+  supported framework.
+- [Reference](/reference/overview/): see the public package surface at a glance.

--- a/workspace/docs/src/content/docs/concepts/overview.md
+++ b/workspace/docs/src/content/docs/concepts/overview.md
@@ -57,13 +57,15 @@ reactive state. In the cart example, `items` and `itemCount` are just getters
 above the private collection. Starbeam records what they read when they run,
 then uses that read trace to validate cached work or update framework renderers.
 
-You do not have to maintain a userland dependency graph.
+You do not list dependencies by hand.
 
 ## Resources
 
 Resources model state with a lifetime. Use them when reactive state needs setup,
 sync, or cleanup: subscriptions, external handles, element work, and other values
-that should start and stop with an owner.
+that should start and stop with an owner. See
+[Resources and lifecycle](/concepts/lifecycle/) for the app-author path from
+resources to services and element resources.
 
 ## Services and app lifetime
 

--- a/workspace/docs/src/content/docs/frameworks/preact.md
+++ b/workspace/docs/src/content/docs/frameworks/preact.md
@@ -137,25 +137,24 @@ value directly.
 
 ```tsx
 import { useResource } from "@starbeam/preact";
-import { Cell, Resource } from "@starbeam/universal";
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
 import type { VNode } from "preact";
 
 const Clock = Resource(({ on }) => {
-  const now = Cell(new Date());
+  const clock = reactive.object({ now: new Date() });
 
   on.sync(() => {
+    clock.now = new Date();
+
     const timer = setInterval(() => {
-      now.set(new Date());
+      clock.now = new Date();
     }, 1000);
 
     return () => clearInterval(timer);
   });
 
-  return {
-    get now(): Date {
-      return now.current;
-    },
-  };
+  return clock;
 });
 
 export function ClockLabel(): VNode {
@@ -166,7 +165,9 @@ export function ClockLabel(): VNode {
 ```
 
 `useResource()` also accepts optional dependencies when the resource blueprint
-depends on changing Preact values.
+depends on changing Preact values. Preact owns the timing: sync is scheduled
+through Preact effects, and cleanup/finalize run when Preact cleans up the
+component.
 
 ## DOM element resources
 
@@ -175,20 +176,20 @@ returns a callback ref plus a pending or attached result.
 
 ```tsx
 import { useElementResource } from "@starbeam/preact";
-import { Cell, Resource } from "@starbeam/universal";
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
 import type { VNode } from "preact";
 
 function ElementSize(element: HTMLElement) {
   return Resource(({ on }) => {
-    const width = Cell(0);
-    const height = Cell(0);
+    const size = reactive.object({ width: 0, height: 0 });
 
     on.sync(() => {
       const observer = new ResizeObserver(([entry]) => {
         if (!entry) return;
 
-        width.set(entry.contentRect.width);
-        height.set(entry.contentRect.height);
+        size.width = entry.contentRect.width;
+        size.height = entry.contentRect.height;
       });
 
       observer.observe(element);
@@ -196,15 +197,7 @@ function ElementSize(element: HTMLElement) {
       return () => observer.disconnect();
     });
 
-    return {
-      get width(): number {
-        return width.current;
-      },
-
-      get height(): number {
-        return height.current;
-      },
-    };
+    return size;
   });
 }
 
@@ -222,7 +215,8 @@ export function MeasuredPanel(): VNode {
 }
 ```
 
-The element comes from Preact. The resource work still lives in Starbeam.
+The element comes from Preact. The resource work still lives in Starbeam and is
+finalized when Preact detaches the element resource.
 
 ## App-scoped services
 
@@ -232,17 +226,12 @@ Preact app.
 
 ```tsx
 import { useService } from "@starbeam/preact";
-import { Cell, Resource } from "@starbeam/universal";
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
 import type { VNode } from "preact";
 
 const SessionService = Resource(() => {
-  const userName = Cell("Guest");
-
-  return {
-    get userName(): string {
-      return userName.current;
-    },
-  };
+  return reactive.object({ userName: "Guest" });
 });
 
 export function CurrentUser(): VNode {

--- a/workspace/docs/src/content/docs/frameworks/react.md
+++ b/workspace/docs/src/content/docs/frameworks/react.md
@@ -127,24 +127,23 @@ value for rendering.
 
 ```tsx
 import { useReactive, useResource } from "@starbeam/react";
-import { Cell, Resource } from "@starbeam/universal";
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
 
 const Clock = Resource(({ on }) => {
-  const now = Cell(new Date());
+  const clock = reactive.object({ now: new Date() });
 
   on.sync(() => {
+    clock.now = new Date();
+
     const timer = setInterval(() => {
-      now.set(new Date());
+      clock.now = new Date();
     }, 1000);
 
     return () => clearInterval(timer);
   });
 
-  return {
-    get now(): Date {
-      return now.current;
-    },
-  };
+  return clock;
 });
 
 export function ClockLabel(): React.ReactElement {
@@ -156,7 +155,8 @@ export function ClockLabel(): React.ReactElement {
 ```
 
 The resource returns a domain-shaped value. The component reads that value at the
-same output boundary as the cart example.
+same output boundary as the cart example. React owns the timing: sync runs after
+React commits, and cleanup/finalize run when React cleans up the component.
 
 ## DOM element resources
 
@@ -165,19 +165,19 @@ returns a callback ref plus a pending or attached result.
 
 ```tsx
 import { useElementResource, useReactive } from "@starbeam/react";
-import { Cell, Resource } from "@starbeam/universal";
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
 
 function ElementSize(element: HTMLElement) {
   return Resource(({ on }) => {
-    const width = Cell(0);
-    const height = Cell(0);
+    const size = reactive.object({ width: 0, height: 0 });
 
     on.sync(() => {
       const observer = new ResizeObserver(([entry]) => {
         if (!entry) return;
 
-        width.set(entry.contentRect.width);
-        height.set(entry.contentRect.height);
+        size.width = entry.contentRect.width;
+        size.height = entry.contentRect.height;
       });
 
       observer.observe(element);
@@ -185,15 +185,7 @@ function ElementSize(element: HTMLElement) {
       return () => observer.disconnect();
     });
 
-    return {
-      get width(): number {
-        return width.current;
-      },
-
-      get height(): number {
-        return height.current;
-      },
-    };
+    return size;
   });
 }
 
@@ -214,7 +206,8 @@ export function MeasuredPanel(): React.ReactElement {
 }
 ```
 
-The element comes from React. The resource work still lives in Starbeam.
+The element comes from React. The resource work still lives in Starbeam and is
+finalized when React detaches the element resource.
 
 ## App-scoped services
 
@@ -224,17 +217,12 @@ app-scoped lifetime.
 
 ```tsx
 import { Starbeam, useReactive, useService } from "@starbeam/react";
-import { Cell, Resource } from "@starbeam/universal";
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
 import { createRoot } from "react-dom/client";
 
 const SessionService = Resource(() => {
-  const userName = Cell("Guest");
-
-  return {
-    get userName(): string {
-      return userName.current;
-    },
-  };
+  return reactive.object({ userName: "Guest" });
 });
 
 createRoot(document.getElementById("root")!).render(

--- a/workspace/docs/src/content/docs/frameworks/svelte.md
+++ b/workspace/docs/src/content/docs/frameworks/svelte.md
@@ -158,7 +158,8 @@ returns one Svelte-readable store that is also attachable. Attach it with
 `size.attach`; read the resource value with Svelte store syntax.
 
 ```ts
-import { Cell, Resource } from "@starbeam/universal";
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
 
 export interface Size {
   readonly width: number;
@@ -167,15 +168,14 @@ export interface Size {
 
 export function ElementSize(element: HTMLElement) {
   return Resource(({ on }) => {
-    const width = Cell(0);
-    const height = Cell(0);
+    const size = reactive.object({ width: 0, height: 0 }) satisfies Size;
 
     on.sync(() => {
       const observer = new ResizeObserver(([entry]) => {
         if (!entry) return;
 
-        width.set(entry.contentRect.width);
-        height.set(entry.contentRect.height);
+        size.width = entry.contentRect.width;
+        size.height = entry.contentRect.height;
       });
 
       observer.observe(element);
@@ -183,15 +183,7 @@ export function ElementSize(element: HTMLElement) {
       return () => observer.disconnect();
     });
 
-    return {
-      get width(): number {
-        return width.current;
-      },
-
-      get height(): number {
-        return height.current;
-      },
-    } satisfies Size;
+    return size;
   });
 }
 ```
@@ -215,6 +207,8 @@ export function ElementSize(element: HTMLElement) {
 The element comes from Svelte. The resource work still lives in Starbeam.
 `elementResource()` and `elementResourceStore()` publish the domain-shaped
 resource value, so the store value is `$size.width`, not `$size.width.current`.
+The attachment owns the resource lifetime and finalizes it when Svelte detaches
+the element.
 
 ## Lower-level element APIs
 

--- a/workspace/docs/src/content/docs/frameworks/vue.md
+++ b/workspace/docs/src/content/docs/frameworks/vue.md
@@ -133,24 +133,23 @@ domain-shaped value.
 ```vue
 <script setup lang="ts">
 import { setupResource } from "@starbeam/vue";
-import { Cell, Resource } from "@starbeam/universal";
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
 
 const Clock = Resource(({ on }) => {
-  const now = Cell(new Date());
+  const clock = reactive.object({ now: new Date() });
 
   on.sync(() => {
+    clock.now = new Date();
+
     const timer = setInterval(() => {
-      now.set(new Date());
+      clock.now = new Date();
     }, 1000);
 
     return () => clearInterval(timer);
   });
 
-  return {
-    get now(): Date {
-      return now.current;
-    },
-  };
+  return clock;
 });
 
 const clock = setupResource(Clock);
@@ -162,7 +161,9 @@ const clock = setupResource(Clock);
 ```
 
 The resource returns ordinary domain data. Vue render reads that data through
-the Starbeam/Vue bridge that `setupResource()` created for the component.
+the Starbeam/Vue bridge that `setupResource()` created for the component. Vue
+owns the timing: sync runs from Vue's component lifecycle, and cleanup/finalize
+run when Vue unmounts the component.
 
 ## DOM element resources
 
@@ -173,7 +174,8 @@ It returns a Vue directive. Directives do not return template values, so pass an
 ```vue
 <script setup lang="ts">
 import { elementResourceDirective } from "@starbeam/vue";
-import { Cell, Resource } from "@starbeam/universal";
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
 import { shallowRef } from "vue";
 
 interface Size {
@@ -183,15 +185,14 @@ interface Size {
 
 function ElementSize(element: Element) {
   return Resource(({ on }) => {
-    const width = Cell(0);
-    const height = Cell(0);
+    const size = reactive.object({ width: 0, height: 0 }) satisfies Size;
 
     on.sync(() => {
       const observer = new ResizeObserver(([entry]) => {
         if (!entry) return;
 
-        width.set(entry.contentRect.width);
-        height.set(entry.contentRect.height);
+        size.width = entry.contentRect.width;
+        size.height = entry.contentRect.height;
       });
 
       observer.observe(element);
@@ -199,15 +200,7 @@ function ElementSize(element: Element) {
       return () => observer.disconnect();
     });
 
-    return {
-      get width(): number {
-        return width.current;
-      },
-
-      get height(): number {
-        return height.current;
-      },
-    } satisfies Size;
+    return size;
   });
 }
 
@@ -250,16 +243,11 @@ Then read the service from component setup.
 ```vue
 <script setup lang="ts">
 import { setupService } from "@starbeam/vue";
-import { Cell, Resource } from "@starbeam/universal";
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
 
 const SessionService = Resource(() => {
-  const userName = Cell("Guest");
-
-  return {
-    get userName(): string {
-      return userName.current;
-    },
-  };
+  return reactive.object({ userName: "Guest" });
 });
 
 const session = setupService(SessionService);

--- a/workspace/docs/src/content/docs/reference/overview.md
+++ b/workspace/docs/src/content/docs/reference/overview.md
@@ -19,7 +19,8 @@ complete API reference.
 
 - `@starbeam/resource`: resource APIs for reusable setup, sync, and cleanup
   abstractions. App code often reaches resources through `@starbeam/universal`
-  or a framework adapter first.
+  or a framework adapter first. Start with
+  [Resources and lifecycle](/concepts/lifecycle/) for the app-author model.
 - `@starbeam/service`: app-lifetime resource composition. Use it for shared
   state that should live with the app or framework root.
 

--- a/workspace/docs/src/content/docs/start/introduction.md
+++ b/workspace/docs/src/content/docs/start/introduction.md
@@ -131,29 +131,28 @@ adds lifecycle hooks. This example is a preview; framework adapters normally
 schedule resources for you.
 
 ```ts
-import { Cell, Resource } from "@starbeam/universal";
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
 
 const Clock = Resource(({ on }) => {
-  const now = Cell(Date.now());
+  const clock = reactive.object({ now: Date.now() });
 
   on.sync(() => {
+    clock.now = Date.now();
+
     const timer = setInterval(() => {
-      now.set(Date.now());
+      clock.now = Date.now();
     }, 1000);
 
     return () => clearInterval(timer);
   });
 
-  return {
-    get now(): number {
-      return now.current;
-    },
-  };
+  return clock;
 });
 ```
 
-The resource returns an ordinary object with a `now` getter. The lifecycle work is
-attached to the resource, not pushed through every caller.
+The resource returns an ordinary object with a `now` property. The lifecycle work
+is attached to the resource, not pushed through every caller.
 
 ## Legible to humans and agents
 
@@ -169,5 +168,7 @@ as JavaScript.
 ## Next steps
 
 - Read [Core concepts](/concepts/overview/) for the map of Starbeam's model.
+- Read [Resources and lifecycle](/concepts/lifecycle/) when work needs setup,
+  sync, or cleanup.
 - Read [Framework guides](/frameworks/overview/) to see how adapters connect this
   model to React, Preact, Vue, and Svelte.


### PR DESCRIPTION
## Summary

- add a Core concepts Lifecycle page for resources, services, and element resources
- link Lifecycle from the Core concepts sidebar, Start next steps, Concepts overview, and Reference overview
- keep the lifecycle story aligned with the positioning memo: root state first, ordinary JavaScript above it, resources only when work needs setup/sync/cleanup

## Validation

- `pnpm --filter @starbeam-workspace/docs test:lint`
- `pnpm --filter @starbeam-workspace/docs test:types`
- `pnpm --filter @starbeam-workspace/docs build`
- `git diff --check`
- content check for quarantined/internal terms and invalid Svelte lifecycle claims
- pre-commit: workspace lint + types

## User-facing changes

Adds a lifecycle concept page at `/concepts/lifecycle/` that explains when plain root state is enough and when to reach for resources, services, or element resources.
