### PR TITLE
docs: add package chooser

### DIFF
--- a/workspace/docs/astro.config.mjs
+++ b/workspace/docs/astro.config.mjs
@@ -21,7 +21,10 @@ export default defineConfig({
       sidebar: [
         {
           label: "Start",
-          items: [{ label: "Introduction", link: "/start/introduction/" }],
+          items: [
+            { label: "Introduction", link: "/start/introduction/" },
+            { label: "Install Starbeam", link: "/start/install/" },
+          ],
         },
         {
           label: "Core concepts",

--- a/workspace/docs/src/content/docs/frameworks/overview.md
+++ b/workspace/docs/src/content/docs/frameworks/overview.md
@@ -25,6 +25,8 @@ Starbeam's model and the framework's rendering and lifecycle rules. Your domain
 model can still expose normal getters, methods, and objects; the adapter is the
 place that connects those reads and resources to React, Preact, Vue, or Svelte.
 
+Need the package list first? Start with [Install Starbeam](/start/install/).
+
 ## Guides
 
 - [**React**](/frameworks/react/): hooks for reactive reads, resources,

--- a/workspace/docs/src/content/docs/reference/overview.md
+++ b/workspace/docs/src/content/docs/reference/overview.md
@@ -6,6 +6,9 @@ description: Starbeam's public package surface at a glance.
 This section maps the public Starbeam package surface. It is an overview, not a
 complete API reference.
 
+If you are choosing what to install first, start with
+[Install Starbeam](/start/install/).
+
 ## Starter and app-facing packages
 
 - `@starbeam/collections`: reactive `Map`, `Set`, array, and object helpers for
@@ -22,7 +25,8 @@ complete API reference.
   or a framework adapter first. Start with
   [Resources and lifecycle](/concepts/lifecycle/) for the app-author model.
 - `@starbeam/service`: app-lifetime resource composition. Use it for shared
-  state that should live with the app or framework root.
+  state that should live with the app or framework root. App authors usually
+  reach services through framework adapter helpers.
 
 ## Lower-level and compatibility packages
 

--- a/workspace/docs/src/content/docs/start/install.md
+++ b/workspace/docs/src/content/docs/start/install.md
@@ -1,0 +1,170 @@
+---
+title: Install Starbeam
+description: "Choose the Starbeam packages to install for framework apps, framework-neutral models, and reusable libraries."
+---
+
+Install the packages you import directly. Most apps need one framework adapter,
+`@starbeam/universal`, and `@starbeam/collections`.
+
+## What are you building?
+
+| If you are building…      | Install…                                                     | Start with…                                                                       |
+| ------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| A framework-neutral model | `@starbeam/universal @starbeam/collections`                  | `reactive` collections, domain objects, and `Resource`                            |
+| A React app               | `@starbeam/react @starbeam/universal @starbeam/collections`  | `useReactive()`, `useResource()`, `useService()`, `useElementResource()`          |
+| A Preact app              | `@starbeam/preact @starbeam/universal @starbeam/collections` | `install(options)`, direct render reads, resource/service hooks                   |
+| A Vue app                 | `@starbeam/vue @starbeam/universal @starbeam/collections`    | `setupReactive()`, `setupResource()`, `setupService()`, element-resource directives |
+| A Svelte app              | `@starbeam/svelte @starbeam/universal @starbeam/collections` | `fromStarbeam()` and Svelte 5 element-resource attachments                        |
+| A reusable library        | `@starbeam/universal @starbeam/collections`                  | framework-neutral state and domain-shaped APIs                                   |
+
+## Framework-neutral state
+
+Use this when you are writing a model that is not tied to one UI framework.
+
+```sh
+pnpm add @starbeam/universal @starbeam/collections
+```
+
+Import collection-shaped root state from `@starbeam/collections`:
+
+```ts
+import { reactive } from "@starbeam/collections";
+```
+
+Import lifecycle APIs from `@starbeam/universal` when work needs setup, sync, or
+cleanup:
+
+```ts
+import { Resource } from "@starbeam/universal";
+```
+
+Most app models start here: mark the storage that changes, then expose ordinary
+JavaScript above it.
+
+## Framework apps
+
+Add the adapter for the framework that owns rendering.
+
+### React
+
+```sh
+pnpm add @starbeam/react @starbeam/universal @starbeam/collections
+```
+
+```ts
+import {
+  Starbeam,
+  useElementResource,
+  useReactive,
+  useResource,
+  useService,
+} from "@starbeam/react";
+```
+
+Use the React guide for the bridge argument, resources, services, and element
+resources: [React](/frameworks/react/).
+
+### Preact
+
+```sh
+pnpm add @starbeam/preact @starbeam/universal @starbeam/collections
+```
+
+```ts
+import {
+  install,
+  useElementResource,
+  useResource,
+  useService,
+} from "@starbeam/preact";
+```
+
+Install Starbeam into Preact `options`, then ordinary render reads are tracked by
+the adapter: [Preact](/frameworks/preact/).
+
+### Vue
+
+```sh
+pnpm add @starbeam/vue @starbeam/universal @starbeam/collections
+```
+
+```ts
+import {
+  Starbeam,
+  elementResourceDirective,
+  setupReactive,
+  setupResource,
+  setupService,
+} from "@starbeam/vue";
+```
+
+Vue uses Composition API setup helpers and directives: [Vue](/frameworks/vue/).
+
+### Svelte
+
+```sh
+pnpm add @starbeam/svelte @starbeam/universal @starbeam/collections
+```
+
+```ts
+import {
+  elementResource,
+  elementResourceAttachment,
+  elementResourceStore,
+  fromStarbeam,
+} from "@starbeam/svelte";
+```
+
+Svelte currently exposes Starbeam reads through `fromStarbeam()` and DOM element
+resources through Svelte 5 attachments. Component-resource and app-service
+helpers are not exposed yet. See [Svelte](/frameworks/svelte/).
+
+## Direct packages
+
+Most app code should start with the packages above. Reach for direct packages
+when you are writing reusable libraries or adapter-level integration code.
+
+If your library only exposes ordinary Starbeam-backed objects, start with the
+same framework-neutral install:
+
+```sh
+pnpm add @starbeam/universal @starbeam/collections
+```
+
+Add direct packages only when your library needs their lower-level APIs.
+
+### `@starbeam/resource`
+
+Use `@starbeam/resource` directly when you are authoring reusable resource
+helpers or doing manual resource integration. App code usually imports
+`Resource` from `@starbeam/universal` or consumes resources through a framework
+adapter.
+
+### `@starbeam/service`
+
+`@starbeam/service` is the lower-level app-scoped service kernel. App authors
+usually use framework adapter helpers instead:
+
+- React and Preact: `useService()`;
+- Vue: `setupService()`; install the Starbeam plugin when you want to establish
+  app ownership explicitly;
+- Svelte: service helpers are not exposed yet.
+
+### `@starbeam/reactive`
+
+Use `@starbeam/reactive` directly when you are writing library code that needs
+primitive reactive values such as `Cell`, `Formula`, or `CachedFormula`. App code
+should usually import those through `@starbeam/universal`.
+
+### `@starbeam/core`
+
+Do not start new code with `@starbeam/core`. It is a deprecated compatibility
+alias for `@starbeam/universal`.
+
+## Next steps
+
+- [Start with root state](/start/introduction/): build a first Starbeam model.
+- [Core concepts](/concepts/overview/): learn the framework-neutral model.
+- [Framework guides](/frameworks/overview/): connect the model to your UI
+  framework.
+- [Reference](/reference/overview/): see the public package surface at a glance.

--- a/workspace/docs/src/content/docs/start/introduction.md
+++ b/workspace/docs/src/content/docs/start/introduction.md
@@ -24,6 +24,9 @@ framework, such as `@starbeam/react`, `@starbeam/preact`, `@starbeam/vue`, or
 `@starbeam/svelte`. This page stays framework-neutral; framework guides cover
 the adapter APIs.
 
+Choosing packages for a framework app or reusable library? See
+[Install Starbeam](/start/install/).
+
 ## Import the first root state helper
 
 The first example uses a reactive `Map` for root state:
@@ -167,6 +170,8 @@ as JavaScript.
 
 ## Next steps
 
+- Read [Install Starbeam](/start/install/) to choose packages for your app or
+  library.
 - Read [Core concepts](/concepts/overview/) for the map of Starbeam's model.
 - Read [Resources and lifecycle](/concepts/lifecycle/) when work needs setup,
   sync, or cleanup.


### PR DESCRIPTION
## Why

Readers can now follow the homepage into real docs, but they still need a direct answer to which Starbeam packages to install for their app or library.

## What changed

- Adds an Install Starbeam page under Start.
- Covers framework-neutral models, React, Preact, Vue, Svelte, and reusable libraries.
- Explains when app authors should avoid direct lower-level packages.
- Links the chooser from Start, Framework overview, and Reference overview.

## User-facing changes

The Start section now includes a package chooser that leads with app/framework choices instead of package taxonomy.
