### PR TITLE
docs: fix homepage hero padding

### DIFF
--- a/workspace/docs/src/components/BrandHero.astro
+++ b/workspace/docs/src/components/BrandHero.astro
@@ -168,7 +168,6 @@ import StarMark from "./StarMark.astro";
       align-items: start;
       grid-template-columns: 1fr;
       min-height: auto;
-      padding-block-end: 0;
     }
 
     .hero__mark {
@@ -188,7 +187,7 @@ import StarMark from "./StarMark.astro";
   @media (max-width: 540px) {
     .hero {
       border-radius: 2rem;
-      padding: 2rem 1.35rem 0;
+      padding: 2rem 1.35rem;
       width: min(88rem, calc(100vw - clamp(1rem, 5vw, 2rem)));
     }
 


### PR DESCRIPTION
## Why

On narrow-ish screens, the homepage hero CTA buttons were flush against the bottom edge of the hero card because responsive rules removed bottom padding.

## What changed

- Restores bottom padding for the responsive hero layout.
- Removes the mobile-only zero bottom padding override.

## User-facing changes

The homepage hero has consistent breathing room around the CTA buttons on narrow and mobile widths.
