### PR TITLE
docs: add experiments overview

### DIFF
--- a/workspace/docs/src/content/docs/experiments/overview.md
+++ b/workspace/docs/src/content/docs/experiments/overview.md
@@ -1,11 +1,76 @@
 ---
 title: Experiments
-description: Placeholder for Starbeam experimental packages.
+description: "Active Starbeam prototypes and experimental packages that are not the stable app-author path."
 ---
 
-This section will cover experimental packages and prototypes once they are ready for public documentation.
+Experiments are active prototypes. They are useful for exploring directions the
+project may take, but they are not the default packages to install for app code.
 
-## Planned topics
+If you are building an app, start with [Install Starbeam](/start/install/) and
+the [Framework guides](/frameworks/overview/). If you are looking for public API
+orientation, use [Reference](/reference/overview/).
 
-- `@starbeamx/store`
-- `@starbeamx/vanilla`
+## How to read experiments
+
+- Treat APIs as provisional.
+- Expect README examples to lag behind source and tests.
+- Prefer current source and tests over older examples.
+- Do not treat experimental packages as compatibility commitments.
+- Use [Archive](/archive/overview/) for historical notes and
+  [Advanced](/advanced/overview/) for current implementor orientation.
+
+## Current experiments
+
+### `@starbeamx/store`
+
+`@starbeamx/store` explores reactive table, query, grouping, and aggregation
+APIs. It is a public experiment, not the default way to model app state.
+
+Useful for exploring:
+
+- table-shaped data;
+- reactive queries and filters;
+- grouping and aggregation over changing rows.
+
+Current runtime exports include `Table`, `Query`, `Filter`, `Average`, and
+`Sum`. Type exports include `Aggregator`, `TableRows`, and `RowTypeFor`.
+
+Source material:
+
+- [packages/x/store/README.md](https://github.com/starbeamjs/starbeam/blob/main/packages/x/store/README.md)
+- [packages/x/store/index.ts](https://github.com/starbeamjs/starbeam/blob/main/packages/x/store/index.ts)
+
+Caution: the README is example-heavy and may lag current source APIs. Use it for
+orientation, not as a stable reference.
+
+### `@starbeamx/vanilla`
+
+`@starbeamx/vanilla` explores a minimal DOM renderer and reference implementation
+for Starbeam-backed rendering without a framework adapter.
+
+Useful for exploring:
+
+- how Starbeam can drive text, attributes, elements, and fragments;
+- renderer ideas without React, Preact, Vue, or Svelte;
+- small implementation examples for people studying render integration.
+
+It is not intended to be a full app framework. App authors should normally use a
+framework adapter.
+
+Source material:
+
+- [packages/x/vanilla/README.md](https://github.com/starbeamjs/starbeam/blob/main/packages/x/vanilla/README.md)
+- [packages/x/vanilla/index.ts](https://github.com/starbeamjs/starbeam/blob/main/packages/x/vanilla/index.ts)
+
+## Not the stable path
+
+Experiments can become future public APIs, stay as examples, or disappear. They
+are intentionally separate from the stable app-author path.
+
+For stable docs, use:
+
+- [Start](/start/introduction/)
+- [Install Starbeam](/start/install/)
+- [Core concepts](/concepts/overview/)
+- [Framework guides](/frameworks/overview/)
+- [Reference](/reference/overview/)


### PR DESCRIPTION
## Why

The Experiments section was still a placeholder. We need a clear distinction between stable app-author docs, active experiments, and historical archive material.

## What changed

- Replaces the experiments placeholder with an overview of active Starbeam experimental packages.
- Frames experiments as provisional prototypes, not the stable app-author path.
- Covers `@starbeamx/store` and `@starbeamx/vanilla` with source links and cautions.
- Links readers back to stable docs for production-ready usage.

## User-facing changes

The Experiments section now explains how to read experimental packages without treating them as default app packages or stable API commitments.
