### PR TITLE
docs: add collections concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ stays inspectable JavaScript.
 
 ## How the model scales
 
-1. **Mark root state.** Use reactive collections for collection-shaped state and
-   framework-neutral primitives when scalar state is the right shape.
+1. **Mark root state.** Use reactive collections and objects for the values that
+   change.
 2. **Keep derived state ordinary.** Use functions, getters, methods, and classes
    above root state.
 3. **Add lifecycle when work needs it.** Use resources for setup, sync, and

--- a/docs/DOCUMENTATION-DASHBOARD.md
+++ b/docs/DOCUMENTATION-DASHBOARD.md
@@ -43,18 +43,18 @@ The remaining documentation work should reinforce the public model:
 
 ## Dashboard
 
-| Priority | Arc                                      | Status  | Primary files                                                                                    | Why it matters                                                                                                                                           |
-| -------- | ---------------------------------------- | ------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| P0       | Collections concept + package README     | Next    | `workspace/docs/src/content/docs/concepts/`, `packages/universal/collections/README.md`          | Collections are now the preferred root-state story for collection-shaped data, but the package README is stale and the concept has no first-class route. |
-| P0       | Reactive primitive README rewrite        | Ready   | `packages/universal/reactive/README.md`                                                          | `@starbeam/reactive` is public for authors building primitives, but the README still blends that surface with runtime/protocol caveats.                  |
-| P1       | Preact package README                    | Ready   | `packages/preact/preact/README.md`                                                               | Preact has a website guide and public package, but no package-level front door.                                                                          |
-| P1       | Core deprecation README + migration page | Ready   | `packages/universal/core/README.md`, `workspace/docs/src/content/docs/`                          | Existing users may land on `@starbeam/core`; they need a direct path to `@starbeam/universal`.                                                           |
-| P1       | Concept route expansion                  | Ready   | `workspace/docs/src/content/docs/concepts/`, `workspace/docs/astro.config.mjs`                   | Services and element resources are central concepts but currently live inside overview/lifecycle pages.                                                  |
-| P1       | Reference expansion                      | Ready   | `workspace/docs/src/content/docs/reference/`, `workspace/docs/astro.config.mjs`                  | The Reference route currently cannot answer concrete API questions.                                                                                      |
-| P2       | Status consistency pass                  | Ready   | `README.md`, framework docs, package READMEs, install/reference pages                            | Svelte, Vue, and experiments need consistent status language across entry points.                                                                        |
-| P2       | `@starbeam/use-strict-lifecycle` README  | Ready   | `packages/react/use-strict-lifecycle/README.md`, `packages/react/use-strict-lifecycle/THEORY.md` | A public package currently ships an empty README.                                                                                                        |
-| P2       | Experiment package README cleanup        | Ready   | `packages/x/store/README.md`, `packages/x/vanilla/README.md`, experiment package metadata        | The website quarantines experiments, but package surfaces still leak stale or placeholder signals.                                                       |
-| P3       | Ember website integration                | Blocked | Ember package/docs after PR #273 is reviewed                                                     | The adapter surface needs review before it becomes part of the public framework guide set.                                                               |
+| Priority | Arc                                      | Status  | Primary files                                                                                    | Why it matters                                                                                                                          |
+| -------- | ---------------------------------------- | ------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| P0       | Collections concept + package README     | Done    | `workspace/docs/src/content/docs/concepts/`, `packages/universal/collections/README.md`          | Collections are now the preferred root-state story for collection-shaped data, with a concept route and aligned package README.         |
+| P0       | Reactive primitive README rewrite        | Next    | `packages/universal/reactive/README.md`                                                          | `@starbeam/reactive` is public for authors building primitives, but the README still blends that surface with runtime/protocol caveats. |
+| P1       | Preact package README                    | Ready   | `packages/preact/preact/README.md`                                                               | Preact has a website guide and public package, but no package-level front door.                                                         |
+| P1       | Core deprecation README + migration page | Ready   | `packages/universal/core/README.md`, `workspace/docs/src/content/docs/`                          | Existing users may land on `@starbeam/core`; they need a direct path to `@starbeam/universal`.                                          |
+| P1       | Concept route expansion                  | Ready   | `workspace/docs/src/content/docs/concepts/`, `workspace/docs/astro.config.mjs`                   | Services and element resources are central concepts but currently live inside overview/lifecycle pages.                                 |
+| P1       | Reference expansion                      | Ready   | `workspace/docs/src/content/docs/reference/`, `workspace/docs/astro.config.mjs`                  | The Reference route currently cannot answer concrete API questions.                                                                     |
+| P2       | Status consistency pass                  | Ready   | `README.md`, framework docs, package READMEs, install/reference pages                            | Svelte, Vue, and experiments need consistent status language across entry points.                                                       |
+| P2       | `@starbeam/use-strict-lifecycle` README  | Ready   | `packages/react/use-strict-lifecycle/README.md`, `packages/react/use-strict-lifecycle/THEORY.md` | A public package currently ships an empty README.                                                                                       |
+| P2       | Experiment package README cleanup        | Ready   | `packages/x/store/README.md`, `packages/x/vanilla/README.md`, experiment package metadata        | The website quarantines experiments, but package surfaces still leak stale or placeholder signals.                                      |
+| P3       | Ember website integration                | Blocked | Ember package/docs after PR #273 is reviewed                                                     | The adapter surface needs review before it becomes part of the public framework guide set.                                              |
 
 ## PER arcs
 
@@ -298,18 +298,21 @@ into the same public docs matrix as the other framework adapters.
 
 ## Recommended next arc
 
-Start with **PER 1: Collections concept and package README**.
+After PER 1 lands, continue with **PER 2: Reactive primitive README rewrite**.
 
-It is the highest-leverage follow-up because it reinforces the correction that
-started the current docs arc: when state is collection-shaped, teach reactive
-collections as the root-state boundary instead of teaching users to model a
-collection as a `Cell` around immutable updates.
+PER 1 reinforces the correction that started the current docs arc: when state is
+collection-shaped, teach reactive collections as the root-state boundary instead
+of teaching users to model a collection as a `Cell` around immutable updates.
 
 The same principle applies to single-slot state in first-run docs: do not teach
 `Cell` as the “one thing” primitive. If the public state wants a `current` slot,
 `reactive.object({ current: ... })` has the same app-facing behavior while
 keeping the teaching model object-shaped. Reserve `Cell` and `Marker` for pages
 about building primitives or low-level reactive storage.
+
+PER 2 should make that reservation explicit by rewriting the primitive package
+README around authors building primitives, not app authors modeling ordinary
+state.
 
 ## Validation checklist
 

--- a/packages/universal/collections/README.md
+++ b/packages/universal/collections/README.md
@@ -1,120 +1,142 @@
-# Starbeam Collections
+# @starbeam/collections
 
-Starbeam collections are reactive implementations of JavaScript built-in
+Reactive JavaScript collections and objects for Starbeam root state.
+
+Use this package when the state you want to track is already shaped like a
+JavaScript `Map`, `Set`, array, or object. Mark that storage reactive, then keep
+the rest of your model as ordinary JavaScript.
+
+```sh
+pnpm add @starbeam/collections
+```
+
+```ts
+import { reactive } from "@starbeam/collections";
+```
+
+## Public helpers
+
+| Helper                     | Use for                                       |
+| -------------------------- | --------------------------------------------- |
+| `reactive.Map<K, V>()`     | keyed records, registries, caches, carts      |
+| `reactive.Set<T>()`        | membership, selection, tags                   |
+| `reactive.array<T>([])`    | ordered list state                            |
+| `reactive.object({ ... })` | object-shaped state, including one-slot state |
+| `reactive.WeakMap<K, V>()` | object-keyed storage with weak ownership      |
+| `reactive.WeakSet<T>()`    | weak object membership                        |
+
+`reactive.Map()` and `reactive.Set()` create empty collections. Add entries with
+the normal JavaScript methods.
+
+```ts
+const recipes = reactive.Map<string, { url: string }>();
+
+recipes.set("pie", { url: "https://example.com/pie" });
+recipes.has("pie");
+recipes.get("pie");
+```
+
+`reactive.object()` and `reactive.array()` wrap an initial object or array.
+
+```ts
+const clock = reactive.object({ now: new Date() });
+clock.now = new Date();
+
+const items = reactive.array<string>([]);
+items.push("tea");
+```
+
+Use the named `reactive` import in examples and application code.
+
+## Domain-shaped models
+
+Reactive storage is usually private. Expose the domain-shaped values and methods
+that callers should use.
+
+```ts
+import { reactive } from "@starbeam/collections";
+
+interface LineItem {
+  readonly id: string;
+  readonly name: string;
+  readonly priceCents: number;
+  readonly quantity: number;
+}
+
+export class Cart {
+  #items = reactive.Map<string, LineItem>();
+
+  get items(): readonly LineItem[] {
+    return [...this.#items.values()];
+  }
+
+  get itemCount(): number {
+    return this.items.reduce((total, item) => total + item.quantity, 0);
+  }
+
+  get totalCents(): number {
+    return this.items.reduce(
+      (sum, item) => sum + item.priceCents * item.quantity,
+      0,
+    );
+  }
+
+  add(item: LineItem): void {
+    this.#items.set(item.id, item);
+  }
+}
+```
+
+The private `Map` is root state. The public API is ordinary JavaScript:
+`cart.items`, `cart.itemCount`, `cart.totalCents`, and `cart.add()`.
+
+## One-slot state is still object-shaped
+
+For app-facing docs and package examples, use the shape your app wants to expose.
+If a value wants a `current` slot, model that slot as an object property.
+
+```ts
+const currentUser = reactive.object({ current: null as User | null });
+
+currentUser.current = { id: "tom", name: "Tom Dale" };
+```
+
+Lower-level storage primitives are useful when you are building new reactive
+primitives. Most app and library models should start with objects and
 collections.
 
-- [Object]
-- [Array]
-- [Map]
-- [Set]
-- [WeakMap]
-- [WeakSet]
+## Granular updates
 
-Starbeam collections behave identically to the JavaScript built-ins that they
-implement.
+Starbeam tracks the JavaScript read your code performed.
 
-> 📢 Starbeam Collections do not support prototype mutation. This is the only known
-> divergence from the JavaScript APIs.
+For a `Map`:
 
-Internally, Starbeam collections model JavaScript read operations in one of
-three ways:
+- `map.has(key)` tracks whether that key is present.
+- `map.get(key)` tracks the value for that key.
+- `map.size` and `map.keys()` track membership changes.
+- `map.values()`, `map.entries()`, spreading, and `forEach()` track value
+  iteration.
 
-- key accesses, which check whether a key is a member of the collection.
-- value accesses, which access and return a value from the collection.
-- key iterations, which iterate over a collection's keys.
-- value iterations, which iterate over a collection's values.
+For a `Set`, `set.has(value)` tracks membership for that value. Adding a value
+that is already present does not change membership.
 
-## Example
+Objects follow the same idea: a direct property read is narrower than enumerating
+the whole object.
 
-For example, in the `Map` API:
+Arrays track length, indices, and iteration, but array updates can affect the
+surrounding list shape. Treat array iteration and list mutations as broader than
+direct object-property reads.
 
-- `has(key)` is a **key access**.
-- `get(key)` is an **value access**.
-- `keys()` is a **key iteration**.
-- `values()` is a **value iteration**.
-- `entries()` is a **key and value iteration**.
-- iterating the map via `Symbol.iterator` or `forEach` is a **key and value
-  iteration**.
+Starbeam tracks storage reads and writes. It does not compare the previous output
+of a getter with the next output to decide whether a read should update.
 
-Consider this formula:
+## Learn more
 
-```ts
-const recipes = reactive.Map(["pie", "http://example.com/pie-recipe"]);
-const hasTastyFood = Formula(() => food.has("pie") || food.has("cookie"));
-```
-
-This formula makes two _key accesses_: `"pie"` and `"cookie"`.
-
-If the URL for `pie` is updated:
-
-```ts
-recipes.set("pie", "http://example.com/better-pie-recipe");
-```
-
-This formula updates the _value_ of `"pie"`, but the _key_ has not changed. The
-`hasTastyFood` formula **will not invalidate**.
-
-Categorizing operations this way supports the intuition that `hasTastyFood` has
-not changed by providing enough granularity to capture the user's intent.
-
-## Iteration
-
-If a formula iterates over a reactive collection, the formula will invalidate
-when the collection changes.
-
-Replacing an existing value will invalidate a _value iteration_ but not a _key
-iteration_. Adding a new entry or deleting an existing entry will invalidate
-both.
-
-Let's create a couple of new formulas in our recipe example:
-
-```ts
-const recipeCount = Formula(() => recipes.size);
-const uniqueRecipeURLs = Formula(
-  () => new Set([...recipes.values()].map((r) => r.url))
-);
-```
-
-The `recipeCount` formula only changes when the _key iteration_ is invalidated.
-
-So let's say we update the pie recipe again:
-
-```ts
-recipes.set("pie", "http://example.com/even-better-pie-recipe");
-```
-
-Since changing the value of an existing entry doesn't invalidate the _key
-iteration_, the `recipeCount` formula **will not invalidate**.
-
-However, the `uniqueRecipeURLs` formula **will invalidate** when the
-collection changes.
-
-Intuitively, this behaves just as we'd expect: changing the value of a recipe
-doesn't change the size of the recipes collection. But it _might_ change the
-number of unique URLs.
-
-## 📢 Invalidation
-
-Starbeam collections have predictable, granular invalidation rules. They
-cannot, however, avoid invalidating a formula just because the formula
-ultimately produces the same answer.
-
-In this example, it's possible to invalidate `uniqueRecipeURLs` by changing
-the value of a recipe URL from a URL that has other existing entries to a URL
-that also has existing entries.
-
-In this situation, computing the formula will ultimately determine that
-nothing has changed. However, Starbeam invalidation rules are based upon the
-invalidation of storage cells, and **never** rely upon comparing the value of
-a previous computation with the value of a new computation.
-
-In practice, this means that renderers may want to compare the new value to
-the old value in order to determine whether to do the work of updating the
-rendererd output.
-
-[Object]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
-[Array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
-[Map]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
-[Set]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
-[WeakMap]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
-[WeakSet]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet
+- [Start with root state](https://starbeamjs.com/start/introduction/): build a
+  first Starbeam model.
+- [Collections and objects](https://starbeamjs.com/concepts/collections/): learn
+  the app-facing collections model.
+- [Library-author guide](https://starbeamjs.com/library-authors/overview/): write
+  reusable domain-shaped abstractions.
+- [Reference](https://starbeamjs.com/reference/overview/): see the public package
+  surface.

--- a/workspace/docs/astro.config.mjs
+++ b/workspace/docs/astro.config.mjs
@@ -30,6 +30,10 @@ export default defineConfig({
           label: "Core concepts",
           items: [
             { label: "Overview", link: "/concepts/overview/" },
+            {
+              label: "Collections and objects",
+              link: "/concepts/collections/",
+            },
             { label: "Resources and lifecycle", link: "/concepts/lifecycle/" },
           ],
         },

--- a/workspace/docs/src/content/docs/concepts/collections.md
+++ b/workspace/docs/src/content/docs/concepts/collections.md
@@ -1,0 +1,240 @@
+---
+title: Collections and objects
+description: "Use reactive Maps, Sets, arrays, and objects as root state while keeping your public model ordinary JavaScript."
+---
+
+Use reactive collections and objects when your state already has a JavaScript
+shape. A cart is a map of line items. A registry is a map of entries. A clock is
+an object with a `now` property. Starbeam tracks those root-state reads without
+asking the rest of your model to change shape.
+
+The rule is the same as the Start guide:
+
+> Mark root state. Keep the rest JavaScript.
+
+## Install and import
+
+```sh
+pnpm add @starbeam/collections
+```
+
+```ts
+import { reactive } from "@starbeam/collections";
+```
+
+Use the named `reactive` import. It exposes helpers for the JavaScript shapes you
+already use:
+
+| Helper                     | Use for                                       |
+| -------------------------- | --------------------------------------------- |
+| `reactive.Map<K, V>()`     | keyed records, registries, caches, carts      |
+| `reactive.Set<T>()`        | membership, selection, tags                   |
+| `reactive.array<T>([])`    | ordered list state                            |
+| `reactive.object({ ... })` | object-shaped state, including one-slot state |
+| `reactive.WeakMap<K, V>()` | object-keyed storage with weak ownership      |
+| `reactive.WeakSet<T>()`    | weak object membership                        |
+
+`reactive.Map()` and `reactive.Set()` create empty collections. Add entries with
+the normal JavaScript methods: `set()`, `add()`, and `delete()`.
+
+`reactive.object()` and `reactive.array()` wrap an initial object or array.
+
+## Keep storage private
+
+A reactive collection is usually an implementation detail. Keep it private,
+then expose the domain-shaped reads and writes your app wants.
+
+```ts
+import { reactive } from "@starbeam/collections";
+
+interface LineItem {
+  readonly id: string;
+  readonly name: string;
+  readonly priceCents: number;
+  readonly quantity: number;
+}
+
+export class Cart {
+  #items = reactive.Map<string, LineItem>();
+
+  get items(): readonly LineItem[] {
+    return [...this.#items.values()];
+  }
+
+  get itemCount(): number {
+    return this.items.reduce((total, item) => total + item.quantity, 0);
+  }
+
+  get totalCents(): number {
+    return this.items.reduce(
+      (sum, item) => sum + item.priceCents * item.quantity,
+      0,
+    );
+  }
+
+  add(item: LineItem): void {
+    this.#items.set(item.id, item);
+  }
+
+  remove(id: string): void {
+    this.#items.delete(id);
+  }
+}
+```
+
+The private `Map` is the root state. `items`, `itemCount`, `totalCents`, `add()`,
+and `remove()` are ordinary JavaScript above that state.
+
+Consumers do not need to know that `Cart` uses a reactive collection internally.
+They read `cart.totalCents` because that is the domain value they care about.
+
+## Use object-shaped state for object-shaped values
+
+If your state is an object, use a reactive object. That is true even when the
+object only has one public slot.
+
+```ts
+import { reactive } from "@starbeam/collections";
+
+const clock = reactive.object({ now: new Date() });
+
+clock.now = new Date();
+clock.now;
+```
+
+This keeps the public shape ordinary: `clock.now`. If your domain wants a
+`current` property, make that shape explicit:
+
+```ts
+const currentUser = reactive.object({ current: null as User | null });
+
+currentUser.current = { id: "tom", name: "Tom Dale" };
+```
+
+Use the shape that matches the value your app wants to expose. Lower-level
+storage primitives are useful when you are building new reactive primitives, not
+as the default way to teach app state.
+
+## Choose the collection shape from the domain
+
+Use the shape that gives your domain the right operations.
+
+```ts
+import { reactive } from "@starbeam/collections";
+
+export class Selection {
+  #ids = reactive.Set<string>();
+
+  get size(): number {
+    return this.#ids.size;
+  }
+
+  isSelected(id: string): boolean {
+    return this.#ids.has(id);
+  }
+
+  select(id: string): void {
+    this.#ids.add(id);
+  }
+
+  deselect(id: string): void {
+    this.#ids.delete(id);
+  }
+
+  clear(): void {
+    this.#ids.clear();
+  }
+}
+```
+
+A `Set` makes membership the root-state operation. A `Map` makes keyed lookup and
+value replacement the root-state operation. An object makes named properties the
+root-state operation. An array makes order and index access the root-state
+operation.
+
+## What updates?
+
+Starbeam tracks the JavaScript read your code performed.
+
+For a `Map`:
+
+- `map.has(key)` tracks whether that key is present.
+- `map.get(key)` tracks the value for that key.
+- `map.size` and `map.keys()` track membership changes.
+- `map.values()`, `map.entries()`, spreading, and `forEach()` track value
+  iteration.
+
+That means a read that only checks membership does not need to update when an
+existing value changes.
+
+```ts
+const recipes = reactive.Map<string, { url: string }>();
+
+recipes.set("pie", { url: "https://example.com/pie" });
+
+function hasDessert(): boolean {
+  return recipes.has("pie") || recipes.has("cookies");
+}
+
+function recipeUrls(): string[] {
+  return [...recipes.values()].map((recipe) => recipe.url);
+}
+```
+
+Updating the URL for `"pie"` changes the result of `recipeUrls()`, but it does
+not change whether the map has a `"pie"` entry. Starbeam can preserve that
+membership-only read.
+
+For a `Set`, `set.has(value)` tracks membership for that value. Adding a value
+that is already present does not change membership.
+
+For objects, use the same intuition: a direct property read is narrower than
+enumerating the whole object.
+
+Arrays track length, indices, and iteration, but array updates can affect the
+surrounding list shape. Treat array iteration and list mutations as broader than
+direct object-property reads.
+
+Starbeam tracks storage reads and writes. It does not compare the old output of a
+getter with the new output to decide whether a read should update.
+
+## Collections and lifecycle
+
+Reactive collections and objects are just root state. They do not need an owner,
+provider, or app container.
+
+Reach for a resource when the work has a lifetime: timers, subscriptions,
+observers, sockets, DOM elements, or app-scoped services. A resource can still
+return a reactive object or a domain object backed by private reactive
+collections.
+
+```ts
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
+
+export const Clock = Resource(({ on }) => {
+  const clock = reactive.object({ now: new Date() });
+
+  on.sync(() => {
+    clock.now = new Date();
+
+    const timer = setInterval(() => {
+      clock.now = new Date();
+    }, 1000);
+
+    return () => clearInterval(timer);
+  });
+
+  return clock;
+});
+```
+
+The root state is still object-shaped. The resource adds setup and cleanup.
+
+## Next steps
+
+- [Resources and lifecycle](/concepts/lifecycle/): add setup, sync, and cleanup
+  when work has a lifetime.
+- [Library-author guide](/library-authors/overview/): expose reusable
+  domain-shaped abstractions.
+- [Reference](/reference/overview/): see the package map.

--- a/workspace/docs/src/content/docs/concepts/overview.md
+++ b/workspace/docs/src/content/docs/concepts/overview.md
@@ -11,7 +11,7 @@ JavaScript.
 
 Root state is the storage Starbeam tracks directly. Most app models should start
 with the shape of the data: use `@starbeam/collections` when the state is
-collection-shaped, and use `Cell` from `@starbeam/universal` for scalar state.
+collection-shaped or object-shaped.
 
 ```ts
 import { reactive } from "@starbeam/collections";
@@ -35,13 +35,14 @@ class Cart {
 
 The private `Map` is the root state. The public reads are ordinary JavaScript.
 This is where you mark the boundary between changing data and the domain code
-that reads it.
+that reads it. See [Collections and objects](/concepts/collections/) for the
+app-facing root-state model.
 
 ## Reactive values
 
 A reactive value is any value whose result depends on reactive storage. It might
-be a `Cell`, a `Formula`, a resource, or a domain object with getters and methods
-that read root state internally.
+be a reactive collection, a reactive object, a resource, or a domain object with
+getters and methods that read root state internally.
 
 The public shape can still look like your app:
 

--- a/workspace/docs/src/content/docs/frameworks/svelte.md
+++ b/workspace/docs/src/content/docs/frameworks/svelte.md
@@ -118,9 +118,9 @@ state: templates, `$derived`, and `$effect`.
 ```svelte
 <script lang="ts">
   import { fromStarbeam } from "@starbeam/svelte";
-  import { Cell } from "@starbeam/universal";
+  import { reactive } from "@starbeam/collections";
 
-  const count = Cell(1);
+  const count = reactive.object({ current: 1 });
   let multiplier = $state(2);
 
   const total = fromStarbeam(() => count.current * multiplier);

--- a/workspace/docs/src/content/docs/reference/overview.md
+++ b/workspace/docs/src/content/docs/reference/overview.md
@@ -12,9 +12,10 @@ If you are choosing what to install first, start with
 ## Starter and app-facing packages
 
 - `@starbeam/collections`: reactive `Map`, `Set`, array, and object helpers for
-  collection-shaped root state.
-- `@starbeam/universal`: framework-neutral scalar state and lifecycle APIs such
-  as `Cell` and `Resource`.
+  collection-shaped and object-shaped root state. Start with
+  [Collections and objects](/concepts/collections/).
+- `@starbeam/universal`: framework-neutral lifecycle APIs such as `Resource`,
+  plus compatibility exports for lower-level primitives.
 - Framework adapters: `@starbeam/react`, `@starbeam/preact`, `@starbeam/vue`, and
   `@starbeam/svelte` connect reactive reads and resources to each framework.
 
@@ -30,9 +31,9 @@ If you are choosing what to install first, start with
 
 ## Lower-level and compatibility packages
 
-- `@starbeam/reactive`: primitive reactive values such as `Cell`, `Marker`,
-  `Formula`, and `CachedFormula`. It is public for library authors, but most app
-  code should start with `@starbeam/collections` and `@starbeam/universal`.
+- `@starbeam/reactive`: lower-level primitives for authors building reactive
+  storage or integration primitives. Most app and library models should start
+  with `@starbeam/collections` and `@starbeam/universal`.
 - `@starbeam/core`: deprecated compatibility alias for `@starbeam/universal`.
   Existing code can keep using it during the compatibility window; new code
   should not start there.

--- a/workspace/docs/src/content/docs/start/install.md
+++ b/workspace/docs/src/content/docs/start/install.md
@@ -8,14 +8,14 @@ Install the packages you import directly. Most apps need one framework adapter,
 
 ## What are you building?
 
-| If you are building…      | Install…                                                     | Start with…                                                                       |
-| ------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------- |
-| A framework-neutral model | `@starbeam/universal @starbeam/collections`                  | `reactive` collections, domain objects, and `Resource`                            |
-| A React app               | `@starbeam/react @starbeam/universal @starbeam/collections`  | `useReactive()`, `useResource()`, `useService()`, `useElementResource()`          |
-| A Preact app              | `@starbeam/preact @starbeam/universal @starbeam/collections` | `install(options)`, direct render reads, resource/service hooks                   |
+| If you are building…      | Install…                                                     | Start with…                                                                         |
+| ------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| A framework-neutral model | `@starbeam/universal @starbeam/collections`                  | `reactive` collections, domain objects, and `Resource`                              |
+| A React app               | `@starbeam/react @starbeam/universal @starbeam/collections`  | `useReactive()`, `useResource()`, `useService()`, `useElementResource()`            |
+| A Preact app              | `@starbeam/preact @starbeam/universal @starbeam/collections` | `install(options)`, direct render reads, resource/service hooks                     |
 | A Vue app                 | `@starbeam/vue @starbeam/universal @starbeam/collections`    | `setupReactive()`, `setupResource()`, `setupService()`, element-resource directives |
-| A Svelte app              | `@starbeam/svelte @starbeam/universal @starbeam/collections` | `fromStarbeam()` and Svelte 5 element-resource attachments                        |
-| A reusable library        | `@starbeam/universal @starbeam/collections`                  | framework-neutral state and domain-shaped APIs                                   |
+| A Svelte app              | `@starbeam/svelte @starbeam/universal @starbeam/collections` | `fromStarbeam()` and Svelte 5 element-resource attachments                          |
+| A reusable library        | `@starbeam/universal @starbeam/collections`                  | framework-neutral state and domain-shaped APIs                                      |
 
 ## Framework-neutral state
 
@@ -152,9 +152,9 @@ usually use framework adapter helpers instead:
 
 ### `@starbeam/reactive`
 
-Use `@starbeam/reactive` directly when you are writing library code that needs
-primitive reactive values such as `Cell`, `Formula`, or `CachedFormula`. App code
-should usually import those through `@starbeam/universal`.
+Use `@starbeam/reactive` directly when you are building lower-level reactive
+primitives. App and library models usually start with `@starbeam/collections`,
+`@starbeam/universal`, or a framework adapter.
 
 ### `@starbeam/core`
 

--- a/workspace/docs/src/content/docs/start/introduction.md
+++ b/workspace/docs/src/content/docs/start/introduction.md
@@ -80,8 +80,8 @@ class Cart {
 The rest of the class is ordinary JavaScript. `items`, `add()`, `itemCount`, and
 `totalCents` are domain-shaped methods and getters built above the root state.
 
-Cells are still useful for scalar root state. Collections are a better starting
-point here because a cart is naturally collection-shaped.
+Collections are the right starting point here because a cart is naturally
+collection-shaped. If state is object-shaped, use `reactive.object(...)` instead.
 
 ## Derive values with ordinary JavaScript
 
@@ -173,6 +173,8 @@ as JavaScript.
 - Read [Install Starbeam](/start/install/) to choose packages for your app or
   library.
 - Read [Core concepts](/concepts/overview/) for the map of Starbeam's model.
+- Read [Collections and objects](/concepts/collections/) for the root-state
+  shapes that match ordinary JavaScript data.
 - Read [Resources and lifecycle](/concepts/lifecycle/) when work needs setup,
   sync, or cleanup.
 - Read [Framework guides](/frameworks/overview/) to see how adapters connect this

--- a/workspace/docs/src/pages/index.astro
+++ b/workspace/docs/src/pages/index.astro
@@ -48,7 +48,7 @@ import "../styles/tokens.css";
               <span class="card-number" aria-hidden="true">01</span>
               <h3>Mark root state</h3>
               <p>
-                Use cells and reactive collections for the values that change.
+                Use reactive collections and objects for the values that change.
                 They are the small surface Starbeam tracks directly.
               </p>
             </article>


### PR DESCRIPTION
## Why

The docs now teach collections and object-shaped state as the app-facing root-state model, but `@starbeam/collections` still had a stale package README and the Concepts section did not have a first-class route for that model.

This PR closes PER 1 from the documentation dashboard: make collections/objects the public root-state concept and keep `Cell`/`Marker` framed as lower-level primitive-building material rather than first-run app state.

## What changed

- Adds a `Collections and objects` concept page and wires it into the Core concepts sidebar.
- Rewrites the `@starbeam/collections` README as a package front door with install/import guidance, helper table, domain-shaped examples, and granular update notes.
- Aligns Start, Concepts, Reference, homepage, root README, and Svelte examples around reactive collections/objects instead of scalar `Cell` examples.
- Updates the documentation dashboard to mark PER 1 done and PER 2 (`@starbeam/reactive` README rewrite) as next.

## Reviewer notes

The granular update language intentionally stays JS-shaped. It explains `Map`/`Set` reads more concretely, while keeping object/array language broad enough not to overpromise implementation details.

## User-facing changes

Docs-only. Users get a new collections concept page and updated package README guidance for `@starbeam/collections`.
