### PR TITLE
docs: clarify collections surface wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Starbeam lets you mark the root state that changes, then build domain-shaped
 functions, classes, getters, methods, and collections around it as ordinary
 JavaScript.
 
+Reactive objects and collections keep their JavaScript and TypeScript surface: a
+reactive `Map<K, V>` is still a `Map<K, V>`, and a reactive object is still typed
+as the object you passed in.
+
 Your public model can look like your app:
 
 - `cart.totalCents`

--- a/packages/universal/collections/README.md
+++ b/packages/universal/collections/README.md
@@ -1,10 +1,15 @@
 # @starbeam/collections
 
-Reactive JavaScript collections and objects for Starbeam root state.
+Reactive versions of ordinary JavaScript objects and built-in collections.
 
-Use this package when the state you want to track is already shaped like a
-JavaScript `Map`, `Set`, array, or object. Mark that storage reactive, then keep
-the rest of your model as ordinary JavaScript.
+Use this package when the state you want to track is already a JavaScript `Map`,
+`Set`, array, or object. The reactive versions keep their JavaScript and
+TypeScript surface: `reactive.Map<K, V>()` gives you a `Map<K, V>`,
+`reactive.Set<T>()` gives you a `Set<T>`, and `reactive.object(value)` gives you
+the same object type back.
+
+Use normal property syntax and built-in collection APIs. Starbeam tracks the
+reads and writes underneath.
 
 ```sh
 pnpm add @starbeam/collections

--- a/workspace/docs/src/content/docs/concepts/collections.md
+++ b/workspace/docs/src/content/docs/concepts/collections.md
@@ -1,12 +1,18 @@
 ---
 title: Collections and objects
-description: "Use reactive Maps, Sets, arrays, and objects as root state while keeping your public model ordinary JavaScript."
+description: "Define reactive versions of ordinary JavaScript objects and built-in collections while keeping their JavaScript and TypeScript surface."
 ---
 
-Use reactive collections and objects when your state already has a JavaScript
-shape. A cart is a map of line items. A registry is a map of entries. A clock is
-an object with a `now` property. Starbeam tracks those root-state reads without
-asking the rest of your model to change shape.
+Starbeam lets you define reactive versions of ordinary JavaScript objects and
+built-in collections. They keep their JavaScript and TypeScript surface:
+`reactive.Map<K, V>()` gives you a `Map<K, V>`, `reactive.Set<T>()` gives you a
+`Set<T>`, and `reactive.object(value)` gives you the same object type back. You
+use normal property syntax and built-in collection APIs; Starbeam tracks the
+reads and writes underneath.
+
+Use those reactive objects and collections when your state already has a
+JavaScript shape. A cart is a map of line items. A registry is a map of entries.
+A clock is an object with a `now` property.
 
 The rule is the same as the Start guide:
 
@@ -22,8 +28,8 @@ pnpm add @starbeam/collections
 import { reactive } from "@starbeam/collections";
 ```
 
-Use the named `reactive` import. It exposes helpers for the JavaScript shapes you
-already use:
+Use the named `reactive` import. It exposes helpers for ordinary objects and
+built-in collection types:
 
 | Helper                     | Use for                                       |
 | -------------------------- | --------------------------------------------- |

--- a/workspace/docs/src/content/docs/start/introduction.md
+++ b/workspace/docs/src/content/docs/start/introduction.md
@@ -37,8 +37,12 @@ import { reactive } from "@starbeam/collections";
 
 ## Mark root state with a collection
 
-A reactive collection has the same shape as the corresponding JavaScript
-collection. Keep it private and expose the shape your app wants.
+Starbeam lets you define reactive versions of ordinary JavaScript objects and
+built-in collections. They keep their JavaScript and TypeScript surface:
+`reactive.Map<K, V>()` gives you a `Map<K, V>`, and you use it with the built-in
+`Map` API.
+
+Keep root state private and expose the shape your app wants.
 
 ```ts
 import { reactive } from "@starbeam/collections";
@@ -74,8 +78,8 @@ class Cart {
 }
 ```
 
-`#items` is the root state. It is reactive, but its API is still the ordinary
-`Map` API: `set()`, `values()`, `get()`, `has()`, and `delete()`.
+`#items` is the root state. It is reactive, but it is still a `Map<string,
+LineItem>`: use `set()`, `values()`, `get()`, `has()`, and `delete()`.
 
 The rest of the class is ordinary JavaScript. `items`, `add()`, `itemCount`, and
 `totalCents` are domain-shaped methods and getters built above the root state.

--- a/workspace/docs/src/content/docs/start/introduction.md
+++ b/workspace/docs/src/content/docs/start/introduction.md
@@ -78,8 +78,9 @@ class Cart {
 }
 ```
 
-`#items` is the root state. It is reactive, but it is still a `Map<string,
-LineItem>`: use `set()`, `values()`, `get()`, `has()`, and `delete()`.
+`#items` is the root state. It is reactive, but it is still a map from string
+IDs to `LineItem` values: use `set()`, `values()`, `get()`, `has()`, and
+`delete()`.
 
 The rest of the class is ordinary JavaScript. `items`, `add()`, `itemCount`, and
 `totalCents` are domain-shaped methods and getters built above the root state.

--- a/workspace/docs/src/pages/index.astro
+++ b/workspace/docs/src/pages/index.astro
@@ -38,9 +38,10 @@ import "../styles/tokens.css";
               Mark the state that changes. Keep the rest JavaScript.
             </h2>
             <p class="section-intro">
-              Starbeam asks you to make the changing roots visible. Above that
-              line, your app can use the JavaScript shapes it already wants:
-              classes, functions, getters, collections, and methods.
+              Starbeam asks you to make the changing roots visible. Reactive
+              objects and collections keep their JavaScript and TypeScript
+              surface, so your app can keep using classes, functions, getters,
+              built-in APIs, and methods.
             </p>
           </div>
           <div class="story-grid">


### PR DESCRIPTION
## Why

The collections docs were directionally right, but the wording still leaned on “shape” language and did not explicitly make the strongest TypeScript/API claim: reactive objects and collections keep their ordinary JavaScript and TypeScript surface.

This is a precursor to the `@starbeam/reactive` README rewrite because it sharpens the boundary between app-facing reactive objects/collections and lower-level primitive wrappers such as `Cell`.

## What changed

- Updates the collections concept page and `@starbeam/collections` README with the new surface-language framing.
- Clarifies that `reactive.Map<K, V>()` gives a `Map<K, V>`, `reactive.Set<T>()` gives a `Set<T>`, and `reactive.object(value)` gives the same object type back.
- Applies the same phrasing to the Start walkthrough, root README, and homepage section.

## Reviewer notes

The intended distinction is that app-facing collections/objects preserve their JavaScript and TypeScript surface, while primitive wrappers like `Cell<T>` remain lower-level primitive-building tools.

## User-facing changes

Docs-only. This tightens the public explanation for how reactive collections and objects are used.
