### PR TITLE
docs: add core compatibility migration

### DIFF
--- a/docs/DOCUMENTATION-DASHBOARD.md
+++ b/docs/DOCUMENTATION-DASHBOARD.md
@@ -48,7 +48,7 @@ The remaining documentation work should reinforce the public model:
 | P0       | Collections concept + package README     | Done    | `workspace/docs/src/content/docs/concepts/`, `packages/universal/collections/README.md`          | Collections are now the preferred root-state story for collection-shaped data, with a concept route and aligned package README.         |
 | P0       | Reactive primitive README rewrite        | Next    | `packages/universal/reactive/README.md`                                                          | `@starbeam/reactive` is public for authors building primitives, but the README still blends that surface with runtime/protocol caveats. |
 | P1       | Preact package README                    | Ready   | `packages/preact/preact/README.md`                                                               | Preact has a website guide and public package, but no package-level front door.                                                         |
-| P1       | Core deprecation README + migration page | Ready   | `packages/universal/core/README.md`, `workspace/docs/src/content/docs/`                          | Existing users may land on `@starbeam/core`; they need a direct path to `@starbeam/universal`.                                          |
+| P1       | Core deprecation README + migration page | Done    | `packages/universal/core/README.md`, `workspace/docs/src/content/docs/`                          | Existing users now have package and website migration guidance from `@starbeam/core` to `@starbeam/universal`.                          |
 | P1       | Concept route expansion                  | Ready   | `workspace/docs/src/content/docs/concepts/`, `workspace/docs/astro.config.mjs`                   | Services and element resources are central concepts but currently live inside overview/lifecycle pages.                                 |
 | P1       | Reference expansion                      | Ready   | `workspace/docs/src/content/docs/reference/`, `workspace/docs/astro.config.mjs`                  | The Reference route currently cannot answer concrete API questions.                                                                     |
 | P2       | Status consistency pass                  | Ready   | `README.md`, framework docs, package READMEs, install/reference pages                            | Svelte, Vue, and experiments need consistent status language across entry points.                                                       |
@@ -148,6 +148,11 @@ guide and makes `install(options)` the framework bridge.
 
 **Hypothesis:** `@starbeam/core` should have an explicit compatibility README and
 the website should include a small migration route.
+
+**Conclusion:** `@starbeam/core` remains as a deprecated compatibility alias
+during the compatibility window. The current action is documentation and
+migration guidance, not deletion. Removing the package is a later breaking
+cleanup.
 
 **Prepare**
 

--- a/packages/universal/core/README.md
+++ b/packages/universal/core/README.md
@@ -1,0 +1,35 @@
+# @starbeam/core
+
+`@starbeam/core` is a deprecated compatibility alias for `@starbeam/universal`.
+
+Do not start new code with `@starbeam/core`. New framework-neutral Starbeam code
+should use `@starbeam/universal`, plus `@starbeam/collections` when state is
+object-shaped or collection-shaped.
+
+## Why this package exists
+
+Older Starbeam code imported framework-neutral APIs from `@starbeam/core`. The
+current package name for that surface is `@starbeam/universal`.
+
+`@starbeam/core` remains published during the compatibility window so existing
+projects can keep installing while they migrate. Importing the compatibility
+package emits a warning and re-exports `@starbeam/universal`.
+
+## Migrate to `@starbeam/universal`
+
+1. Add `@starbeam/universal` to your dependencies.
+2. Change imports that point at `@starbeam/core` so they point at
+   `@starbeam/universal`.
+3. Remove `@starbeam/core` once no imports use it.
+
+There is no separate `@starbeam/core` API story. For the compatibility surface,
+the migration is a package rename.
+
+## Learn more
+
+- [Core compatibility](https://starbeamjs.com/reference/core-compatibility/):
+  migration notes for existing users.
+- [Install Starbeam](https://starbeamjs.com/start/install/): choose packages for
+  new code.
+- [Reference](https://starbeamjs.com/reference/overview/): current public package
+  surface.

--- a/workspace/docs/astro.config.mjs
+++ b/workspace/docs/astro.config.mjs
@@ -53,7 +53,13 @@ export default defineConfig({
         },
         {
           label: "Reference",
-          items: [{ label: "Overview", link: "/reference/overview/" }],
+          items: [
+            { label: "Overview", link: "/reference/overview/" },
+            {
+              label: "Core compatibility",
+              link: "/reference/core-compatibility/",
+            },
+          ],
         },
         {
           label: "Advanced / implementor",

--- a/workspace/docs/src/content/docs/library-authors/overview.md
+++ b/workspace/docs/src/content/docs/library-authors/overview.md
@@ -195,7 +195,8 @@ the lower-level service package only for adapter-level or integration code.
 ### `@starbeam/core`
 
 Do not use `@starbeam/core` for new library code. It is a deprecated
-compatibility alias for `@starbeam/universal`.
+compatibility alias for `@starbeam/universal`. Existing libraries can follow the
+[core compatibility migration](/reference/core-compatibility/).
 
 ## Out of scope
 

--- a/workspace/docs/src/content/docs/reference/core-compatibility.md
+++ b/workspace/docs/src/content/docs/reference/core-compatibility.md
@@ -1,0 +1,44 @@
+---
+title: Migrate from @starbeam/core
+description: "Move existing imports from the deprecated @starbeam/core compatibility package to @starbeam/universal."
+---
+
+`@starbeam/core` is a deprecated compatibility alias for `@starbeam/universal`.
+
+This page is for existing projects that still depend on `@starbeam/core`. Do not
+start new code there. New framework-neutral Starbeam code should use
+`@starbeam/universal`, plus `@starbeam/collections` when state is object-shaped
+or collection-shaped.
+
+## What changed
+
+Older Starbeam code imported framework-neutral APIs from `@starbeam/core`. The
+current package name for that surface is `@starbeam/universal`.
+
+`@starbeam/core` remains available during the compatibility window so existing
+projects can migrate without combining an upgrade with an immediate source edit.
+Importing it emits a warning and re-exports `@starbeam/universal`.
+
+## Migration steps
+
+1. Add `@starbeam/universal` to your dependencies.
+2. Change imports that point at the deprecated compatibility package so they point
+   at `@starbeam/universal`.
+3. Run your tests and typecheck.
+4. Remove `@starbeam/core` from your dependencies once no imports use it.
+
+For the compatibility surface, this is a package rename. There is no separate
+`@starbeam/core` API to learn.
+
+## New code
+
+Use current package entry points instead:
+
+- `@starbeam/collections` for reactive versions of ordinary JavaScript objects
+  and built-in collections;
+- `@starbeam/universal` for framework-neutral resources and common authoring
+  APIs;
+- a framework adapter when a framework owns rendering.
+
+See [Install Starbeam](/start/install/) for the package chooser and
+[Reference](/reference/overview/) for the current package map.

--- a/workspace/docs/src/content/docs/reference/overview.md
+++ b/workspace/docs/src/content/docs/reference/overview.md
@@ -36,4 +36,5 @@ If you are choosing what to install first, start with
   with `@starbeam/collections` and `@starbeam/universal`.
 - `@starbeam/core`: deprecated compatibility alias for `@starbeam/universal`.
   Existing code can keep using it during the compatibility window; new code
-  should not start there.
+  should not start there. See
+  [Core compatibility](/reference/core-compatibility/) for migration notes.

--- a/workspace/docs/src/content/docs/start/install.md
+++ b/workspace/docs/src/content/docs/start/install.md
@@ -159,7 +159,8 @@ primitives. App and library models usually start with `@starbeam/collections`,
 ### `@starbeam/core`
 
 Do not start new code with `@starbeam/core`. It is a deprecated compatibility
-alias for `@starbeam/universal`.
+alias for `@starbeam/universal`. Existing users can follow the
+[core compatibility migration](/reference/core-compatibility/).
 
 ## Next steps
 


### PR DESCRIPTION
## Why

`@starbeam/core` is still a published compatibility alias for `@starbeam/universal`, but the package did not have a README and existing users did not have a direct website migration page.

This keeps the compatibility package for the current window while making the migration path explicit. Deleting the package remains a later breaking cleanup.

## What changed

- Adds a package README for `@starbeam/core` that explains its deprecated compatibility role.
- Adds a Reference migration page for moving from `@starbeam/core` to `@starbeam/universal`.
- Links the migration page from Install, Reference, and Library Author docs.
- Adds the migration page to the Reference sidebar.
- Updates the documentation dashboard to mark the core compatibility PER complete.

## Reviewer notes

This is docs-only. It intentionally does not change the alias implementation, package manifest, exports, or release behavior.

## User-facing changes

Existing `@starbeam/core` users now have package and website migration guidance. New-code docs continue to point to `@starbeam/universal`.
