### PR TITLE
docs: add services and element resource concepts

### DIFF
--- a/docs/DOCUMENTATION-DASHBOARD.md
+++ b/docs/DOCUMENTATION-DASHBOARD.md
@@ -10,19 +10,19 @@ arc should still get a fresh Prepare before editing.
 
 ## Current state
 
-| Area                   | Status       | Notes                                                                                                  |
-| ---------------------- | ------------ | ------------------------------------------------------------------------------------------------------ |
-| Homepage               | Done         | Public narrative is aligned around “Reactivity that stays JavaScript.”                                 |
-| Start                  | Done         | Introduction and install chooser teach framework-neutral and adapter paths.                            |
-| Core concepts          | Partial      | Overview and lifecycle exist; collections, services, and element resources still need their own pages. |
-| Framework guides       | Partial      | React, Preact, Vue, and Svelte pages exist; status and package README alignment remains.               |
-| Library authors        | Done         | Reusable framework-neutral abstractions have a first guide.                                            |
-| Reference              | Partial      | Current page is a package map, not a usable API reference.                                             |
-| Advanced / implementor | Done for now | It routes readers to source notes and records the status of implementor material.                      |
-| Experiments            | Done for now | Experiments are quarantined, but package READMEs still need cleanup.                                   |
-| Archive                | Done         | Historical material is explicitly quarantined.                                                         |
-| Root README            | Done         | It now routes readers into the website instead of old package README lists.                            |
-| Ember adapter docs     | Deferred     | Do not integrate Ember into the website until the adapter surface has been reviewed.                   |
+| Area                   | Status       | Notes                                                                                       |
+| ---------------------- | ------------ | ------------------------------------------------------------------------------------------- |
+| Homepage               | Done         | Public narrative is aligned around “Reactivity that stays JavaScript.”                      |
+| Start                  | Done         | Introduction and install chooser teach framework-neutral and adapter paths.                 |
+| Core concepts          | Done for now | Overview, collections, lifecycle, services, and element resources have first concept pages. |
+| Framework guides       | Partial      | React, Preact, Vue, and Svelte pages exist; status and package README alignment remains.    |
+| Library authors        | Done         | Reusable framework-neutral abstractions have a first guide.                                 |
+| Reference              | Partial      | Current page is a package map, not a usable API reference.                                  |
+| Advanced / implementor | Done for now | It routes readers to source notes and records the status of implementor material.           |
+| Experiments            | Done for now | Experiments are quarantined, but package READMEs still need cleanup.                        |
+| Archive                | Done         | Historical material is explicitly quarantined.                                              |
+| Root README            | Done         | It now routes readers into the website instead of old package README lists.                 |
+| Ember adapter docs     | Deferred     | Do not integrate Ember into the website until the adapter surface has been reviewed.        |
 
 ## North star
 
@@ -49,8 +49,8 @@ The remaining documentation work should reinforce the public model:
 | P0       | Reactive primitive README rewrite        | Next    | `packages/universal/reactive/README.md`                                                          | `@starbeam/reactive` is public for authors building primitives, but the README still blends that surface with runtime/protocol caveats. |
 | P1       | Preact package README                    | Ready   | `packages/preact/preact/README.md`                                                               | Preact has a website guide and public package, but no package-level front door.                                                         |
 | P1       | Core deprecation README + migration page | Done    | `packages/universal/core/README.md`, `workspace/docs/src/content/docs/`                          | Existing users now have package and website migration guidance from `@starbeam/core` to `@starbeam/universal`.                          |
-| P1       | Concept route expansion                  | Ready   | `workspace/docs/src/content/docs/concepts/`, `workspace/docs/astro.config.mjs`                   | Services and element resources are central concepts but currently live inside overview/lifecycle pages.                                 |
-| P1       | Reference expansion                      | Ready   | `workspace/docs/src/content/docs/reference/`, `workspace/docs/astro.config.mjs`                  | The Reference route currently cannot answer concrete API questions.                                                                     |
+| P1       | Concept route expansion                  | Done    | `workspace/docs/src/content/docs/concepts/`, `workspace/docs/astro.config.mjs`                   | Services and element resources now have first-class concept pages linked from lifecycle and framework guides.                           |
+| P1       | Reference expansion                      | Next    | `workspace/docs/src/content/docs/reference/`, `workspace/docs/astro.config.mjs`                  | The Reference route currently cannot answer concrete API questions.                                                                     |
 | P2       | Status consistency pass                  | Ready   | `README.md`, framework docs, package READMEs, install/reference pages                            | Svelte, Vue, and experiments need consistent status language across entry points.                                                       |
 | P2       | `@starbeam/use-strict-lifecycle` README  | Ready   | `packages/react/use-strict-lifecycle/README.md`, `packages/react/use-strict-lifecycle/THEORY.md` | A public package currently ships an empty README.                                                                                       |
 | P2       | Experiment package README cleanup        | Ready   | `packages/x/store/README.md`, `packages/x/vanilla/README.md`, experiment package metadata        | The website quarantines experiments, but package surfaces still leak stale or placeholder signals.                                      |
@@ -178,6 +178,11 @@ cleanup.
 **Hypothesis:** Services and element resources should have first-class concept
 routes, while lifecycle remains the progression page that connects them.
 
+**Conclusion:** Services and element resources are app-facing concepts with
+their own routes. Lifecycle remains the progression page: resources add setup,
+sync, and cleanup; services choose app ownership; element resources attach work
+to framework-supplied DOM elements.
+
 **Prepare**
 
 - Identify the sections currently compressed into `concepts/lifecycle.md`.
@@ -303,21 +308,15 @@ into the same public docs matrix as the other framework adapters.
 
 ## Recommended next arc
 
-After PER 1 lands, continue with **PER 2: Reactive primitive README rewrite**.
+After PER 5 lands, continue with **PER 6: Hand-written reference expansion**.
 
-PER 1 reinforces the correction that started the current docs arc: when state is
-collection-shaped, teach reactive collections as the root-state boundary instead
-of teaching users to model a collection as a `Cell` around immutable updates.
+The concept pages now give Reference somewhere stable to point. Reference can be
+concise and API-shaped because the conceptual story lives in Start, Concepts, and
+Framework guides.
 
-The same principle applies to single-slot state in first-run docs: do not teach
-`Cell` as the “one thing” primitive. If the public state wants a `current` slot,
-`reactive.object({ current: ... })` has the same app-facing behavior while
-keeping the teaching model object-shaped. Reserve `Cell` and `Marker` for pages
-about building primitives or low-level reactive storage.
-
-PER 2 should make that reservation explicit by rewriting the primitive package
-README around authors building primitives, not app authors modeling ordinary
-state.
+Start with the public surfaces that already have settled concepts:
+collections, universal resources, reactive primitives, services, framework
+adapters, and core compatibility.
 
 ## Validation checklist
 

--- a/workspace/docs/astro.config.mjs
+++ b/workspace/docs/astro.config.mjs
@@ -35,6 +35,11 @@ export default defineConfig({
               link: "/concepts/collections/",
             },
             { label: "Resources and lifecycle", link: "/concepts/lifecycle/" },
+            { label: "Services", link: "/concepts/services/" },
+            {
+              label: "Element resources",
+              link: "/concepts/element-resources/",
+            },
           ],
         },
         {

--- a/workspace/docs/src/content/docs/concepts/element-resources.md
+++ b/workspace/docs/src/content/docs/concepts/element-resources.md
@@ -52,6 +52,10 @@ export function ElementSize(element: Element) {
 The element belongs to the framework. The observer and cleanup belong to the
 resource.
 
+This `ElementSize` definition is framework-neutral. The same element resource can
+be used from every supported framework; only the adapter API that delivers the
+DOM element changes.
+
 ## Framework dialects
 
 Each framework has its own way to deliver DOM elements. Starbeam adapters expose

--- a/workspace/docs/src/content/docs/concepts/element-resources.md
+++ b/workspace/docs/src/content/docs/concepts/element-resources.md
@@ -1,0 +1,129 @@
+---
+title: Element resources and DOM attachment
+description: "Attach Starbeam resource work to DOM elements supplied by a framework."
+---
+
+Element resources model work that needs a DOM element. The framework supplies the
+element, Starbeam creates resource-backed work for that element, and cleanup
+follows the framework's element lifetime.
+
+That concept is also called DOM attachment: Starbeam attaches resource work to an
+element without becoming the framework that owns the DOM.
+
+## The stable shape
+
+An element resource starts with a framework-supplied element and returns a
+resource value for your app to read.
+
+```ts
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
+
+interface Size {
+  readonly width: number;
+  readonly height: number;
+}
+
+export function ElementSize(element: Element) {
+  return Resource(({ on }) => {
+    const size = reactive.object({ width: 0, height: 0 }) satisfies Size;
+
+    on.sync(() => {
+      const observer = new ResizeObserver(([entry]) => {
+        if (!entry) return;
+
+        size.width = entry.contentRect.width;
+        size.height = entry.contentRect.height;
+      });
+
+      observer.observe(element);
+      return () => observer.disconnect();
+    });
+
+    const value: Size = size;
+    return value;
+  });
+}
+```
+
+`ElementSize` returns a domain-shaped value. Consumers read `size.width`, not
+`size.width.current`.
+
+The element belongs to the framework. The observer and cleanup belong to the
+resource.
+
+## Framework dialects
+
+Each framework has its own way to deliver DOM elements. Starbeam adapters expose
+that framework's native dialect.
+
+| Framework | Element-resource API         | Framework dialect   |
+| --------- | ---------------------------- | ------------------- |
+| React     | `useElementResource()`       | callback ref        |
+| Preact    | `useElementResource()`       | callback ref        |
+| Vue       | `elementResourceDirective()` | custom directive    |
+| Svelte    | `elementResource()`          | Svelte 5 attachment |
+
+The resource definition can stay framework-neutral. The adapter owns element
+delivery, scheduling, and publication back into the framework.
+
+## React and Preact
+
+React and Preact use callback refs. The hook returns both the ref and the current
+attachment state.
+
+```tsx
+const size = useElementResource((element: HTMLElement) => ElementSize(element));
+
+return <section ref={size.ref}>{size.status}</section>;
+```
+
+The hook owns the element lifetime. When the element is detached, the adapter
+finalizes the element resource.
+
+## Vue
+
+Vue uses directives for element-owned work. `elementResourceDirective()` creates a
+directive and can publish the resource value into a ref owned by the component.
+
+```ts
+const size = shallowRef<Size | null>(null);
+const vSize = elementResourceDirective(ElementSize, { into: size });
+```
+
+The directive owns the element lifetime. The `into` ref is the handoff from the
+directive back to Vue render data.
+
+## Svelte
+
+Svelte 5 uses attachments. `elementResource()` returns a Svelte-readable value
+that is also attachable.
+
+```svelte
+<script lang="ts">
+  const size = elementResource(ElementSize);
+</script>
+
+<section {@attach size.attach}>
+  {$size ? `${$size.width} × ${$size.height}` : "Measuring…"}
+</section>
+```
+
+The attachment owns the element lifetime and finalizes the resource when Svelte
+detaches the element.
+
+## Adapter-author details
+
+Shared adapter-author setup primitives live below the app-facing concept. Most
+app and library code should not need those lower-level integration details.
+
+Use the framework adapter APIs first. Reach for lower-level renderer material only
+when you are implementing an adapter or investigating framework integration.
+
+## Next steps
+
+- [Resources and lifecycle](/concepts/lifecycle/): setup, sync, cleanup, and
+  finalize.
+- [Services](/concepts/services/): app-scoped resource-backed state.
+- [Framework guides](/frameworks/overview/): framework-specific element-resource
+  syntax.

--- a/workspace/docs/src/content/docs/concepts/lifecycle.md
+++ b/workspace/docs/src/content/docs/concepts/lifecycle.md
@@ -135,68 +135,20 @@ A service is resource-backed state with an app lifetime. Use services for shared
 application concerns that should live with the app or framework root, not with a
 single component.
 
-```ts
-import { reactive } from "@starbeam/collections";
-import { Resource } from "@starbeam/universal";
-
-export const Session = Resource(() => {
-  return reactive.object({ userName: "Guest" });
-});
-```
-
-Framework adapters expose service helpers where that app lifetime is available:
-
-- [React](/frameworks/react/) and [Preact](/frameworks/preact/) use
-  `useService()`.
-- [Vue](/frameworks/vue/) uses `setupService()` after installing Starbeam on the
-  Vue app.
-- [Svelte](/frameworks/svelte/) service support is not exposed yet.
+The resource still returns a domain-shaped value. The difference is ownership:
+the app owns the service lifetime. See
+[Services and app lifetime](/concepts/services/) for the app-facing service
+model.
 
 ## Element resources attach work to DOM elements
 
 Some resources need a DOM element. Element resources let the framework provide
 the element while Starbeam owns the setup, sync, and cleanup work.
 
-```ts
-import { reactive } from "@starbeam/collections";
-import { Resource } from "@starbeam/universal";
-
-interface Size {
-  readonly width: number;
-  readonly height: number;
-}
-
-export function ElementSize(element: Element) {
-  return Resource(({ on }) => {
-    const size = reactive.object({ width: 0, height: 0 }) satisfies Size;
-
-    on.sync(() => {
-      const observer = new ResizeObserver(([entry]) => {
-        if (!entry) return;
-
-        size.width = entry.contentRect.width;
-        size.height = entry.contentRect.height;
-      });
-
-      observer.observe(element);
-
-      return () => observer.disconnect();
-    });
-
-    return size;
-  });
-}
-```
-
-The framework guide for each adapter shows the native attachment shape:
-
-- [React](/frameworks/react/) and [Preact](/frameworks/preact/) use
-  element-resource hooks.
-- [Vue](/frameworks/vue/) uses an element-resource directive.
-- [Svelte](/frameworks/svelte/) uses Svelte 5 attachments.
-
 The concept stays the same: the element comes from the framework, and the value
-you read stays domain-shaped.
+you read stays domain-shaped. See
+[Element resources and DOM attachment](/concepts/element-resources/) for the
+framework dialects and the stable element-resource shape.
 
 ## The resource progression
 
@@ -205,9 +157,10 @@ The app-author path is:
 1. Mark root state.
 2. Keep derived state as ordinary JavaScript.
 3. Use a resource when work needs setup, sync, or cleanup.
-4. Use a service when resource-backed state should live with the app.
-5. Use an element resource when the resource needs a DOM element from a
-   framework.
+4. Use a [service](/concepts/services/) when resource-backed state should live
+   with the app.
+5. Use an [element resource](/concepts/element-resources/) when the resource
+   needs a DOM element from a framework.
 
 You do not need a resource for every reactive value. Use one when the work has a
 lifetime.
@@ -216,4 +169,8 @@ lifetime.
 
 - [Framework guides](/frameworks/overview/): connect resource lifetimes to each
   supported framework.
+- [Services and app lifetime](/concepts/services/): app-scoped resource-backed
+  state.
+- [Element resources and DOM attachment](/concepts/element-resources/): resources
+  attached to framework-supplied elements.
 - [Reference](/reference/overview/): see the public package surface at a glance.

--- a/workspace/docs/src/content/docs/concepts/overview.md
+++ b/workspace/docs/src/content/docs/concepts/overview.md
@@ -65,20 +65,22 @@ You do not list dependencies by hand.
 Resources model state with a lifetime. Use them when reactive state needs setup,
 sync, or cleanup: subscriptions, external handles, element work, and other values
 that should start and stop with an owner. See
-[Resources and lifecycle](/concepts/lifecycle/) for the app-author path from
-resources to services and element resources.
+[Resources and lifecycle](/concepts/lifecycle/) for the app-author path.
 
 ## Services and app lifetime
 
 Services are resource-backed state with an app-scoped lifetime. They are useful
 for shared application concerns that should live as long as the app or framework
-root lives.
+root lives. See [Services and app lifetime](/concepts/services/) for the
+app-facing model.
 
 ## Element resources
 
 Element resources attach resource work to DOM elements supplied by a framework.
 They let Starbeam model setup, sync, and cleanup for element-backed behavior
-without turning Starbeam into a framework replacement.
+without turning Starbeam into a framework replacement. See
+[Element resources and DOM attachment](/concepts/element-resources/) for the
+framework dialects.
 
 ## Advanced details
 

--- a/workspace/docs/src/content/docs/concepts/services.md
+++ b/workspace/docs/src/content/docs/concepts/services.md
@@ -31,6 +31,10 @@ export const SessionService = Resource(() => {
 The returned value stays domain-shaped. Consumers read `session.userName`, not a
 reactive-storage wrapper.
 
+This definition is framework-neutral. The same `SessionService` resource can be
+used from every supported adapter that exposes service helpers; only the adapter
+API that attaches it to the app changes.
+
 ## The first reader does not own the service
 
 A service is shared by every consumer in the same app. The first component that

--- a/workspace/docs/src/content/docs/concepts/services.md
+++ b/workspace/docs/src/content/docs/concepts/services.md
@@ -1,0 +1,109 @@
+---
+title: Services and app lifetime
+description: "Use services when resource-backed state should live with the app instead of one component."
+---
+
+A service is resource-backed state with an app lifetime. Use a service when the
+state belongs to the application as a whole, not to the component that first asks
+for it.
+
+Services follow the same progression as the rest of Starbeam:
+
+1. Define ordinary reactive state.
+2. Wrap setup, sync, or cleanup in a `Resource` when the work has a lifetime.
+3. Let the framework adapter attach that resource to the app lifetime.
+
+## Services are app-scoped resources
+
+A resource belongs to the owner that sets it up. In a component, that owner is
+usually the component. A service uses the same resource model, but the owner is
+the app.
+
+```ts
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
+
+export const SessionService = Resource(() => {
+  return reactive.object({ userName: "Guest" });
+});
+```
+
+The returned value stays domain-shaped. Consumers read `session.userName`, not a
+reactive-storage wrapper.
+
+## The first reader does not own the service
+
+A service is shared by every consumer in the same app. The first component that
+asks for the service may cause it to be created, but that component does not own
+its lifetime.
+
+That distinction matters for shared state such as:
+
+- session and account state;
+- current workspace or organization state;
+- app-wide feature or configuration state;
+- shared resource-backed subscriptions.
+
+Use component resources for state that should start and stop with one component.
+Use services for resource-backed state that should live with the framework root.
+
+## Adapter APIs
+
+Use the service API from the framework adapter that owns your app.
+
+| Framework | App-facing service API                  | Notes                                                                |
+| --------- | --------------------------------------- | -------------------------------------------------------------------- |
+| React     | `Starbeam` provider plus `useService()` | The provider establishes the app lifetime.                           |
+| Preact    | `install(options)` plus `useService()`  | The installed adapter owns the app lifetime.                         |
+| Vue       | `Starbeam` plugin plus `setupService()` | Install the plugin on the Vue app.                                   |
+| Svelte    | Not exposed yet                         | The Svelte adapter does not expose app-scoped service helpers today. |
+
+For example, React establishes the app lifetime with `Starbeam`, then components
+read the service with `useService()`:
+
+```tsx
+import { Starbeam, useReactive, useService } from "@starbeam/react";
+import { createRoot } from "react-dom/client";
+
+createRoot(document.getElementById("root")!).render(
+  <Starbeam>
+    <CurrentUser />
+  </Starbeam>,
+);
+
+function CurrentUser(): React.ReactElement {
+  const session = useService(SessionService);
+  const userName = useReactive(() => session.userName);
+
+  return <p>{userName}</p>;
+}
+```
+
+Each framework guide shows the native app setup and read boundary for that
+framework.
+
+## Lower-level service APIs
+
+Starbeam also has lower-level app-scoped service APIs for adapters and
+integration code. Most app code should not import them directly.
+
+If you are writing an adapter or manual runtime integration, use the package
+README and reference material for the lower-level APIs. App authors should start
+with the adapter helpers above.
+
+## Services and lifecycle
+
+Services do not replace resources. They choose a different owner for a resource.
+
+- Use [Resources and lifecycle](/concepts/lifecycle/) to model setup, sync, and
+  cleanup.
+- Use services when that resource-backed state should live with the app.
+- Use [Element resources](/concepts/element-resources/) when the resource needs a
+  DOM element from a framework.
+
+## Next steps
+
+- [React](/frameworks/react/), [Preact](/frameworks/preact/), and
+  [Vue](/frameworks/vue/) show current service APIs.
+- [Svelte](/frameworks/svelte/) documents the current Svelte adapter scope.
+- [Reference](/reference/overview/) maps the package surface.

--- a/workspace/docs/src/content/docs/frameworks/preact.md
+++ b/workspace/docs/src/content/docs/frameworks/preact.md
@@ -173,6 +173,8 @@ component.
 
 Use `useElementResource()` when a resource needs a DOM element from Preact. It
 returns a callback ref plus a pending or attached result.
+See [Element resources and DOM attachment](/concepts/element-resources/) for the
+framework-neutral concept.
 
 ```tsx
 import { useElementResource } from "@starbeam/preact";
@@ -223,6 +225,8 @@ finalized when Preact detaches the element resource.
 Use `useService()` for shared resource-backed state under the installed Preact
 root. Keep services for app-level concerns whose lifetime should follow the
 Preact app.
+See [Services and app lifetime](/concepts/services/) for the framework-neutral
+concept.
 
 ```tsx
 import { useService } from "@starbeam/preact";
@@ -253,4 +257,8 @@ shared services.
 ## Next steps
 
 - [Core concepts](/concepts/overview/): the framework-neutral Starbeam model.
+- [Services and app lifetime](/concepts/services/): app-scoped resource-backed
+  state.
+- [Element resources and DOM attachment](/concepts/element-resources/): resources
+  attached to framework-supplied elements.
 - [Reference](/reference/overview/): the public package surface at a glance.

--- a/workspace/docs/src/content/docs/frameworks/react.md
+++ b/workspace/docs/src/content/docs/frameworks/react.md
@@ -162,6 +162,8 @@ React commits, and cleanup/finalize run when React cleans up the component.
 
 Use `useElementResource()` when a resource needs a DOM element from React. It
 returns a callback ref plus a pending or attached result.
+See [Element resources and DOM attachment](/concepts/element-resources/) for the
+framework-neutral concept.
 
 ```tsx
 import { useElementResource, useReactive } from "@starbeam/react";
@@ -214,6 +216,8 @@ finalized when React detaches the element resource.
 Use `useService()` for resource-backed state that should live for the app root,
 not for one component. Wrap the React tree in `Starbeam` so services have an
 app-scoped lifetime.
+See [Services and app lifetime](/concepts/services/) for the framework-neutral
+concept.
 
 ```tsx
 import { Starbeam, useReactive, useService } from "@starbeam/react";
@@ -249,4 +253,8 @@ resources, and `useService()` for app-scoped services.
 ## Next steps
 
 - Read [Core concepts](/concepts/overview/) for the model behind the adapter.
+- Read [Services and app lifetime](/concepts/services/) for app-scoped
+  resource-backed state.
+- Read [Element resources and DOM attachment](/concepts/element-resources/) for
+  resources attached to framework-supplied elements.
 - Read [Reference](/reference/overview/) for the public package surface.

--- a/workspace/docs/src/content/docs/frameworks/svelte.md
+++ b/workspace/docs/src/content/docs/frameworks/svelte.md
@@ -156,6 +156,8 @@ work still belongs in Svelte effects or element resources.
 Use `elementResource()` when a resource needs a DOM element from Svelte. It
 returns one Svelte-readable store that is also attachable. Attach it with
 `size.attach`; read the resource value with Svelte store syntax.
+See [Element resources and DOM attachment](/concepts/element-resources/) for the
+framework-neutral concept.
 
 ```ts
 import { reactive } from "@starbeam/collections";
@@ -254,10 +256,14 @@ The Svelte adapter does not yet expose component-lifetime `Resource` helpers or
 app-scoped `Service` helpers. Use `fromStarbeam()` for component reads and
 `elementResource()` for DOM element resources today. Track deeper Svelte adapter
 work in [starbeamjs/starbeam#261](https://github.com/starbeamjs/starbeam/issues/261).
+See [Services and app lifetime](/concepts/services/) for the app-facing service
+concept in adapters that expose service helpers.
 
 ## Next steps
 
 - [Core concepts](/concepts/overview/): the framework-neutral Starbeam model.
+- [Element resources and DOM attachment](/concepts/element-resources/): resources
+  attached to framework-supplied elements.
 - [Framework overview](/frameworks/overview/): how the adapter boundary changes
   by framework.
 - [Reference](/reference/overview/): the public package surface at a glance.

--- a/workspace/docs/src/content/docs/frameworks/vue.md
+++ b/workspace/docs/src/content/docs/frameworks/vue.md
@@ -170,6 +170,8 @@ run when Vue unmounts the component.
 Use `elementResourceDirective()` when a resource needs a DOM element from Vue.
 It returns a Vue directive. Directives do not return template values, so pass an
 `into` ref when the component needs to display the resource value.
+See [Element resources and DOM attachment](/concepts/element-resources/) for the
+framework-neutral concept.
 
 ```vue
 <script setup lang="ts">
@@ -228,6 +230,8 @@ component's render data.
 Use `setupService()` for resource-backed state that should live for the Vue app,
 not for one component. Install `Starbeam` on the Vue app so services have the
 app as their owner.
+See [Services and app lifetime](/concepts/services/) for the framework-neutral
+concept.
 
 ```ts
 import { Starbeam } from "@starbeam/vue";
@@ -287,6 +291,10 @@ The Vue package also exports public element-resource types, including
 ## Next steps
 
 - [Core concepts](/concepts/overview/): the framework-neutral Starbeam model.
+- [Services and app lifetime](/concepts/services/): app-scoped resource-backed
+  state.
+- [Element resources and DOM attachment](/concepts/element-resources/): resources
+  attached to framework-supplied elements.
 - [Framework overview](/frameworks/overview/): how the adapter boundary changes
   by framework.
 - [Reference](/reference/overview/): the public package surface at a glance.

--- a/workspace/docs/src/content/docs/library-authors/overview.md
+++ b/workspace/docs/src/content/docs/library-authors/overview.md
@@ -148,6 +148,8 @@ export function ElementSize(element: Element) {
 
 The resource returns the value consumers want to read: `size.width` and
 `size.height`. The observer and cleanup stay inside the resource.
+See [Element resources and DOM attachment](/concepts/element-resources/) for the
+concept behind framework element-resource APIs.
 
 ## Let adapters consume your library
 
@@ -191,6 +193,7 @@ inside your abstraction unless they are the API you intentionally expose.
 Avoid making app authors consume `@starbeam/service` directly. Framework adapters
 provide the app-facing service helpers where service support is available. Use
 the lower-level service package only for adapter-level or integration code.
+See [Services and app lifetime](/concepts/services/) for the app-facing concept.
 
 ### `@starbeam/core`
 

--- a/workspace/docs/src/content/docs/reference/overview.md
+++ b/workspace/docs/src/content/docs/reference/overview.md
@@ -27,7 +27,8 @@ If you are choosing what to install first, start with
   [Resources and lifecycle](/concepts/lifecycle/) for the app-author model.
 - `@starbeam/service`: app-lifetime resource composition. Use it for shared
   state that should live with the app or framework root. App authors usually
-  reach services through framework adapter helpers.
+  reach services through framework adapter helpers. Start with
+  [Services and app lifetime](/concepts/services/).
 
 ## Lower-level and compatibility packages
 

--- a/workspace/docs/src/content/docs/start/install.md
+++ b/workspace/docs/src/content/docs/start/install.md
@@ -150,6 +150,8 @@ usually use framework adapter helpers instead:
   app ownership explicitly;
 - Svelte: service helpers are not exposed yet.
 
+See [Services and app lifetime](/concepts/services/) for the app-facing model.
+
 ### `@starbeam/reactive`
 
 Use `@starbeam/reactive` directly when you are building lower-level reactive

--- a/workspace/docs/src/pages/index.astro
+++ b/workspace/docs/src/pages/index.astro
@@ -112,7 +112,7 @@ import "../styles/tokens.css";
                   the app root where the adapter exposes an app lifetime.
                 </p>
                 <a class="text-link" href="/concepts/services/">
-                  Read services concepts
+                  Read about services
                 </a>
               </article>
               <article>
@@ -122,7 +122,7 @@ import "../styles/tokens.css";
                   element and Starbeam should own the setup and cleanup work.
                 </p>
                 <a class="text-link" href="/concepts/element-resources/">
-                  Read element resource concepts
+                  Read about element resources
                 </a>
               </article>
             </div>

--- a/workspace/docs/src/pages/index.astro
+++ b/workspace/docs/src/pages/index.astro
@@ -111,6 +111,9 @@ import "../styles/tokens.css";
                   Use a service for resource-backed state that should live with
                   the app root where the adapter exposes an app lifetime.
                 </p>
+                <a class="text-link" href="/concepts/services/">
+                  Read services concepts
+                </a>
               </article>
               <article>
                 <h3>Element resources</h3>
@@ -118,6 +121,9 @@ import "../styles/tokens.css";
                   Use an element resource when the framework should provide a DOM
                   element and Starbeam should own the setup and cleanup work.
                 </p>
+                <a class="text-link" href="/concepts/element-resources/">
+                  Read element resource concepts
+                </a>
               </article>
             </div>
           </div>


### PR DESCRIPTION
## Why

The lifecycle page introduced services and element resources, but both concepts were compressed into that one route. They are central enough to need first-class concept pages before the Reference section expands.

This closes the Concept route expansion PER: lifecycle stays the progression page, while services and element resources get their own app-facing routes.

## What changed

- Adds a Services and app lifetime concept page.
- Adds an Element resources and DOM attachment concept page.
- Shortens the lifecycle page so it links out to the new concept routes while keeping the resource progression.
- Adds Core concepts sidebar entries for Services and Element resources.
- Adds cross-links from framework guides, install, reference, library-author docs, and homepage.
- Updates the documentation dashboard to mark the concept route expansion complete and make reference expansion next.

## Reviewer notes

The new pages intentionally keep low-level `@starbeam/service` and renderer details out of the first-run concept path. Framework adapter APIs are the app-facing path; lower-level package details remain Reference/Advanced material.

## User-facing changes

Docs-only. Readers now have first-class concept pages for services and element resources instead of finding those concepts only inside lifecycle.
