### PR TITLE
docs: expand reference section

### DIFF
--- a/docs/DOCUMENTATION-DASHBOARD.md
+++ b/docs/DOCUMENTATION-DASHBOARD.md
@@ -17,7 +17,7 @@ arc should still get a fresh Prepare before editing.
 | Core concepts          | Done for now | Overview, collections, lifecycle, services, and element resources have first concept pages. |
 | Framework guides       | Partial      | React, Preact, Vue, and Svelte pages exist; status and package README alignment remains.    |
 | Library authors        | Done         | Reusable framework-neutral abstractions have a first guide.                                 |
-| Reference              | Partial      | Current page is a package map, not a usable API reference.                                  |
+| Reference              | Done for now | First hand-written reference cards exist for public packages and framework adapters.        |
 | Advanced / implementor | Done for now | It routes readers to source notes and records the status of implementor material.           |
 | Experiments            | Done for now | Experiments are quarantined, but package READMEs still need cleanup.                        |
 | Archive                | Done         | Historical material is explicitly quarantined.                                              |
@@ -50,7 +50,7 @@ The remaining documentation work should reinforce the public model:
 | P1       | Preact package README                    | Ready   | `packages/preact/preact/README.md`                                                               | Preact has a website guide and public package, but no package-level front door.                                                         |
 | P1       | Core deprecation README + migration page | Done    | `packages/universal/core/README.md`, `workspace/docs/src/content/docs/`                          | Existing users now have package and website migration guidance from `@starbeam/core` to `@starbeam/universal`.                          |
 | P1       | Concept route expansion                  | Done    | `workspace/docs/src/content/docs/concepts/`, `workspace/docs/astro.config.mjs`                   | Services and element resources now have first-class concept pages linked from lifecycle and framework guides.                           |
-| P1       | Reference expansion                      | Next    | `workspace/docs/src/content/docs/reference/`, `workspace/docs/astro.config.mjs`                  | The Reference route currently cannot answer concrete API questions.                                                                     |
+| P1       | Reference expansion                      | Done    | `workspace/docs/src/content/docs/reference/`, `workspace/docs/astro.config.mjs`                  | Reference now has a first batch of hand-written package and adapter cards.                                                              |
 | P2       | Status consistency pass                  | Ready   | `README.md`, framework docs, package READMEs, install/reference pages                            | Svelte, Vue, and experiments need consistent status language across entry points.                                                       |
 | P2       | `@starbeam/use-strict-lifecycle` README  | Ready   | `packages/react/use-strict-lifecycle/README.md`, `packages/react/use-strict-lifecycle/THEORY.md` | A public package currently ships an empty README.                                                                                       |
 | P2       | Experiment package README cleanup        | Ready   | `packages/x/store/README.md`, `packages/x/vanilla/README.md`, experiment package metadata        | The website quarantines experiments, but package surfaces still leak stale or placeholder signals.                                      |
@@ -208,6 +208,11 @@ to framework-supplied DOM elements.
 **Hypothesis:** The Reference section needs hand-written subpages before a
 generated API reference exists.
 
+**Conclusion:** The first batch should stay package-level and adapter-level:
+collections, universal APIs, resources, services, reactive primitives, framework
+adapters, and core compatibility. Generated or per-symbol API docs remain a later
+follow-up.
+
 **Prepare**
 
 - Decide the first batch of reference pages and their audience.
@@ -308,15 +313,14 @@ into the same public docs matrix as the other framework adapters.
 
 ## Recommended next arc
 
-After PER 5 lands, continue with **PER 6: Hand-written reference expansion**.
+After PER 6 lands, continue with **PER 7: Status consistency pass**.
 
-The concept pages now give Reference somewhere stable to point. Reference can be
-concise and API-shaped because the conceptual story lives in Start, Concepts, and
-Framework guides.
+Reference now has concise package and adapter cards. The next gap is consistency
+between website entry points and package READMEs for experimental, low-level,
+deprecated, and historical surfaces.
 
-Start with the public surfaces that already have settled concepts:
-collections, universal resources, reactive primitives, services, framework
-adapters, and core compatibility.
+Start with Svelte status, Vue package README alignment, and experiment package
+metadata/readme cleanup.
 
 ## Validation checklist
 

--- a/workspace/docs/astro.config.mjs
+++ b/workspace/docs/astro.config.mjs
@@ -60,6 +60,18 @@ export default defineConfig({
           label: "Reference",
           items: [
             { label: "Overview", link: "/reference/overview/" },
+            { label: "Collections", link: "/reference/collections/" },
+            { label: "Universal APIs", link: "/reference/universal/" },
+            { label: "Resources", link: "/reference/resources/" },
+            { label: "Services", link: "/reference/services/" },
+            {
+              label: "Reactive primitives",
+              link: "/reference/reactive-primitives/",
+            },
+            {
+              label: "Framework adapters",
+              link: "/reference/framework-adapters/",
+            },
             {
               label: "Core compatibility",
               link: "/reference/core-compatibility/",

--- a/workspace/docs/src/content/docs/reference/collections.md
+++ b/workspace/docs/src/content/docs/reference/collections.md
@@ -1,0 +1,51 @@
+---
+title: Collections
+description: "Reference for @starbeam/collections helpers."
+---
+
+`@starbeam/collections` defines reactive versions of ordinary JavaScript objects
+and built-in collections. Use it for collection-shaped and object-shaped root
+state.
+
+For the concept guide, start with [Collections and objects](/concepts/collections/).
+
+## Install
+
+```sh
+pnpm add @starbeam/collections
+```
+
+```ts
+import { reactive } from "@starbeam/collections";
+```
+
+## Recommended helpers
+
+| Helper                      | Returns         | Use for                                  |
+| --------------------------- | --------------- | ---------------------------------------- |
+| `reactive.Map<K, V>()`      | `Map<K, V>`     | keyed records, registries, caches, carts |
+| `reactive.Set<T>()`         | `Set<T>`        | membership, selections, tags             |
+| `reactive.array<T>(values)` | `T[]`           | ordered list state                       |
+| `reactive.object<T>(value)` | `T`             | object-shaped state                      |
+| `reactive.WeakMap<K, V>()`  | `WeakMap<K, V>` | object-keyed storage with weak ownership |
+| `reactive.WeakSet<T>()`     | `WeakSet<T>`    | weak object membership                   |
+
+`reactive.Map()` and `reactive.Set()` create empty collections. Add entries with
+the normal JavaScript APIs.
+
+`reactive.object()` and `reactive.array()` wrap an initial object or array and
+return the same JavaScript/TypeScript surface.
+
+## Notes
+
+- Prefer the named `reactive` import in user-facing examples.
+- Keep reactive storage private inside domain objects when the collection is an
+  implementation detail.
+- Use [Resources and lifecycle](/concepts/lifecycle/) when the work has setup,
+  sync, cleanup, or finalization.
+
+## Related docs
+
+- [Collections and objects](/concepts/collections/)
+- [Start with root state](/start/introduction/)
+- [Library-author guide](/library-authors/overview/)

--- a/workspace/docs/src/content/docs/reference/framework-adapters.md
+++ b/workspace/docs/src/content/docs/reference/framework-adapters.md
@@ -37,13 +37,13 @@ when there is nothing to bridge.
 
 Package: `@starbeam/preact`
 
-| API                                           | Use for                                                    |
-| --------------------------------------------- | ---------------------------------------------------------- |
-| `install(options)`                            | Install Starbeam into Preact render/lifecycle hooks.       |
-| `useResource(blueprint, deps?)`               | Attach a resource to a Preact component lifetime.          |
-| `useElementResource(build, deps?)`            | Attach element-backed resource work to a callback ref.     |
-| `useService(blueprint)`                       | Resolve app-scoped service state under the installed root. |
-| `useReactive()` / `setup*()` / `createCell()` | Lower-level APIs, not the main Preact path.                |
+| API                                     | Use for                                                    |
+| --------------------------------------- | ---------------------------------------------------------- |
+| `install(options)`                      | Install Starbeam into Preact render/lifecycle hooks.       |
+| `useResource(blueprint, deps?)`         | Attach a resource to a Preact component lifetime.          |
+| `useElementResource(build, bridge?)`    | Attach element-backed resource work to a callback ref.     |
+| `useService(blueprint)`                 | Resolve app-scoped service state under the installed root. |
+| `useReactive` / `setup*` / `createCell` | Lower-level APIs, not the main Preact path.                |
 
 After `install(options)`, direct render reads are the main Preact output boundary.
 

--- a/workspace/docs/src/content/docs/reference/framework-adapters.md
+++ b/workspace/docs/src/content/docs/reference/framework-adapters.md
@@ -1,0 +1,87 @@
+---
+title: Framework adapters
+description: "Reference for Starbeam's React, Preact, Vue, and Svelte adapter surfaces."
+---
+
+Framework adapters connect Starbeam reads, resources, services, and element
+resources to framework rendering and lifecycle.
+
+Use the guide for your framework for full examples. This page is a quick API map.
+
+## Adapter matrix
+
+| Framework | Read boundary                                 | Resources                         | Services                                         | Element resources                               |
+| --------- | --------------------------------------------- | --------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| React     | `useReactive(compute, bridge?)`               | `useResource(blueprint, bridge?)` | `Starbeam` plus `useService(blueprint)`          | `useElementResource(build, bridge?)`            |
+| Preact    | `install(options)` tracks render reads        | `useResource(blueprint, deps?)`   | `useService(blueprint)`                          | `useElementResource(build, bridge?)`            |
+| Vue       | `useReactive()` or `setupReactive(blueprint)` | `setupResource(blueprint)`        | `Starbeam` plugin plus `setupService(blueprint)` | `elementResourceDirective(blueprint, options?)` |
+| Svelte    | `fromStarbeam(compute)`                       | Not exposed yet                   | Not exposed yet                                  | `elementResource(blueprint)`                    |
+
+## React
+
+Package: `@starbeam/react`
+
+| API                                                   | Use for                                                   |
+| ----------------------------------------------------- | --------------------------------------------------------- |
+| `Starbeam`                                            | Establish app lifetime for React services.                |
+| `useReactive(compute, bridge?)`                       | Read Starbeam-backed values at the React render boundary. |
+| `useResource(blueprint, bridge?)`                     | Attach a resource to a React component lifetime.          |
+| `useElementResource(build, bridge?)`                  | Attach element-backed resource work to a callback ref.    |
+| `useService(blueprint)`                               | Resolve app-scoped service state.                         |
+| `useSetup(setup)` / `useProp(variable, description?)` | Lower-level setup helpers.                                |
+
+Use `bridge` for changing non-Starbeam values captured by the callback. Omit it
+when there is nothing to bridge.
+
+## Preact
+
+Package: `@starbeam/preact`
+
+| API                                           | Use for                                                    |
+| --------------------------------------------- | ---------------------------------------------------------- |
+| `install(options)`                            | Install Starbeam into Preact render/lifecycle hooks.       |
+| `useResource(blueprint, deps?)`               | Attach a resource to a Preact component lifetime.          |
+| `useElementResource(build, deps?)`            | Attach element-backed resource work to a callback ref.     |
+| `useService(blueprint)`                       | Resolve app-scoped service state under the installed root. |
+| `useReactive()` / `setup*()` / `createCell()` | Lower-level APIs, not the main Preact path.                |
+
+After `install(options)`, direct render reads are the main Preact output boundary.
+
+## Vue
+
+Package: `@starbeam/vue`
+
+| API                                             | Use for                                                          |
+| ----------------------------------------------- | ---------------------------------------------------------------- |
+| `Starbeam`                                      | Vue plugin for app-scoped service ownership.                     |
+| `useReactive()`                                 | Make direct Starbeam reads visible to the current Vue component. |
+| `setupReactive(blueprint)`                      | Expose a Starbeam read as a Vue ref.                             |
+| `setupResource(blueprint)`                      | Attach a resource to Vue component setup/lifecycle.              |
+| `setupService(blueprint)`                       | Resolve app-scoped service state.                                |
+| `elementResourceDirective(blueprint, options?)` | Attach element-backed work to a Vue directive.                   |
+| `elementResource(blueprint)`                    | Experimental lower-level handle with a directive and ref.        |
+
+## Svelte
+
+Package: `@starbeam/svelte`
+
+| API                                              | Use for                                                                   |
+| ------------------------------------------------ | ------------------------------------------------------------------------- |
+| `fromStarbeam(compute)`                          | Experimental Svelte 5 read bridge for templates, `$derived`, and effects. |
+| `elementResource(blueprint)`                     | Primary Svelte 5 attachment API.                                          |
+| `elementResourceStore(blueprint)`                | Explicit store-shaped spelling.                                           |
+| `elementResourceAttachment(blueprint, options?)` | Lower-level attachment sink.                                              |
+
+The Svelte adapter does not expose component-resource or service helpers yet.
+Deeper integration is tracked in
+[starbeamjs/starbeam#261](https://github.com/starbeamjs/starbeam/issues/261).
+
+## Related docs
+
+- [React guide](/frameworks/react/)
+- [Preact guide](/frameworks/preact/)
+- [Vue guide](/frameworks/vue/)
+- [Svelte guide](/frameworks/svelte/)
+- [Resources](/reference/resources/)
+- [Services](/reference/services/)
+- [Element resources and DOM attachment](/concepts/element-resources/)

--- a/workspace/docs/src/content/docs/reference/overview.md
+++ b/workspace/docs/src/content/docs/reference/overview.md
@@ -1,10 +1,10 @@
 ---
 title: Reference
-description: Starbeam's public package surface at a glance.
+description: Starbeam's public package and adapter surface at a glance.
 ---
 
-This section maps the public Starbeam package surface. It is an overview, not a
-complete API reference.
+This section maps the public Starbeam package and adapter surface. These pages
+are hand-written reference cards, not a generated API encyclopedia.
 
 If you are choosing what to install first, start with
 [Install Starbeam](/start/install/).
@@ -13,28 +13,34 @@ If you are choosing what to install first, start with
 
 - `@starbeam/collections`: reactive `Map`, `Set`, array, and object helpers for
   collection-shaped and object-shaped root state. Start with
-  [Collections and objects](/concepts/collections/).
+  [Collections](/reference/collections/) or the
+  [Collections and objects](/concepts/collections/) concept guide.
 - `@starbeam/universal`: framework-neutral lifecycle APIs such as `Resource`,
-  plus compatibility exports for lower-level primitives.
+  plus compatibility exports for lower-level primitives. See
+  [Universal APIs](/reference/universal/).
 - Framework adapters: `@starbeam/react`, `@starbeam/preact`, `@starbeam/vue`, and
-  `@starbeam/svelte` connect reactive reads and resources to each framework.
+  `@starbeam/svelte` connect reactive reads and resources to each framework. See
+  [Framework adapters](/reference/framework-adapters/).
 
 ## Lifecycle and composition packages
 
 - `@starbeam/resource`: resource APIs for reusable setup, sync, and cleanup
   abstractions. App code often reaches resources through `@starbeam/universal`
   or a framework adapter first. Start with
+  [Resources](/reference/resources/) or
   [Resources and lifecycle](/concepts/lifecycle/) for the app-author model.
 - `@starbeam/service`: app-lifetime resource composition. Use it for shared
   state that should live with the app or framework root. App authors usually
   reach services through framework adapter helpers. Start with
+  [Services](/reference/services/) or
   [Services and app lifetime](/concepts/services/).
 
 ## Lower-level and compatibility packages
 
 - `@starbeam/reactive`: lower-level primitives for authors building reactive
   storage or integration primitives. Most app and library models should start
-  with `@starbeam/collections` and `@starbeam/universal`.
+  with `@starbeam/collections` and `@starbeam/universal`. See
+  [Reactive primitives](/reference/reactive-primitives/).
 - `@starbeam/core`: deprecated compatibility alias for `@starbeam/universal`.
   Existing code can keep using it during the compatibility window; new code
   should not start there. See

--- a/workspace/docs/src/content/docs/reference/reactive-primitives.md
+++ b/workspace/docs/src/content/docs/reference/reactive-primitives.md
@@ -1,0 +1,53 @@
+---
+title: Reactive primitives
+description: "Reference for @starbeam/reactive primitive-building APIs."
+---
+
+`@starbeam/reactive` exposes primitive reactive values for authors building
+Starbeam primitives, adapters, and integration layers. It is not the normal
+starting point for app state.
+
+Most app and library models should start with `@starbeam/collections`,
+`@starbeam/universal`, or a framework adapter.
+
+## Install
+
+```sh
+pnpm add @starbeam/reactive
+```
+
+## Primitive-building surface
+
+| Export                                              | Use for                                                      |
+| --------------------------------------------------- | ------------------------------------------------------------ |
+| `Cell`                                              | Store one reactive value inside a primitive.                 |
+| `Marker`                                            | Mark external storage as reactive without storing the value. |
+| `Formula`                                           | Compute a reactive value every time it is read.              |
+| `CachedFormula`                                     | Cache a reactive computation until one of its reads changes. |
+| `Static`                                            | Wrap a non-changing value as reactive.                       |
+| `read`                                              | Read either a reactive value or a plain value.               |
+| `CellOptions`, `Equality`, `FormulaFn`, `ReadValue` | Helper types for primitive authors.                          |
+
+Use these APIs when the public value you are building is itself a reactive
+primitive or low-level abstraction. For ordinary app state, prefer reactive
+objects and collections.
+
+## Compatibility and implementor exports
+
+`@starbeam/reactive` also exports lower-level APIs used by Starbeam adapters,
+runtime packages, and debug setup:
+
+- tracking frames such as `StartTrackingFrame`, `startFrame`, and `finishFrame`;
+- runtime and debug registration such as `defineRuntime`, `defineDebug`, `DEBUG`,
+  and `UNKNOWN_REACTIVE_VALUE`;
+- protocol helpers such as `isReactive`, `isTagged`, `intoReactive`, and
+  `isFormulaFn`.
+
+These remain exported for compatibility. They are not the app-facing primitive
+path.
+
+## Related docs
+
+- [Reactive README](https://github.com/starbeamjs/starbeam/tree/main/packages/universal/reactive)
+- [Collections and objects](/concepts/collections/)
+- [Universal APIs](/reference/universal/)

--- a/workspace/docs/src/content/docs/reference/resources.md
+++ b/workspace/docs/src/content/docs/reference/resources.md
@@ -1,0 +1,62 @@
+---
+title: Resources
+description: "Reference for Starbeam resource authoring APIs."
+---
+
+Resources model stable values with setup, sync, cleanup, and finalization. Start
+with [Resources and lifecycle](/concepts/lifecycle/) for the concept guide.
+
+App code usually imports `Resource` from `@starbeam/universal`. Reusable resource
+helpers and manual integrations may import direct APIs from `@starbeam/resource`.
+
+## Common import
+
+```ts
+import { Resource } from "@starbeam/universal";
+```
+
+## Direct package
+
+```sh
+pnpm add @starbeam/resource
+```
+
+```ts
+import { Resource, ResourceList, setupResource } from "@starbeam/resource";
+```
+
+## Authoring APIs
+
+| API                             | Use for                                                                                              |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `Resource(constructor)`         | Define a resource blueprint.                                                                         |
+| `resource.use(childBlueprint)`  | Set up a child resource under the current resource.                                                  |
+| `resource.on.sync(handler)`     | Register sync work. Cleanup returned from the handler runs before the next sync and on finalization. |
+| `resource.on.finalize(handler)` | Register cleanup that runs when the resource scope finalizes.                                        |
+| `ResourceList(list, options)`   | Keep a keyed list of child resources stable by key.                                                  |
+
+## Low-level APIs
+
+| API                        | Use for                                                              |
+| -------------------------- | -------------------------------------------------------------------- |
+| `setupResource(blueprint)` | Manual or adapter-facing resource setup.                             |
+| `SyncTo(constructor)`      | Lower-level sync blueprint without child-resource helpers.           |
+| `PrimitiveSyncTo(define)`  | Lowest-level setup/sync/finalization primitive for integration code. |
+
+Most app code should use framework adapter APIs such as React/Preact
+`useResource()` or Vue `setupResource()` instead of `setupResource()` directly.
+
+## Semantics
+
+- Setup creates the stable value.
+- Sync work is scheduled by the caller or framework adapter.
+- Sync cleanup runs before the next sync and when the owner finalizes.
+- Finalizers run when the owning scope finalizes.
+- Child resources sync after their parent.
+
+## Related docs
+
+- [Resources and lifecycle](/concepts/lifecycle/)
+- [Services and app lifetime](/concepts/services/)
+- [Element resources and DOM attachment](/concepts/element-resources/)
+- [Framework adapters](/reference/framework-adapters/)

--- a/workspace/docs/src/content/docs/reference/services.md
+++ b/workspace/docs/src/content/docs/reference/services.md
@@ -1,0 +1,51 @@
+---
+title: Services
+description: "Reference for Starbeam service APIs and adapter-facing service helpers."
+---
+
+Services are resource-backed state with an app lifetime. Start with
+[Services and app lifetime](/concepts/services/) for the concept guide.
+
+App authors usually use service helpers from their framework adapter. The direct
+`@starbeam/service` package is for adapter and manual integration code.
+
+## App-facing adapter APIs
+
+| Framework | API                                              | Notes                                                     |
+| --------- | ------------------------------------------------ | --------------------------------------------------------- |
+| React     | `Starbeam` provider plus `useService(blueprint)` | The provider establishes the app lifetime.                |
+| Preact    | `install(options)` plus `useService(blueprint)`  | The installed adapter owns the app lifetime.              |
+| Vue       | `Starbeam` plugin plus `setupService(blueprint)` | Install the plugin on the Vue app.                        |
+| Svelte    | Not exposed yet                                  | The Svelte adapter does not expose service helpers today. |
+
+## Direct package
+
+```sh
+pnpm add @starbeam/service
+```
+
+```ts
+import { getServiceFormula, service, Service } from "@starbeam/service";
+```
+
+## Low-level APIs
+
+| API                           | Use for                                                            |
+| ----------------------------- | ------------------------------------------------------------------ |
+| `service(resource, options?)` | Resolve the singleton value for a resource blueprint in an app.    |
+| `getServiceFormula(app)`      | Get the formula adapters use to synchronize services for an app.   |
+| `Service(resource, options?)` | Wrap a resource blueprint so it resolves through the selected app. |
+
+## Semantics
+
+- A service is a singleton per app object and resource blueprint.
+- Service setup is tied to the app lifetime, not the first component that asks
+  for it.
+- Finalizing the app finalizes services created for that app.
+- Framework adapters own scheduling and app integration.
+
+## Related docs
+
+- [Services and app lifetime](/concepts/services/)
+- [Resources](/reference/resources/)
+- [Framework adapters](/reference/framework-adapters/)

--- a/workspace/docs/src/content/docs/reference/universal.md
+++ b/workspace/docs/src/content/docs/reference/universal.md
@@ -1,0 +1,64 @@
+---
+title: Universal APIs
+description: "Reference for @starbeam/universal, the framework-neutral Starbeam authoring package."
+---
+
+`@starbeam/universal` is the framework-neutral authoring package for Starbeam.
+Use it for resources and common reactive authoring APIs that are not tied to a
+specific framework adapter.
+
+Most framework-neutral app and library code pairs it with `@starbeam/collections`.
+
+## Install
+
+```sh
+pnpm add @starbeam/universal @starbeam/collections
+```
+
+## Common imports
+
+```ts
+import { Resource } from "@starbeam/universal";
+import { reactive } from "@starbeam/collections";
+```
+
+## Current public surface
+
+| Export group         | Exports                                                        | Notes                                                                                                |
+| -------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Resources            | `Resource`, `ResourceList`                                     | Framework-neutral lifecycle authoring.                                                               |
+| Resource types       | `ResourceBlueprint`, `IntoResourceBlueprint`                   | Useful for reusable resource helpers.                                                                |
+| Reactive primitives  | `Cell`, `Marker`, `Formula`, `CachedFormula`, `Static`, `read` | Prefer `@starbeam/collections` for app state; use primitives when building lower-level abstractions. |
+| Reactive types       | `Reactive`, `Equality`, `FormulaFn`                            | Helper types for library and primitive authors.                                                      |
+| Higher-level helpers | `FormulaList`, `Freshness`, `Variants`                         | Advanced reactive helpers.                                                                           |
+
+## Direct packages not re-exported here
+
+Some public APIs intentionally stay in direct packages:
+
+| Package              | Use for                                                          |
+| -------------------- | ---------------------------------------------------------------- |
+| `@starbeam/service`  | lower-level app-scoped service machinery                         |
+| `@starbeam/resource` | low-level resource setup and sync helpers                        |
+| `@starbeam/reactive` | primitive-building surface and implementor compatibility exports |
+
+App authors usually reach services and resource scheduling through framework
+adapters.
+
+## Compatibility exports
+
+`@starbeam/universal` still exports a few lower-level values for compatibility
+with existing packages and integrations. These are not the first APIs to teach in
+new examples:
+
+- debug wiring such as `DEBUG` and `DEBUG_RENDERER`;
+- runtime/protocol wiring such as `CONTEXT`, `RUNTIME`, and `TAG`.
+
+Prefer direct package imports or adapter APIs for new low-level integration code.
+
+## Related docs
+
+- [Resources and lifecycle](/concepts/lifecycle/)
+- [Collections reference](/reference/collections/)
+- [Reactive primitives](/reference/reactive-primitives/)
+- [Services](/reference/services/)

--- a/workspace/docs/src/styles/starlight.css
+++ b/workspace/docs/src/styles/starlight.css
@@ -235,6 +235,23 @@ pre:not(:where(.not-content *)) {
   box-shadow: var(--starbeam-shadow-soft);
 }
 
+/* The site is light-only, so don't let OS dark mode pick the dark token palette. */
+.expressive-code {
+  --ec-codeBg: #f6f7f9;
+  --ec-codeFg: #403f53;
+  --ec-frm-edBg: #f6f7f9;
+  --ec-frm-trmBg: #f6f7f9;
+  --ec-frm-trmTtbBg: var(--starbeam-docs-sidebar);
+}
+
+.expressive-code .ec-line :where(span[style^="--"]:not([class])) {
+  background-color: var(--1bg, transparent);
+  color: var(--1, inherit);
+  font-style: var(--1fs, inherit);
+  font-weight: var(--1fw, inherit);
+  text-decoration: var(--1td, inherit);
+}
+
 .right-sidebar-panel {
   color: var(--starbeam-muted);
 }


### PR DESCRIPTION
## Why

The Reference section was still only a package map. Now that the concept pages exist for collections, lifecycle, services, and element resources, Reference can stay concise and API-shaped instead of trying to teach the model.

This closes the first hand-written reference expansion PER.

## What changed

- Adds reference cards for Collections, Universal APIs, Resources, Services, Reactive primitives, and Framework adapters.
- Updates the Reference overview to link to those pages.
- Adds the new pages to the Reference sidebar.
- Updates the documentation dashboard to mark the first reference expansion done and make the status consistency pass next.

## Reviewer notes

These pages are intentionally package-level and adapter-level reference cards, not generated per-symbol API docs. Conceptual explanations link back to Concepts and Framework guides.

## User-facing changes

Docs-only. Readers now have concise reference pages for the main public packages and framework adapter surfaces.
