### PR TITLE
docs: align package status language

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Framework apps add the adapter for the framework that owns rendering:
 - `@starbeam/vue`
 - `@starbeam/svelte`
 
+The current Svelte adapter is a focused Svelte 5 slice: experimental
+`fromStarbeam()` reads and attachment-backed element resources. Component
+resources and app-scoped service helpers are not exposed yet.
+
 See [Install Starbeam] for the package chooser.
 
 ## Documentation

--- a/docs/DOCUMENTATION-DASHBOARD.md
+++ b/docs/DOCUMENTATION-DASHBOARD.md
@@ -15,11 +15,11 @@ arc should still get a fresh Prepare before editing.
 | Homepage               | Done         | Public narrative is aligned around “Reactivity that stays JavaScript.”                      |
 | Start                  | Done         | Introduction and install chooser teach framework-neutral and adapter paths.                 |
 | Core concepts          | Done for now | Overview, collections, lifecycle, services, and element resources have first concept pages. |
-| Framework guides       | Partial      | React, Preact, Vue, and Svelte pages exist; status and package README alignment remains.    |
+| Framework guides       | Done for now | React, Preact, Vue, and Svelte pages exist with current adapter status language.            |
 | Library authors        | Done         | Reusable framework-neutral abstractions have a first guide.                                 |
 | Reference              | Done for now | First hand-written reference cards exist for public packages and framework adapters.        |
 | Advanced / implementor | Done for now | It routes readers to source notes and records the status of implementor material.           |
-| Experiments            | Done for now | Experiments are quarantined, but package READMEs still need cleanup.                        |
+| Experiments            | Done for now | Experiments are quarantined, with package README and metadata status language aligned.      |
 | Archive                | Done         | Historical material is explicitly quarantined.                                              |
 | Root README            | Done         | It now routes readers into the website instead of old package README lists.                 |
 | Ember adapter docs     | Deferred     | Do not integrate Ember into the website until the adapter surface has been reviewed.        |
@@ -51,9 +51,9 @@ The remaining documentation work should reinforce the public model:
 | P1       | Core deprecation README + migration page | Done    | `packages/universal/core/README.md`, `workspace/docs/src/content/docs/`                          | Existing users now have package and website migration guidance from `@starbeam/core` to `@starbeam/universal`.                          |
 | P1       | Concept route expansion                  | Done    | `workspace/docs/src/content/docs/concepts/`, `workspace/docs/astro.config.mjs`                   | Services and element resources now have first-class concept pages linked from lifecycle and framework guides.                           |
 | P1       | Reference expansion                      | Done    | `workspace/docs/src/content/docs/reference/`, `workspace/docs/astro.config.mjs`                  | Reference now has a first batch of hand-written package and adapter cards.                                                              |
-| P2       | Status consistency pass                  | Ready   | `README.md`, framework docs, package READMEs, install/reference pages                            | Svelte, Vue, and experiments need consistent status language across entry points.                                                       |
+| P2       | Status consistency pass                  | Done    | `README.md`, framework docs, package READMEs, install/reference pages                            | Svelte, Vue, and experiment status language is aligned across website entry points and package surfaces.                                |
 | P2       | `@starbeam/use-strict-lifecycle` README  | Ready   | `packages/react/use-strict-lifecycle/README.md`, `packages/react/use-strict-lifecycle/THEORY.md` | A public package currently ships an empty README.                                                                                       |
-| P2       | Experiment package README cleanup        | Ready   | `packages/x/store/README.md`, `packages/x/vanilla/README.md`, experiment package metadata        | The website quarantines experiments, but package surfaces still leak stale or placeholder signals.                                      |
+| P2       | Experiment package README cleanup        | Done    | `packages/x/store/README.md`, `packages/x/vanilla/README.md`, experiment package metadata        | Experiment package surfaces now describe their provisional status and headless-form is clearly private placeholder metadata.            |
 | P3       | Ember website integration                | Blocked | Ember package/docs after PR #273 is reviewed                                                     | The adapter surface needs review before it becomes part of the public framework guide set.                                              |
 
 ## PER arcs
@@ -236,6 +236,11 @@ follow-up.
 **Hypothesis:** The website and package READMEs should use the same status words
 for Svelte, Vue, experiments, and direct packages.
 
+**Conclusion:** Svelte is documented as the current Svelte 5 slice with
+experimental reads and element-resource attachments. Vue package docs now match
+the website's `useReactive()` / `setupReactive()` distinction. Experiment package
+READMEs and metadata now use public-experiment or private-placeholder language.
+
 **Prepare**
 
 - Inventory status language in the root README, install page, framework overview,
@@ -313,14 +318,13 @@ into the same public docs matrix as the other framework adapters.
 
 ## Recommended next arc
 
-After PER 6 lands, continue with **PER 7: Status consistency pass**.
+After PER 7 lands, continue with **PER 8: Public infrastructure README closeout**.
 
-Reference now has concise package and adapter cards. The next gap is consistency
-between website entry points and package READMEs for experimental, low-level,
-deprecated, and historical surfaces.
+The remaining public package gap is `@starbeam/use-strict-lifecycle`, which still
+needs an honest README that does not promote it as first-run app-author API.
 
-Start with Svelte status, Vue package README alignment, and experiment package
-metadata/readme cleanup.
+Use its theory notes and React adapter context to decide whether to frame it as a
+standalone React lifecycle utility, Starbeam adapter infrastructure, or both.
 
 ## Validation checklist
 

--- a/packages/svelte/svelte/README.md
+++ b/packages/svelte/svelte/README.md
@@ -2,6 +2,13 @@
 
 Svelte adapter for Starbeam reactive reads and element-backed resources.
 
+## Current scope
+
+`fromStarbeam()` is the current tested Svelte 5 read bridge and is experimental.
+`elementResource()` is the current Svelte 5 attachment path for element-backed
+resources. Component-lifetime resource helpers and app-scoped service helpers are
+not exposed yet.
+
 ## Reactive reads
 
 > Experimental: `fromStarbeam()` is the current tested Svelte 5 read bridge.

--- a/packages/vue/vue/README.md
+++ b/packages/vue/vue/README.md
@@ -5,14 +5,24 @@ resources.
 
 ## Public APIs
 
-- `setupReactive(blueprint)`: expose a Starbeam reactive value as a Vue ref.
+- `useReactive()`: make direct Starbeam reads visible to the current Vue
+  component. Use this when a template reads Starbeam-backed JavaScript directly.
+- `setupReactive(blueprint)`: expose one specific Starbeam read as a Vue ref.
 - `setupResource(blueprint)`: create a Starbeam resource in component setup.
 - `setupService(blueprint)`: access an app-scoped Starbeam service.
-- `elementResource(blueprint)`: create an experimental handle with both a
-  directive and a Vue ref for an element-backed resource.
 - `elementResourceDirective(blueprint, options?)`: attach an element-backed
   resource to a Vue custom directive.
+- `elementResource(blueprint)`: create an experimental lower-level handle with
+  both a directive and a Vue ref for an element-backed resource.
 - `Starbeam`: Vue plugin that owns app-scoped Starbeam services.
+
+## Reactive reads
+
+Use `useReactive()` in setup or `<script setup>` when the template reads
+Starbeam-backed JavaScript directly. It makes the current Vue component aware of
+Starbeam reads, but it does not create a Vue ref by itself.
+
+Use `setupReactive()` when you want a specific Starbeam read as a Vue ref.
 
 ## Element resources
 
@@ -80,9 +90,9 @@ expose getters or methods, so consumers read `size.width`, not
 
 ### Handle experiment
 
-`elementResource()` returns a Vue ref augmented with the directive. This mirrors
-the Svelte experiment where a modifier-like object is both attachable and
-readable.
+`elementResource()` is public but experimental and lower-level. It returns a Vue
+ref augmented with the directive. This mirrors the Svelte experiment where a
+modifier-like object is both attachable and readable.
 
 ```ts
 const size = elementResource(ElementSize);

--- a/packages/x/headless-form/package.json
+++ b/packages/x/headless-form/package.json
@@ -3,23 +3,14 @@
   "name": "@starbeamx/headless-form",
   "type": "module",
   "version": "0.8.9",
-  "description": "A placeholder for a headless form library",
+  "description": "Private placeholder for a future Starbeam headless form experiment",
   "main": "index.ts",
   "types": "index.ts",
   "exports": {
     "default": "./index.ts"
   },
-  "publishConfig": {
-    "exports": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
-    },
-    "main": "dist/index.cjs",
-    "types": "dist/index.d.ts"
-  },
   "starbeam": {
-    "type": "library:public"
+    "type": "library:private"
   },
   "scripts": {
     "test:lint": "eslint . --max-warnings 0",

--- a/packages/x/store/README.md
+++ b/packages/x/store/README.md
@@ -1,4 +1,14 @@
-## Aggregating and Grouping
+# @starbeamx/store
+
+`@starbeamx/store` is a public experiment for reactive table, query, grouping,
+and aggregation APIs. It is useful for exploring table-shaped data, but it is not
+the default app-state path.
+
+The examples below are provisional and may lag current source and tests. For
+stable app docs, start with `@starbeam/collections`, framework adapters, and the
+website guides.
+
+## Aggregating and grouping
 
 **Grouping** turns a list of rows into a map of lists of rows based on some grouping criteria.
 

--- a/packages/x/store/package.json
+++ b/packages/x/store/package.json
@@ -2,7 +2,7 @@
   "name": "@starbeamx/store",
   "type": "module",
   "version": "0.8.9",
-  "description": "A Starbeam Store that's fun and easy to use",
+  "description": "Experimental reactive table, query, grouping, and aggregation APIs for Starbeam",
   "main": "index.ts",
   "types": "index.ts",
   "exports": {

--- a/packages/x/vanilla/README.md
+++ b/packages/x/vanilla/README.md
@@ -1,13 +1,13 @@
-# The Vanilla Renderer
+# @starbeamx/vanilla
 
-The Vanilla Renderer is a minimal, experimental renderer for reactive Starbeam data. It doesn't
-depend on any specific framework, and is capable of rendering HTML constructs.
+`@starbeamx/vanilla` is a public experiment and minimal DOM renderer/reference
+implementation for Starbeam-backed rendering without a framework adapter.
 
-It is intentionally minimal, and in its current form, is not intended to be used as a full-featured
-framework.
+It is intentionally minimal. In its current form, it is not intended to be used
+as a full-featured app framework.
 
-Rather, it is **a useful demonstration** of how to build a Starbeam renderer, and useful in its own
-right for situations where existing frameworks aren't appropriate.
+Use it as a demonstration of how to build a Starbeam renderer, or for situations
+where a small framework-free renderer is useful.
 
-The Vanilla Renderer intentionally does not include any kind of JSX or SFC-like syntax, but instead focuses
-on use-cases where a compiler or other framework structure would get in the way.
+The Vanilla Renderer intentionally does not include JSX or SFC-like syntax. It
+focuses on cases where a compiler or framework structure would get in the way.

--- a/packages/x/vanilla/package.json
+++ b/packages/x/vanilla/package.json
@@ -2,7 +2,7 @@
   "name": "@starbeamx/vanilla",
   "type": "module",
   "version": "0.8.9",
-  "description": "A renderer for Starbeam using Vanilla JavaScript",
+  "description": "Experimental minimal DOM renderer and reference implementation for Starbeam",
   "main": "index.ts",
   "types": "index.ts",
   "exports": {

--- a/workspace/docs/src/content/docs/frameworks/overview.md
+++ b/workspace/docs/src/content/docs/frameworks/overview.md
@@ -8,7 +8,8 @@ native by connecting Starbeam's reactive model to each framework's rendering and
 lifecycle rules.
 
 The goal is not one framework with incidental ports. React, Preact, Vue, and
-Svelte are first-class targets for the public docs.
+Svelte are public docs targets, with adapter coverage maturing at different
+speeds.
 
 ## Same model, native edges
 
@@ -35,8 +36,9 @@ Need the package list first? Start with [Install Starbeam](/start/install/).
   resources, services, and element resources.
 - [**Vue**](/frameworks/vue/): setup helpers and directives for reactive state,
   resources, services, and element resources.
-- [**Svelte**](/frameworks/svelte/): explicit reactive read values with
-  `fromStarbeam()`, plus Svelte 5 element-resource attachments.
+- [**Svelte**](/frameworks/svelte/): current Svelte 5 slice with experimental
+  `fromStarbeam()` reads and element-resource attachments. Component-resource and
+  service helpers are not exposed yet.
 
 Some guide details may mature at different speeds. The top-level posture stays
 the same: Starbeam is designed to make the same domain-shaped reactive model work

--- a/workspace/docs/src/content/docs/reference/overview.md
+++ b/workspace/docs/src/content/docs/reference/overview.md
@@ -19,7 +19,9 @@ If you are choosing what to install first, start with
   plus compatibility exports for lower-level primitives. See
   [Universal APIs](/reference/universal/).
 - Framework adapters: `@starbeam/react`, `@starbeam/preact`, `@starbeam/vue`, and
-  `@starbeam/svelte` connect reactive reads and resources to each framework. See
+  `@starbeam/svelte` connect Starbeam to framework rendering and lifecycle. The
+  Svelte adapter is a current experimental slice with reads and element resources
+  but no component-resource or service helpers yet. See
   [Framework adapters](/reference/framework-adapters/).
 
 ## Lifecycle and composition packages

--- a/workspace/docs/src/content/docs/start/install.md
+++ b/workspace/docs/src/content/docs/start/install.md
@@ -8,14 +8,14 @@ Install the packages you import directly. Most apps need one framework adapter,
 
 ## What are you building?
 
-| If you are building…      | Install…                                                     | Start with…                                                                         |
-| ------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
-| A framework-neutral model | `@starbeam/universal @starbeam/collections`                  | `reactive` collections, domain objects, and `Resource`                              |
-| A React app               | `@starbeam/react @starbeam/universal @starbeam/collections`  | `useReactive()`, `useResource()`, `useService()`, `useElementResource()`            |
-| A Preact app              | `@starbeam/preact @starbeam/universal @starbeam/collections` | `install(options)`, direct render reads, resource/service hooks                     |
-| A Vue app                 | `@starbeam/vue @starbeam/universal @starbeam/collections`    | `setupReactive()`, `setupResource()`, `setupService()`, element-resource directives |
-| A Svelte app              | `@starbeam/svelte @starbeam/universal @starbeam/collections` | `fromStarbeam()` and Svelte 5 element-resource attachments                          |
-| A reusable library        | `@starbeam/universal @starbeam/collections`                  | framework-neutral state and domain-shaped APIs                                      |
+| If you are building…      | Install…                                                     | Start with…                                                                            |
+| ------------------------- | ------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| A framework-neutral model | `@starbeam/universal @starbeam/collections`                  | `reactive` collections, domain objects, and `Resource`                                 |
+| A React app               | `@starbeam/react @starbeam/universal @starbeam/collections`  | `useReactive()`, `useResource()`, `useService()`, `useElementResource()`               |
+| A Preact app              | `@starbeam/preact @starbeam/universal @starbeam/collections` | `install(options)`, direct render reads, resource/service hooks                        |
+| A Vue app                 | `@starbeam/vue @starbeam/universal @starbeam/collections`    | `useReactive()`, `setupResource()`, `setupService()`, element-resource directives      |
+| A Svelte app              | `@starbeam/svelte @starbeam/universal @starbeam/collections` | current Svelte 5 slice: experimental `fromStarbeam()` and element-resource attachments |
+| A reusable library        | `@starbeam/universal @starbeam/collections`                  | framework-neutral state and domain-shaped APIs                                         |
 
 ## Framework-neutral state
 
@@ -92,13 +92,16 @@ pnpm add @starbeam/vue @starbeam/universal @starbeam/collections
 import {
   Starbeam,
   elementResourceDirective,
+  useReactive,
   setupReactive,
   setupResource,
   setupService,
 } from "@starbeam/vue";
 ```
 
-Vue uses Composition API setup helpers and directives: [Vue](/frameworks/vue/).
+Vue uses `useReactive()` for direct template reads, `setupReactive()` when you
+want a specific Starbeam read as a Vue ref, and directives for element resources:
+[Vue](/frameworks/vue/).
 
 ### Svelte
 
@@ -115,9 +118,9 @@ import {
 } from "@starbeam/svelte";
 ```
 
-Svelte currently exposes Starbeam reads through `fromStarbeam()` and DOM element
-resources through Svelte 5 attachments. Component-resource and app-service
-helpers are not exposed yet. See [Svelte](/frameworks/svelte/).
+Svelte currently exposes experimental Starbeam reads through `fromStarbeam()` and
+DOM element resources through Svelte 5 attachments. Component-resource and
+app-service helpers are not exposed yet. See [Svelte](/frameworks/svelte/).
 
 ## Direct packages
 

--- a/workspace/docs/src/pages/index.astro
+++ b/workspace/docs/src/pages/index.astro
@@ -167,8 +167,9 @@ import "../styles/tokens.css";
               <span aria-hidden="true">Svelte</span>
               <h3>Svelte</h3>
               <p>
-                <code>fromStarbeam()</code> exposes Starbeam reads to Svelte 5,
-                and element resources work through Svelte attachments today.
+                The current Svelte 5 slice exposes experimental
+                <code>fromStarbeam()</code> reads, and element resources work
+                through Svelte attachments today.
               </p>
             </a>
           </div>


### PR DESCRIPTION
## Why

The website and package README surfaces had a few status mismatches: Svelte appeared equivalent to the other adapters at some entry points, Vue's package README lagged the website's `useReactive()` story, and experimental package metadata still sounded stable or placeholder-like.

This closes the status consistency PER.

## What changed

- Aligns Svelte status language across root README, homepage, install, framework overview, reference, and package README.
- Updates the Vue package README to document `useReactive()` and clarify `setupReactive()`.
- Clarifies Vue `elementResource()` as public but experimental/lower-level while keeping `elementResourceDirective()` as the first app path.
- Adds public-experiment framing to `@starbeamx/store` and `@starbeamx/vanilla` READMEs and metadata.
- Marks `@starbeamx/headless-form` as a private placeholder consistently.
- Updates the documentation dashboard to mark the status pass done and make `@starbeam/use-strict-lifecycle` README next.

## Reviewer notes

This is a docs/metadata status pass. It does not introduce a new package classification type; experiments remain publishable public packages where appropriate, and the headless-form placeholder remains private.

## User-facing changes

Readers get consistent status language for Svelte, Vue, and experimental packages across website entry points and package READMEs.
