### PR TITLE
docs: add use strict lifecycle README

### DIFF
--- a/docs/DOCUMENTATION-DASHBOARD.md
+++ b/docs/DOCUMENTATION-DASHBOARD.md
@@ -52,7 +52,7 @@ The remaining documentation work should reinforce the public model:
 | P1       | Concept route expansion                  | Done    | `workspace/docs/src/content/docs/concepts/`, `workspace/docs/astro.config.mjs`                   | Services and element resources now have first-class concept pages linked from lifecycle and framework guides.                           |
 | P1       | Reference expansion                      | Done    | `workspace/docs/src/content/docs/reference/`, `workspace/docs/astro.config.mjs`                  | Reference now has a first batch of hand-written package and adapter cards.                                                              |
 | P2       | Status consistency pass                  | Done    | `README.md`, framework docs, package READMEs, install/reference pages                            | Svelte, Vue, and experiment status language is aligned across website entry points and package surfaces.                                |
-| P2       | `@starbeam/use-strict-lifecycle` README  | Ready   | `packages/react/use-strict-lifecycle/README.md`, `packages/react/use-strict-lifecycle/THEORY.md` | A public package currently ships an empty README.                                                                                       |
+| P2       | `@starbeam/use-strict-lifecycle` README  | Done    | `packages/react/use-strict-lifecycle/README.md`, `packages/react/use-strict-lifecycle/THEORY.md` | The public React lifecycle infrastructure package now has a README and website reference pointers.                                      |
 | P2       | Experiment package README cleanup        | Done    | `packages/x/store/README.md`, `packages/x/vanilla/README.md`, experiment package metadata        | Experiment package surfaces now describe their provisional status and headless-form is clearly private placeholder metadata.            |
 | P3       | Ember website integration                | Blocked | Ember package/docs after PR #273 is reviewed                                                     | The adapter surface needs review before it becomes part of the public framework guide set.                                              |
 
@@ -268,6 +268,10 @@ READMEs and metadata now use public-experiment or private-placeholder language.
 **Hypothesis:** Public but non-first-run packages need honest README pages even
 when they are not part of the app-author path.
 
+**Conclusion:** `@starbeam/use-strict-lifecycle` is public React lifecycle
+infrastructure for library and adapter authors. It is also used by
+`@starbeam/react`, but app code should start with the adapter APIs.
+
 **Prepare**
 
 - Read the `@starbeam/use-strict-lifecycle` theory notes and current package
@@ -279,8 +283,7 @@ when they are not part of the app-author path.
 **Execute**
 
 - Write `packages/react/use-strict-lifecycle/README.md`.
-- Clean up experiment package READMEs or explicitly mark them provisional.
-- Link to Advanced or Experiments rather than Start.
+- Link to Advanced or Reference rather than Start.
 
 **Review**
 
@@ -318,13 +321,14 @@ into the same public docs matrix as the other framework adapters.
 
 ## Recommended next arc
 
-After PER 7 lands, continue with **PER 8: Public infrastructure README closeout**.
+After PER 8 lands, the remaining blocked dashboard item is **PER 9: Ember
+documentation integration**.
 
-The remaining public package gap is `@starbeam/use-strict-lifecycle`, which still
-needs an honest README that does not promote it as first-run app-author API.
+Do not start Ember docs until the adapter surface in PR #273 has been reviewed
+and accepted.
 
-Use its theory notes and React adapter context to decide whether to frame it as a
-standalone React lifecycle utility, Starbeam adapter infrastructure, or both.
+If Ember stays deferred, use the dashboard as a checkpoint and decide whether to
+return to release prep or close the docs arc.
 
 ## Validation checklist
 

--- a/docs/WEBSITE-READINESS.md
+++ b/docs/WEBSITE-READINESS.md
@@ -56,7 +56,7 @@ can become site content.
 | [packages/universal/runtime/README.md](../packages/universal/runtime/README.md)                             | Historical / archive          | Archive only; rewrite source for advanced docs | Explicitly outdated; contains historical timeline/API language and stale examples.               |
 | [packages/universal/debug/src/description/README.md](../packages/universal/debug/src/description/README.md) | Historical / internal         | Archive only                                   | Explicitly outdated and internal to debug architecture.                                          |
 | [packages/react/react/src/modifiers/README.md](../packages/react/react/src/modifiers/README.md)             | Rewrite needed                | None until rewritten                           | Under construction.                                                                              |
-| [packages/react/use-strict-lifecycle/README.md](../packages/react/use-strict-lifecycle/README.md)           | Rewrite needed                | Public package guide                           | Empty despite the package being public.                                                          |
+| [packages/react/use-strict-lifecycle/README.md](../packages/react/use-strict-lifecycle/README.md)           | Canonical with caveats        | Public infrastructure package guide            | React lifecycle infrastructure; not a first-run app-author path.                                 |
 | [packages/x/store/README.md](../packages/x/store/README.md)                                                 | Experiment / rewrite needed   | Experiments section                            | Example-heavy fragment, not a package overview.                                                  |
 | [packages/x/vanilla/README.md](../packages/x/vanilla/README.md)                                             | Experiment / rewrite needed   | Experiments section                            | Explicitly experimental and minimal.                                                             |
 
@@ -80,8 +80,9 @@ technology or creating a docs app.
    taxonomy should explicitly say whether it is first-class for this website.
 7. **Historical quarantine.** Runtime and universal historical docs must not
    appear as current docs in the site nav.
-8. **`@starbeam/use-strict-lifecycle` README.** The package is public, but the
-   README is empty.
+8. **`@starbeam/use-strict-lifecycle` README.** Completed after website
+   scaffolding. The package is public React lifecycle infrastructure, not a
+   first-run app-author path.
 9. **App-author service examples.** Website service docs should show framework
    adapter APIs, not only the low-level `app` object path.
 

--- a/packages/react/use-strict-lifecycle/README.md
+++ b/packages/react/use-strict-lifecycle/README.md
@@ -37,30 +37,38 @@ pnpm add @starbeam/use-strict-lifecycle
 `useLifecycle(options).render(build)` creates or returns a lifecycle-managed
 instance.
 
+The `build` callback does not run on every render. It runs when the instance is
+first created and when React or `validate` forces a rebuild. Per-render work
+belongs in lifecycle handlers such as `on.update()`, `on.layout()`, and
+`on.idle()`.
+
 ```tsx
 import { useLifecycle } from "@starbeam/use-strict-lifecycle";
 
 interface TimerHandle {
   readonly startedAt: number;
+  label: string;
   current: number;
 }
 
 export function useTimer(label: string): TimerHandle {
-  return useLifecycle({ props: label }).render(({ on }, currentLabel, prev) => {
+  return useLifecycle({ props: label }).render(({ on }, initialLabel, prev) => {
     const timer: TimerHandle = prev ?? {
       startedAt: Date.now(),
+      label: initialLabel,
       current: Date.now(),
     };
 
-    on.update(() => {
+    on.update((currentLabel) => {
+      timer.label = currentLabel;
       timer.current = Date.now();
     });
 
-    on.layout(() => {
+    on.layout((currentLabel) => {
       console.log("attached", currentLabel);
     });
 
-    on.cleanup(() => {
+    on.cleanup((currentLabel) => {
       console.log("detached", currentLabel);
     });
 
@@ -69,9 +77,12 @@ export function useTimer(label: string): TimerHandle {
 }
 ```
 
-The `build` callback runs during render, so keep it to synchronous identity setup
-and lifecycle handler registration. Put effectful work in `layout`, `idle`, or
-`cleanup` handlers.
+The `build` callback runs during render, but only for initial creation or
+rebuild. Keep it to synchronous identity setup and lifecycle handler
+registration. Put per-render updates in `update` handlers, and put layout,
+passive, or cleanup work in `layout`, `idle`, or `cleanup` handlers. Read current
+`props` from the handler argument so handlers do not close over stale render
+values.
 
 ## Options
 

--- a/packages/react/use-strict-lifecycle/README.md
+++ b/packages/react/use-strict-lifecycle/README.md
@@ -1,0 +1,136 @@
+# @starbeam/use-strict-lifecycle
+
+React lifecycle infrastructure for code that needs a fresh instance when React
+re-activates a component.
+
+This package is public, but it is not the normal app-author starting point for
+Starbeam. App code should usually start with `@starbeam/react` hooks such as
+`useReactive()`, `useResource()`, `useElementResource()`, and `useService()`.
+
+Use this package directly when you are writing React infrastructure or reusable
+library code that needs to manage setup, update, layout, idle, and cleanup across
+React Strict Mode, Fast Refresh, and hidden/revealed trees.
+
+## Why this exists
+
+React can keep a component instance while running its cleanup and setup work
+again. This happens in development Strict Mode and Fast Refresh, and similar
+activation/deactivation patterns appear in newer React lifecycle features.
+
+That means infrastructure code cannot treat cleanup as final unmount, and it
+cannot assume setup only runs once for a component instance.
+
+`useLifecycle()` gives infrastructure code one place to create an instance,
+register lifecycle handlers, clean it up when React deactivates it, and create a
+fresh instance when React activates it again.
+
+## Install
+
+```sh
+pnpm add @starbeam/use-strict-lifecycle
+```
+
+`react`, `react-dom`, and `scheduler` are peer dependencies.
+
+## `useLifecycle()`
+
+`useLifecycle(options).render(build)` creates or returns a lifecycle-managed
+instance.
+
+```tsx
+import { useLifecycle } from "@starbeam/use-strict-lifecycle";
+
+interface TimerHandle {
+  readonly startedAt: number;
+  current: number;
+}
+
+export function useTimer(label: string): TimerHandle {
+  return useLifecycle({ props: label }).render(({ on }, currentLabel, prev) => {
+    const timer: TimerHandle = prev ?? {
+      startedAt: Date.now(),
+      current: Date.now(),
+    };
+
+    on.update(() => {
+      timer.current = Date.now();
+    });
+
+    on.layout(() => {
+      console.log("attached", currentLabel);
+    });
+
+    on.cleanup(() => {
+      console.log("detached", currentLabel);
+    });
+
+    return timer;
+  });
+}
+```
+
+The `build` callback runs during render, so keep it to synchronous identity setup
+and lifecycle handler registration. Put effectful work in `layout`, `idle`, or
+`cleanup` handlers.
+
+## Options
+
+| Option     | Use for                                                                                              |
+| ---------- | ---------------------------------------------------------------------------------------------------- |
+| `props`    | Per-render values passed to the build callback and lifecycle handlers.                               |
+| `validate` | A value that decides whether the existing instance is still valid.                                   |
+| `with`     | Equality function for comparing the current and previous `validate` values. Defaults to `Object.is`. |
+
+When validation fails, `useLifecycle()` runs cleanup, rebuilds the instance, and
+runs layout handlers for the new instance.
+
+## Builder API
+
+The build callback receives a `Builder`.
+
+| Builder member        | Use for                                                         |
+| --------------------- | --------------------------------------------------------------- |
+| `on.update(handler)`  | Run during updates while the component is active.               |
+| `on.layout(handler)`  | Run in layout-effect timing after React attaches the component. |
+| `on.idle(handler)`    | Run in passive-effect timing.                                   |
+| `on.cleanup(handler)` | Run when React deactivates or unmounts the instance.            |
+| `notify()`            | Ask React to rerender when the managed instance changes.        |
+
+The build callback also receives the current `props` value and, when available,
+the previous instance value. Use `prev` when your infrastructure needs to carry a
+selected piece of identity across a rebuild.
+
+## Helper APIs
+
+| API                       | Use for                                                                      |
+| ------------------------- | ---------------------------------------------------------------------------- |
+| `useInstance(blueprint)`  | Small wrapper around `useLifecycle().render(blueprint)`.                     |
+| `useLastRenderRef(value)` | Expose the latest render value to lifecycle handlers without stale closures. |
+
+## Starbeam integration helpers
+
+The package also exports helpers used by `@starbeam/react` to enforce Starbeam's
+React read rules:
+
+- `isRendering()`;
+- `maskRendering()` / `unmaskRendering()`;
+- `setupFunction()`;
+- `unsafeTrackedElsewhere()`.
+
+These are integration helpers, not normal app APIs. Use them only when building
+React infrastructure that needs to participate in Starbeam's read barriers.
+
+## What this package does not do
+
+- It does not bypass React Strict Mode.
+- It does not make effects run only once.
+- It does not replace `@starbeam/react` for app code.
+- It does not decide when a Starbeam resource syncs; framework adapters own that
+  scheduling.
+
+## Learn more
+
+- [React guide](https://starbeamjs.com/frameworks/react/): app-facing React APIs.
+- [Advanced / implementor docs](https://starbeamjs.com/advanced/overview/): React
+  lifecycle and compiler notes.
+- [Theory notes](./THEORY.md): implementation background for the lifecycle model.

--- a/packages/react/use-strict-lifecycle/package.json
+++ b/packages/react/use-strict-lifecycle/package.json
@@ -2,7 +2,7 @@
   "name": "@starbeam/use-strict-lifecycle",
   "type": "module",
   "version": "0.8.9",
-  "description": "React hook to manage the lifecycle of a component correctly. It handles double-rendering in React 16.8+ strict mode and remounting in React 18+ strict mode. It does not circumvent those strict modes, but rather provides an ergonomic way to satisfy their requirements.",
+  "description": "React lifecycle infrastructure for setup, update, layout, idle, and cleanup across Strict Mode, Fast Refresh, and hidden/revealed trees.",
   "main": "index.ts",
   "types": "index.ts",
   "exports": {

--- a/workspace/docs/src/content/docs/advanced/overview.md
+++ b/workspace/docs/src/content/docs/advanced/overview.md
@@ -110,11 +110,12 @@ lifecycle behavior or reviewing compiler-facing code.
 
 Source material:
 
+- [packages/react/use-strict-lifecycle/README.md](https://github.com/starbeamjs/starbeam/blob/main/packages/react/use-strict-lifecycle/README.md)
 - [packages/react/use-strict-lifecycle/THEORY.md](https://github.com/starbeamjs/starbeam/blob/main/packages/react/use-strict-lifecycle/THEORY.md)
 - [docs/INVARIANTS.md](https://github.com/starbeamjs/starbeam/blob/main/docs/INVARIANTS.md)
 
-The `@starbeam/use-strict-lifecycle` README is not yet a finished public guide.
-Treat the theory note as implementation background.
+Use the `@starbeam/use-strict-lifecycle` README for the public infrastructure
+surface. Treat the theory note as implementation background.
 
 ### Package-surface policy
 

--- a/workspace/docs/src/content/docs/reference/overview.md
+++ b/workspace/docs/src/content/docs/reference/overview.md
@@ -43,6 +43,8 @@ If you are choosing what to install first, start with
   storage or integration primitives. Most app and library models should start
   with `@starbeam/collections` and `@starbeam/universal`. See
   [Reactive primitives](/reference/reactive-primitives/).
+- `@starbeam/use-strict-lifecycle`: public React lifecycle infrastructure for
+  library and adapter authors. App code should start with `@starbeam/react`.
 - `@starbeam/core`: deprecated compatibility alias for `@starbeam/universal`.
   Existing code can keep using it during the compatibility window; new code
   should not start there. See


### PR DESCRIPTION
## Why

`@starbeam/use-strict-lifecycle` is a public package and ships a README, but the README was empty. The package is infrastructure used by `@starbeam/react` and can also be used directly by React library/infrastructure authors, but it should not look like the first app-author path.

This closes the public infrastructure README PER.

## What changed

- Adds a README for `@starbeam/use-strict-lifecycle`.
- Frames the package as public React lifecycle infrastructure, not a first-run app API.
- Documents `useLifecycle()`, options, builder handlers, helper APIs, and Starbeam integration helpers.
- Updates the package description.
- Updates Advanced, Reference, Website Readiness, and the documentation dashboard to point at the finished README.

## Reviewer notes

The README intentionally avoids promoting the read-barrier helpers as normal app APIs. App code should still start with `@starbeam/react`.

## User-facing changes

Docs and package metadata only. Package readers now get an honest README for `@starbeam/use-strict-lifecycle`.
