### PR TITLE
docs: add Ember adapter guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ Framework apps add the adapter for the framework that owns rendering:
 
 - `@starbeam/react`
 - `@starbeam/preact`
+- `@starbeam/ember`
 - `@starbeam/vue`
 - `@starbeam/svelte`
+
+The current Ember adapter is an experimental v2 addon. Use `fromStarbeam()` at
+the Ember boundary so Starbeam reads invalidate Glimmer tags.
 
 The current Svelte adapter is a focused Svelte 5 slice: experimental
 `fromStarbeam()` reads and attachment-backed element resources. Component
@@ -55,7 +59,7 @@ See [Install Starbeam] for the package chooser.
 - [Start]: build a first Starbeam model.
 - [Install Starbeam]: choose packages for your app or library.
 - [Core concepts]: learn root state, derived reads, resources, and services.
-- [Framework guides]: connect Starbeam to React, Preact, Vue, or Svelte.
+- [Framework guides]: connect Starbeam to React, Preact, Ember, Vue, or Svelte.
 - [Library-author guide]: write reusable framework-neutral abstractions.
 - [Reference]: see the package reference.
 - [Advanced docs]: orient to adapter and runtime internals.

--- a/docs/DOCUMENTATION-DASHBOARD.md
+++ b/docs/DOCUMENTATION-DASHBOARD.md
@@ -15,14 +15,14 @@ arc should still get a fresh Prepare before editing.
 | Homepage               | Done         | Public narrative is aligned around “Reactivity that stays JavaScript.”                      |
 | Start                  | Done         | Introduction and install chooser teach framework-neutral and adapter paths.                 |
 | Core concepts          | Done for now | Overview, collections, lifecycle, services, and element resources have first concept pages. |
-| Framework guides       | Done for now | React, Preact, Vue, and Svelte pages exist with current adapter status language.            |
+| Framework guides       | Done for now | React, Preact, Ember, Vue, and Svelte pages exist with current adapter status language.     |
 | Library authors        | Done         | Reusable framework-neutral abstractions have a first guide.                                 |
 | Reference              | Done for now | First hand-written reference cards exist for public packages and framework adapters.        |
 | Advanced / implementor | Done for now | It routes readers to source notes and records the status of implementor material.           |
 | Experiments            | Done for now | Experiments are quarantined, with package README and metadata status language aligned.      |
 | Archive                | Done         | Historical material is explicitly quarantined.                                              |
 | Root README            | Done         | It now routes readers into the website instead of old package README lists.                 |
-| Ember adapter docs     | Deferred     | Do not integrate Ember into the website until the adapter surface has been reviewed.        |
+| Ember adapter docs     | Done         | Ember is integrated as an experimental v2 addon after adapter review.                       |
 
 ## North star
 
@@ -43,18 +43,18 @@ The remaining documentation work should reinforce the public model:
 
 ## Dashboard
 
-| Priority | Arc                                      | Status  | Primary files                                                                                    | Why it matters                                                                                                                          |
-| -------- | ---------------------------------------- | ------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
-| P0       | Collections concept + package README     | Done    | `workspace/docs/src/content/docs/concepts/`, `packages/universal/collections/README.md`          | Collections are now the preferred root-state story for collection-shaped data, with a concept route and aligned package README.         |
-| P0       | Reactive primitive README rewrite        | Next    | `packages/universal/reactive/README.md`                                                          | `@starbeam/reactive` is public for authors building primitives, but the README still blends that surface with runtime/protocol caveats. |
-| P1       | Preact package README                    | Ready   | `packages/preact/preact/README.md`                                                               | Preact has a website guide and public package, but no package-level front door.                                                         |
-| P1       | Core deprecation README + migration page | Done    | `packages/universal/core/README.md`, `workspace/docs/src/content/docs/`                          | Existing users now have package and website migration guidance from `@starbeam/core` to `@starbeam/universal`.                          |
-| P1       | Concept route expansion                  | Done    | `workspace/docs/src/content/docs/concepts/`, `workspace/docs/astro.config.mjs`                   | Services and element resources now have first-class concept pages linked from lifecycle and framework guides.                           |
-| P1       | Reference expansion                      | Done    | `workspace/docs/src/content/docs/reference/`, `workspace/docs/astro.config.mjs`                  | Reference now has a first batch of hand-written package and adapter cards.                                                              |
-| P2       | Status consistency pass                  | Done    | `README.md`, framework docs, package READMEs, install/reference pages                            | Svelte, Vue, and experiment status language is aligned across website entry points and package surfaces.                                |
-| P2       | `@starbeam/use-strict-lifecycle` README  | Done    | `packages/react/use-strict-lifecycle/README.md`, `packages/react/use-strict-lifecycle/THEORY.md` | The public React lifecycle infrastructure package now has a README and website reference pointers.                                      |
-| P2       | Experiment package README cleanup        | Done    | `packages/x/store/README.md`, `packages/x/vanilla/README.md`, experiment package metadata        | Experiment package surfaces now describe their provisional status and headless-form is clearly private placeholder metadata.            |
-| P3       | Ember website integration                | Blocked | Ember package/docs after PR #273 is reviewed                                                     | The adapter surface needs review before it becomes part of the public framework guide set.                                              |
+| Priority | Arc                                      | Status | Primary files                                                                                    | Why it matters                                                                                                                          |
+| -------- | ---------------------------------------- | ------ | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| P0       | Collections concept + package README     | Done   | `workspace/docs/src/content/docs/concepts/`, `packages/universal/collections/README.md`          | Collections are now the preferred root-state story for collection-shaped data, with a concept route and aligned package README.         |
+| P0       | Reactive primitive README rewrite        | Next   | `packages/universal/reactive/README.md`                                                          | `@starbeam/reactive` is public for authors building primitives, but the README still blends that surface with runtime/protocol caveats. |
+| P1       | Preact package README                    | Ready  | `packages/preact/preact/README.md`                                                               | Preact has a website guide and public package, but no package-level front door.                                                         |
+| P1       | Core deprecation README + migration page | Done   | `packages/universal/core/README.md`, `workspace/docs/src/content/docs/`                          | Existing users now have package and website migration guidance from `@starbeam/core` to `@starbeam/universal`.                          |
+| P1       | Concept route expansion                  | Done   | `workspace/docs/src/content/docs/concepts/`, `workspace/docs/astro.config.mjs`                   | Services and element resources now have first-class concept pages linked from lifecycle and framework guides.                           |
+| P1       | Reference expansion                      | Done   | `workspace/docs/src/content/docs/reference/`, `workspace/docs/astro.config.mjs`                  | Reference now has a first batch of hand-written package and adapter cards.                                                              |
+| P2       | Status consistency pass                  | Done   | `README.md`, framework docs, package READMEs, install/reference pages                            | Svelte, Vue, and experiment status language is aligned across website entry points and package surfaces.                                |
+| P2       | `@starbeam/use-strict-lifecycle` README  | Done   | `packages/react/use-strict-lifecycle/README.md`, `packages/react/use-strict-lifecycle/THEORY.md` | The public React lifecycle infrastructure package now has a README and website reference pointers.                                      |
+| P2       | Experiment package README cleanup        | Done   | `packages/x/store/README.md`, `packages/x/vanilla/README.md`, experiment package metadata        | Experiment package surfaces now describe their provisional status and headless-form is clearly private placeholder metadata.            |
+| P3       | Ember website integration                | Done   | Ember website guide, framework matrix, install chooser, reference, and root README               | Ember is now part of the public framework guide set with experimental v2 addon status language.                                         |
 
 ## PER arcs
 
@@ -292,7 +292,7 @@ infrastructure for library and adapter authors. It is also used by
 
 ### PER 9: Ember documentation integration
 
-**Blocked until the adapter review happens.**
+**Status:** Done after the adapter surface was accepted.
 
 **Hypothesis:** If the Ember adapter surface is accepted, Ember should be wired
 into the same public docs matrix as the other framework adapters.
@@ -300,7 +300,7 @@ into the same public docs matrix as the other framework adapters.
 **Prepare**
 
 - Review the accepted Ember public surface after PR #273 is revised or approved.
-- Decide whether Ember belongs beside React/Preact/Vue/Svelte or behind an
+- Decide whether Ember belongs beside the other framework guides or behind an
   experimental caveat.
 - Confirm the read bridge, resource API, service API, and element-resource API
   are documented in Ember-native terms.
@@ -312,6 +312,10 @@ into the same public docs matrix as the other framework adapters.
   root README if appropriate.
 - Align the package README with the website guide.
 
+**Outcome:** Ember is now wired into the website and root README as an
+experimental v2 addon. The guide documents the Glimmer tag bridge explicitly and
+does not imply raw template reads are reactive.
+
 **Review**
 
 - Confirm the guide does not assume raw template reads are reactive without the
@@ -321,14 +325,9 @@ into the same public docs matrix as the other framework adapters.
 
 ## Recommended next arc
 
-After PER 8 lands, the remaining blocked dashboard item is **PER 9: Ember
-documentation integration**.
-
-Do not start Ember docs until the adapter surface in PR #273 has been reviewed
-and accepted.
-
-If Ember stays deferred, use the dashboard as a checkpoint and decide whether to
-return to release prep or close the docs arc.
+The public website spine is complete for the current adapter set. Use this
+dashboard as a checkpoint and decide whether to return to release prep or start a
+new documentation arc.
 
 ## Validation checklist
 

--- a/docs/DOCUMENTATION-DASHBOARD.md
+++ b/docs/DOCUMENTATION-DASHBOARD.md
@@ -299,7 +299,7 @@ into the same public docs matrix as the other framework adapters.
 
 **Prepare**
 
-- Review the accepted Ember public surface after PR #273 is revised or approved.
+- Review the accepted Ember public surface after PR #286 lands.
 - Decide whether Ember belongs beside the other framework guides or behind an
   experimental caveat.
 - Confirm the read bridge, resource API, service API, and element-resource API

--- a/workspace/docs/astro.config.mjs
+++ b/workspace/docs/astro.config.mjs
@@ -48,6 +48,7 @@ export default defineConfig({
             { label: "Overview", link: "/frameworks/overview/" },
             { label: "React", link: "/frameworks/react/" },
             { label: "Preact", link: "/frameworks/preact/" },
+            { label: "Ember", link: "/frameworks/ember/" },
             { label: "Vue", link: "/frameworks/vue/" },
             { label: "Svelte", link: "/frameworks/svelte/" },
           ],

--- a/workspace/docs/src/content/docs/concepts/element-resources.md
+++ b/workspace/docs/src/content/docs/concepts/element-resources.md
@@ -65,6 +65,7 @@ that framework's native dialect.
 | --------- | ---------------------------- | ------------------- |
 | React     | `useElementResource()`       | callback ref        |
 | Preact    | `useElementResource()`       | callback ref        |
+| Ember     | `elementResourceModifier()`  | modifier            |
 | Vue       | `elementResourceDirective()` | custom directive    |
 | Svelte    | `elementResource()`          | Svelte 5 attachment |
 
@@ -84,6 +85,36 @@ return <section ref={size.ref}>{size.status}</section>;
 
 The hook owns the element lifetime. When the element is detached, the adapter
 finalizes the element resource.
+
+## Ember
+
+Ember uses modifiers for element-owned work. `elementResourceModifier()` creates
+a modifier and can publish the resource value into tracked state owned by the
+component.
+
+```gjs
+class Panel extends Component {
+  @tracked size = null;
+  measure = elementResourceModifier(ElementSize, {
+    into: (value) => {
+      this.size = value;
+    },
+  });
+
+  <template>
+    <section {{this.measure}}>
+      {{#if this.size}}
+        {{this.size.width}} × {{this.size.height}}
+      {{else}}
+        Measuring…
+      {{/if}}
+    </section>
+  </template>
+}
+```
+
+The modifier owns the element lifetime. The `into` callback is the handoff from
+the modifier back to Ember render data.
 
 ## Vue
 

--- a/workspace/docs/src/content/docs/concepts/lifecycle.md
+++ b/workspace/docs/src/content/docs/concepts/lifecycle.md
@@ -119,6 +119,9 @@ sync, cleanup, and finalize fit into the framework that owns the component.
 - [Preact](/frameworks/preact/) uses `useResource()`. The resource belongs to
   the Preact component; sync is scheduled through Preact effects, and finalize
   runs when the component unmounts.
+- [Ember](/frameworks/ember/) uses `setupResource()`. The resource belongs to an
+  Ember destroyable; template-facing reads go through `fromStarbeam()` so
+  Glimmer autotracking sees Starbeam invalidations.
 - [Vue](/frameworks/vue/) uses `setupResource()`. The resource is created from
   Vue setup, sync is scheduled through Vue's component lifecycle, and finalize
   runs when Vue unmounts the component.

--- a/workspace/docs/src/content/docs/concepts/services.md
+++ b/workspace/docs/src/content/docs/concepts/services.md
@@ -59,6 +59,7 @@ Use the service API from the framework adapter that owns your app.
 | --------- | --------------------------------------- | -------------------------------------------------------------------- |
 | React     | `Starbeam` provider plus `useService()` | The provider establishes the app lifetime.                           |
 | Preact    | `install(options)` plus `useService()`  | The installed adapter owns the app lifetime.                         |
+| Ember     | `setupService()` or `useService()`      | Pass the Ember owner so the service lifetime follows the app owner.  |
 | Vue       | `Starbeam` plugin plus `setupService()` | Install the plugin on the Vue app.                                   |
 | Svelte    | Not exposed yet                         | The Svelte adapter does not expose app-scoped service helpers today. |
 
@@ -107,7 +108,8 @@ Services do not replace resources. They choose a different owner for a resource.
 
 ## Next steps
 
-- [React](/frameworks/react/), [Preact](/frameworks/preact/), and
-  [Vue](/frameworks/vue/) show current service APIs.
+- [React](/frameworks/react/), [Preact](/frameworks/preact/),
+  [Ember](/frameworks/ember/), and [Vue](/frameworks/vue/) show current service
+  APIs.
 - [Svelte](/frameworks/svelte/) documents the current Svelte adapter scope.
 - [Reference](/reference/overview/) maps the package surface.

--- a/workspace/docs/src/content/docs/experiments/overview.md
+++ b/workspace/docs/src/content/docs/experiments/overview.md
@@ -51,7 +51,7 @@ for Starbeam-backed rendering without a framework adapter.
 Useful for exploring:
 
 - how Starbeam can drive text, attributes, elements, and fragments;
-- renderer ideas without React, Preact, Vue, or Svelte;
+- renderer ideas without React, Preact, Ember, Vue, or Svelte;
 - small implementation examples for people studying render integration.
 
 It is not intended to be a full app framework. App authors should normally use a

--- a/workspace/docs/src/content/docs/frameworks/ember.md
+++ b/workspace/docs/src/content/docs/frameworks/ember.md
@@ -213,7 +213,7 @@ It returns an Ember modifier. Pass `into` to publish the resource value into
 tracked component state. See [Element resources and DOM attachment](/concepts/element-resources/)
 for the framework-neutral concept.
 
-```gjs
+```gts
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { reactive } from "@starbeam/collections";

--- a/workspace/docs/src/content/docs/frameworks/ember.md
+++ b/workspace/docs/src/content/docs/frameworks/ember.md
@@ -1,0 +1,321 @@
+---
+title: Ember
+description: "The Ember adapter connects Starbeam reads, resources, services, and element-backed resources to Glimmer autotracking and Ember lifetimes."
+---
+
+Ember components are the output boundary for a Starbeam model. Your state can
+stay ordinary JavaScript: classes, getters, methods, maps, and resources.
+
+The current Ember bridge is explicit. Use `fromStarbeam()` to turn a Starbeam
+read into a Glimmer-autotracked value, then read its `current` getter from a
+template, getter, helper, or modifier. Ember templates do not subscribe to raw
+Starbeam reads on their own; the bridge dirties a Glimmer tag when Starbeam
+invalidates the read.
+
+The Ember adapter is experimental. It is available as a v2 Ember addon, but some
+API names may still be refined as the adapter settles.
+
+## Install
+
+Install the Ember adapter with the framework-neutral Starbeam packages you will
+use for root state and resources:
+
+```sh
+pnpm add @starbeam/ember @starbeam/universal @starbeam/collections
+```
+
+`ember-source` and `ember-modifier` are peer dependencies. Your Ember app usually
+provides them already. The adapter targets Ember 4.12+ with Embroider.
+
+## Keep the model ordinary JavaScript
+
+Start by marking the storage that changes. The rest of the model can be normal
+domain code.
+
+```ts
+import { reactive } from "@starbeam/collections";
+
+interface LineItem {
+  readonly id: string;
+  readonly name: string;
+  readonly priceCents: number;
+  readonly quantity: number;
+}
+
+interface ProductInput {
+  readonly name: string;
+  readonly priceCents: number;
+}
+
+export class Cart {
+  #items = reactive.Map<string, LineItem>();
+  #nextItemId = 1;
+
+  get items(): readonly LineItem[] {
+    return [...this.#items.values()];
+  }
+
+  get itemCount(): number {
+    return this.items.reduce((total, item) => total + item.quantity, 0);
+  }
+
+  get totalCents(): number {
+    return this.items.reduce(
+      (sum, item) => sum + item.priceCents * item.quantity,
+      0,
+    );
+  }
+
+  add(product: ProductInput): void {
+    const id = `item-${this.#nextItemId++}`;
+
+    this.#items.set(id, {
+      id,
+      name: product.name,
+      priceCents: product.priceCents,
+      quantity: 1,
+    });
+  }
+}
+```
+
+`#items` is the reactive root state. `itemCount`, `totalCents`, and `add()` are
+ordinary JavaScript above it.
+
+## Read the model from Ember
+
+Use `fromStarbeam()` at the Ember boundary. The callback reads ordinary
+Starbeam-backed JavaScript. The returned value has a readonly `current` getter
+that participates in Glimmer autotracking.
+
+```gjs
+import { on } from "@ember/modifier";
+import Component from "@glimmer/component";
+import { fromStarbeam } from "@starbeam/ember";
+
+import { Cart } from "./cart.js";
+
+const cart = new Cart();
+
+export default class CartSummary extends Component {
+  itemCount = fromStarbeam(() => cart.itemCount, { parent: this });
+  totalLabel = fromStarbeam(
+    () => `$${(cart.totalCents / 100).toFixed(2)}`,
+    { parent: this },
+  );
+
+  addTea = () => {
+    cart.add({ name: "Tea", priceCents: 500 });
+  };
+
+  <template>
+    <section>
+      <p>{{this.itemCount.current}} items</p>
+      <p>{{this.totalLabel.current}}</p>
+
+      <button type="button" {{on "click" this.addTea}}>Add tea</button>
+    </section>
+  </template>
+}
+```
+
+The `Cart` shape does not change for Ember. The adapter boundary is the
+`fromStarbeam(() => cart.totalCents)` call, not a special domain-object shape.
+
+Do not rely on a template read like `{{cart.totalCents}}` to subscribe to
+Starbeam state. It can compute a value during a render Ember already scheduled,
+but Starbeam invalidations will not schedule Ember work unless the read goes
+through the `fromStarbeam()` bridge.
+
+Pass `parent: this` from components, helpers, and modifiers so Ember destroys the
+bridge with the owner. Without a parent, call `disconnect()` yourself.
+
+## Add lifecycle with `setupResource()`
+
+Use a `Resource` when state needs setup, sync, or cleanup. `setupResource()` ties
+the resource lifetime to an Ember destroyable, usually the component using it.
+Use `fromStarbeam()` for template reads of the returned value.
+
+```gjs
+import Component from "@glimmer/component";
+import { reactive } from "@starbeam/collections";
+import { fromStarbeam, setupResource } from "@starbeam/ember";
+import { Resource } from "@starbeam/universal";
+
+const Clock = Resource(({ on }) => {
+  const clock = reactive.object({ now: new Date() });
+
+  on.sync(() => {
+    clock.now = new Date();
+
+    const timer = setInterval(() => {
+      clock.now = new Date();
+    }, 1000);
+
+    return () => clearInterval(timer);
+  });
+
+  return clock;
+});
+
+export default class ClockLabel extends Component {
+  clock = setupResource(Clock, this);
+  label = fromStarbeam(() => this.clock.now.toLocaleTimeString(), {
+    parent: this,
+  });
+
+  <template>
+    <time>{{this.label.current}}</time>
+  </template>
+}
+```
+
+The resource returns a domain-shaped value. Ember owns the lifetime: setup and
+sync happen under the component owner, and cleanup/finalize run when Ember
+destroys that owner. The template read still goes through `fromStarbeam()` so
+Glimmer can see the Starbeam invalidation.
+
+## App-scoped services
+
+Use `setupService()` for resource-backed state that should live with the Ember
+owner, not with one component. Pass an Ember owner so the service lifetime tracks
+the app.
+
+```gjs
+import { getOwner } from "@ember/owner";
+import Component from "@glimmer/component";
+import { reactive } from "@starbeam/collections";
+import { fromStarbeam, setupService } from "@starbeam/ember";
+import { Resource } from "@starbeam/universal";
+
+const SessionService = Resource(() => {
+  return reactive.object({ userName: "Guest" });
+});
+
+export default class CurrentUser extends Component {
+  session = setupService(SessionService, getOwner(this));
+  userName = fromStarbeam(() => this.session.userName, { parent: this });
+
+  <template>
+    <p>{{this.userName.current}}</p>
+  </template>
+}
+```
+
+Two components in the same owner that ask for the same service blueprint receive
+the same instance. Component teardown does not finalize the service; owner
+teardown does.
+
+## DOM element resources
+
+Use `elementResourceModifier()` when a resource needs a DOM element from Ember.
+It returns an Ember modifier. Pass `into` to publish the resource value into
+tracked component state. See [Element resources and DOM attachment](/concepts/element-resources/)
+for the framework-neutral concept.
+
+```gjs
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { reactive } from "@starbeam/collections";
+import { elementResourceModifier } from "@starbeam/ember/modifier";
+import { Resource } from "@starbeam/universal";
+
+interface Size {
+  readonly width: number;
+  readonly height: number;
+}
+
+function ElementSize(element: HTMLElement) {
+  return Resource(({ on }) => {
+    const size = reactive.object({ width: 0, height: 0 }) satisfies Size;
+
+    on.sync(() => {
+      const observer = new ResizeObserver(([entry]) => {
+        if (!entry) return;
+
+        size.width = entry.contentRect.width;
+        size.height = entry.contentRect.height;
+      });
+
+      observer.observe(element);
+
+      return () => observer.disconnect();
+    });
+
+    return size;
+  });
+}
+
+export default class SizedBox extends Component {
+  @tracked size: Size | null = null;
+
+  measure = elementResourceModifier(ElementSize, {
+    into: (value) => {
+      this.size = value;
+    },
+  });
+
+  get label(): string {
+    return this.size
+      ? `${Math.round(this.size.width)} × ${Math.round(this.size.height)}`
+      : "Measuring…";
+  }
+
+  <template>
+    <section {{this.measure}}>{{this.label}}</section>
+  </template>
+}
+```
+
+The element comes from Ember. The resource work still lives in Starbeam. The
+modifier owns the element lifetime, and `into` is the handoff from the modifier
+back into Ember render data.
+
+## Lower-level APIs
+
+`resource()`, `useResource()`, `getResource()`, and `setupReactiveResource()` are
+public resource helpers for Ember helper-manager and JavaScript integration
+cases. Start with `setupResource()` when a component owns the resource.
+
+`elementResource()` is an experimental convenience handle that pairs a modifier
+with an autotracked `current` value:
+
+```gjs
+import { elementResource } from "@starbeam/ember/modifier";
+
+export default class SizedBox extends Component {
+  size = elementResource(ElementSize);
+
+  <template>
+    <section {{this.size.modifier}}>
+      {{#if this.size.current}}
+        {{this.size.current.width}} × {{this.size.current.height}}
+      {{else}}
+        Measuring…
+      {{/if}}
+    </section>
+  </template>
+}
+```
+
+The package also exports the public element-resource types:
+`ElementResourceBlueprint`, `ElementResourceHandle`, `ElementResourceModifier`,
+`ElementResourceModifierOptions`, and `ElementResourceSink`.
+
+## Notes on the v2 addon
+
+The package is shipped as a v2 Ember addon. Embroider resolves the internal
+`@glimmer/*` imports to the bundled copies from `ember-source`. Do not add
+separate `@glimmer/*` runtime packages to your app to fix resolution; duplicate
+validator instances break the Glimmer tag bridge.
+
+## Next steps
+
+- [Core concepts](/concepts/overview/): the framework-neutral Starbeam model.
+- [Services and app lifetime](/concepts/services/): app-scoped resource-backed
+  state.
+- [Element resources and DOM attachment](/concepts/element-resources/): resources
+  attached to framework-supplied elements.
+- [Framework overview](/frameworks/overview/): how the adapter boundary changes
+  by framework.
+- [Reference](/reference/overview/): the public package surface at a glance.

--- a/workspace/docs/src/content/docs/frameworks/overview.md
+++ b/workspace/docs/src/content/docs/frameworks/overview.md
@@ -1,14 +1,14 @@
 ---
 title: Framework guides
-description: "Starbeam's framework adapters connect the same reactive model to React, Preact, Vue, and Svelte as each adapter matures."
+description: "Starbeam's framework adapters connect the same reactive model to React, Preact, Ember, Vue, and Svelte as each adapter matures."
 ---
 
 Starbeam's state model is framework-neutral. Framework adapters make it feel
 native by connecting Starbeam's reactive model to each framework's rendering and
 lifecycle rules.
 
-The goal is not one framework with incidental ports. React, Preact, Vue, and
-Svelte are public docs targets, with adapter coverage maturing at different
+The goal is not one framework with incidental ports. React, Preact, Ember, Vue,
+and Svelte are public docs targets, with adapter coverage maturing at different
 speeds.
 
 ## Same model, native edges
@@ -24,7 +24,9 @@ The core model stays the same in every framework:
 The framework-specific layer should feel small. It is the bridge between
 Starbeam's model and the framework's rendering and lifecycle rules. Your domain
 model can still expose normal getters, methods, and objects; the adapter is the
-place that connects those reads and resources to React, Preact, Vue, or Svelte.
+place that connects those reads and resources to each framework. Ember does that
+through a Glimmer tag bridge, so template-facing Starbeam reads go through
+`fromStarbeam()`.
 
 Need the package list first? Start with [Install Starbeam](/start/install/).
 
@@ -34,6 +36,8 @@ Need the package list first? Start with [Install Starbeam](/start/install/).
   services, and element resources.
 - [**Preact**](/frameworks/preact/): adapter installation, reactive reads,
   resources, services, and element resources.
+- [**Ember**](/frameworks/ember/): experimental v2 addon with `fromStarbeam()`
+  read bridging, component resources, services, and element-resource modifiers.
 - [**Vue**](/frameworks/vue/): setup helpers and directives for reactive state,
   resources, services, and element resources.
 - [**Svelte**](/frameworks/svelte/): current Svelte 5 slice with experimental

--- a/workspace/docs/src/content/docs/library-authors/overview.md
+++ b/workspace/docs/src/content/docs/library-authors/overview.md
@@ -4,8 +4,8 @@ description: "Write reusable Starbeam abstractions that stay framework-neutral a
 ---
 
 This guide is for authors of reusable Starbeam-backed libraries: models,
-resources, and utilities that app authors can use from React, Preact, Vue,
-Svelte, or framework-neutral code.
+resources, and utilities that app authors can use from React, Preact, Ember,
+Vue, Svelte, or framework-neutral code.
 
 The goal is the same as app code: mark root state, then expose ordinary
 JavaScript above it. Your library should give consumers domain-shaped values,

--- a/workspace/docs/src/content/docs/reference/framework-adapters.md
+++ b/workspace/docs/src/content/docs/reference/framework-adapters.md
@@ -1,6 +1,6 @@
 ---
 title: Framework adapters
-description: "Reference for Starbeam's React, Preact, Vue, and Svelte adapter surfaces."
+description: "Reference for Starbeam's React, Preact, Ember, Vue, and Svelte adapter surfaces."
 ---
 
 Framework adapters connect Starbeam reads, resources, services, and element
@@ -10,12 +10,13 @@ Use the guide for your framework for full examples. This page is a quick API map
 
 ## Adapter matrix
 
-| Framework | Read boundary                                 | Resources                         | Services                                         | Element resources                               |
-| --------- | --------------------------------------------- | --------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
-| React     | `useReactive(compute, bridge?)`               | `useResource(blueprint, bridge?)` | `Starbeam` plus `useService(blueprint)`          | `useElementResource(build, bridge?)`            |
-| Preact    | `install(options)` tracks render reads        | `useResource(blueprint, deps?)`   | `useService(blueprint)`                          | `useElementResource(build, bridge?)`            |
-| Vue       | `useReactive()` or `setupReactive(blueprint)` | `setupResource(blueprint)`        | `Starbeam` plugin plus `setupService(blueprint)` | `elementResourceDirective(blueprint, options?)` |
-| Svelte    | `fromStarbeam(compute)`                       | Not exposed yet                   | Not exposed yet                                  | `elementResource(blueprint)`                    |
+| Framework | Read boundary                                 | Resources                          | Services                                         | Element resources                               |
+| --------- | --------------------------------------------- | ---------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| React     | `useReactive(compute, bridge?)`               | `useResource(blueprint, bridge?)`  | `Starbeam` plus `useService(blueprint)`          | `useElementResource(build, bridge?)`            |
+| Preact    | `install(options)` tracks render reads        | `useResource(blueprint, deps?)`    | `useService(blueprint)`                          | `useElementResource(build, bridge?)`            |
+| Ember     | `fromStarbeam(compute, options?)`             | `setupResource(blueprint, parent)` | `setupService(blueprint, owner?)`                | `elementResourceModifier(blueprint, options?)`  |
+| Vue       | `useReactive()` or `setupReactive(blueprint)` | `setupResource(blueprint)`         | `Starbeam` plugin plus `setupService(blueprint)` | `elementResourceDirective(blueprint, options?)` |
+| Svelte    | `fromStarbeam(compute)`                       | Not exposed yet                    | Not exposed yet                                  | `elementResource(blueprint)`                    |
 
 ## React
 
@@ -46,6 +47,28 @@ Package: `@starbeam/preact`
 | `useReactive` / `setup*` / `createCell` | Lower-level APIs, not the main Preact path.                |
 
 After `install(options)`, direct render reads are the main Preact output boundary.
+
+## Ember
+
+Package: `@starbeam/ember`
+
+The Ember adapter is experimental and ships as a v2 Ember addon. Its read bridge
+uses Glimmer tags: Ember templates, `@cached` getters, helpers, and modifiers see
+Starbeam invalidations when the read goes through `fromStarbeam()`.
+
+| API                                                       | Use for                                                          |
+| --------------------------------------------------------- | ---------------------------------------------------------------- |
+| `fromStarbeam(compute, options?)`                         | Bridge a Starbeam read into Glimmer autotracking.                |
+| `setupResource(blueprint, parent)`                        | Attach a resource to an Ember destroyable.                       |
+| `setupReactiveResource(blueprint, parent)`                | Lower-level resource setup with an autotracked `current` getter. |
+| `setupService(blueprint, owner?)` / `useService()`        | Resolve owner-scoped service state.                              |
+| `resource(blueprint)` / `useResource()` / `getResource()` | Lower-level helper-manager resource integration.                 |
+| `elementResourceModifier(blueprint, options?)`            | Attach element-backed work to an Ember modifier.                 |
+| `elementResource(blueprint)`                              | Experimental modifier plus autotracked `current` handle.         |
+
+Use `fromStarbeam()` for template-facing reads. A raw template read of a
+Starbeam-backed getter can compute during a render Ember already scheduled, but
+it does not subscribe to Starbeam invalidations by itself.
 
 ## Vue
 
@@ -80,6 +103,7 @@ Deeper integration is tracked in
 
 - [React guide](/frameworks/react/)
 - [Preact guide](/frameworks/preact/)
+- [Ember guide](/frameworks/ember/)
 - [Vue guide](/frameworks/vue/)
 - [Svelte guide](/frameworks/svelte/)
 - [Resources](/reference/resources/)

--- a/workspace/docs/src/content/docs/reference/overview.md
+++ b/workspace/docs/src/content/docs/reference/overview.md
@@ -18,10 +18,12 @@ If you are choosing what to install first, start with
 - `@starbeam/universal`: framework-neutral lifecycle APIs such as `Resource`,
   plus compatibility exports for lower-level primitives. See
   [Universal APIs](/reference/universal/).
-- Framework adapters: `@starbeam/react`, `@starbeam/preact`, `@starbeam/vue`, and
-  `@starbeam/svelte` connect Starbeam to framework rendering and lifecycle. The
-  Svelte adapter is a current experimental slice with reads and element resources
-  but no component-resource or service helpers yet. See
+- Framework adapters: `@starbeam/react`, `@starbeam/preact`, `@starbeam/ember`,
+  `@starbeam/vue`, and `@starbeam/svelte` connect Starbeam to framework
+  rendering and lifecycle. The Ember adapter is an experimental v2 addon whose
+  read bridge uses Glimmer tags. The Svelte adapter is a current experimental
+  slice with reads and element resources but no component-resource or service
+  helpers yet. See
   [Framework adapters](/reference/framework-adapters/).
 
 ## Lifecycle and composition packages

--- a/workspace/docs/src/content/docs/reference/services.md
+++ b/workspace/docs/src/content/docs/reference/services.md
@@ -11,12 +11,13 @@ App authors usually use service helpers from their framework adapter. The direct
 
 ## App-facing adapter APIs
 
-| Framework | API                                              | Notes                                                     |
-| --------- | ------------------------------------------------ | --------------------------------------------------------- |
-| React     | `Starbeam` provider plus `useService(blueprint)` | The provider establishes the app lifetime.                |
-| Preact    | `install(options)` plus `useService(blueprint)`  | The installed adapter owns the app lifetime.              |
-| Vue       | `Starbeam` plugin plus `setupService(blueprint)` | Install the plugin on the Vue app.                        |
-| Svelte    | Not exposed yet                                  | The Svelte adapter does not expose service helpers today. |
+| Framework | API                                                                  | Notes                                                     |
+| --------- | -------------------------------------------------------------------- | --------------------------------------------------------- |
+| React     | `Starbeam` provider plus `useService(blueprint)`                     | The provider establishes the app lifetime.                |
+| Preact    | `install(options)` plus `useService(blueprint)`                      | The installed adapter owns the app lifetime.              |
+| Ember     | `setupService(blueprint, owner?)` / `useService(context, blueprint)` | Pass an Ember owner for app-scoped service lifetime.      |
+| Vue       | `Starbeam` plugin plus `setupService(blueprint)`                     | Install the plugin on the Vue app.                        |
+| Svelte    | Not exposed yet                                                      | The Svelte adapter does not expose service helpers today. |
 
 ## Direct package
 

--- a/workspace/docs/src/content/docs/start/install.md
+++ b/workspace/docs/src/content/docs/start/install.md
@@ -169,7 +169,8 @@ adapter.
 usually use framework adapter helpers instead:
 
 - React and Preact: `useService()`;
-- Ember: `setupService()` or `useService()` with the Ember owner;
+- Ember: `setupService(blueprint, owner?)` with an Ember owner, or
+  `useService(this, Blueprint)` from an Ember context;
 - Vue: `setupService()`; install the Starbeam plugin when you want to establish
   app ownership explicitly;
 - Svelte: service helpers are not exposed yet.

--- a/workspace/docs/src/content/docs/start/install.md
+++ b/workspace/docs/src/content/docs/start/install.md
@@ -13,6 +13,7 @@ Install the packages you import directly. Most apps need one framework adapter,
 | A framework-neutral model | `@starbeam/universal @starbeam/collections`                  | `reactive` collections, domain objects, and `Resource`                                 |
 | A React app               | `@starbeam/react @starbeam/universal @starbeam/collections`  | `useReactive()`, `useResource()`, `useService()`, `useElementResource()`               |
 | A Preact app              | `@starbeam/preact @starbeam/universal @starbeam/collections` | `install(options)`, direct render reads, resource/service hooks                        |
+| An Ember app              | `@starbeam/ember @starbeam/universal @starbeam/collections`  | experimental v2 addon: `fromStarbeam()`, resources, services, element modifiers        |
 | A Vue app                 | `@starbeam/vue @starbeam/universal @starbeam/collections`    | `useReactive()`, `setupResource()`, `setupService()`, element-resource directives      |
 | A Svelte app              | `@starbeam/svelte @starbeam/universal @starbeam/collections` | current Svelte 5 slice: experimental `fromStarbeam()` and element-resource attachments |
 | A reusable library        | `@starbeam/universal @starbeam/collections`                  | framework-neutral state and domain-shaped APIs                                         |
@@ -82,6 +83,25 @@ import {
 Install Starbeam into Preact `options`, then ordinary render reads are tracked by
 the adapter: [Preact](/frameworks/preact/).
 
+### Ember
+
+```sh
+pnpm add @starbeam/ember @starbeam/universal @starbeam/collections
+```
+
+```ts
+import { fromStarbeam, setupResource, setupService } from "@starbeam/ember";
+import {
+  elementResource,
+  elementResourceModifier,
+} from "@starbeam/ember/modifier";
+```
+
+Ember support is an experimental v2 addon. Use `fromStarbeam()` to bridge
+Starbeam reads into Glimmer autotracking; raw Starbeam reads in templates do not
+subscribe on their own. Component resources, owner-scoped services, and
+element-resource modifiers are available today. See [Ember](/frameworks/ember/).
+
 ### Vue
 
 ```sh
@@ -149,6 +169,7 @@ adapter.
 usually use framework adapter helpers instead:
 
 - React and Preact: `useService()`;
+- Ember: `setupService()` or `useService()` with the Ember owner;
 - Vue: `setupService()`; install the Starbeam plugin when you want to establish
   app ownership explicitly;
 - Svelte: service helpers are not exposed yet.

--- a/workspace/docs/src/content/docs/start/introduction.md
+++ b/workspace/docs/src/content/docs/start/introduction.md
@@ -183,4 +183,4 @@ as JavaScript.
 - Read [Resources and lifecycle](/concepts/lifecycle/) when work needs setup,
   sync, or cleanup.
 - Read [Framework guides](/frameworks/overview/) to see how adapters connect this
-  model to React, Preact, Vue, and Svelte.
+  model to React, Preact, Ember, Vue, and Svelte.

--- a/workspace/docs/src/pages/index.astro
+++ b/workspace/docs/src/pages/index.astro
@@ -155,6 +155,15 @@ import "../styles/tokens.css";
                 hooks cover resources, services, and element resources.
               </p>
             </a>
+            <a class="adapter-card" href="/frameworks/ember/">
+              <span aria-hidden="true">Ember</span>
+              <h3>Ember</h3>
+              <p>
+                The experimental v2 addon bridges Starbeam reads through
+                Glimmer tags and connects resources, services, and element
+                resources to Ember lifetimes.
+              </p>
+            </a>
             <a class="adapter-card" href="/frameworks/vue/">
               <span aria-hidden="true">Vue</span>
               <h3>Vue</h3>
@@ -212,8 +221,8 @@ import "../styles/tokens.css";
             <a class="route-card" href="/frameworks/overview/">
               <h3>Frameworks</h3>
               <p>
-                Connect the same Starbeam model to React, Preact, Vue, or
-                Svelte.
+                Connect the same Starbeam model to React, Preact, Ember, Vue,
+                or Svelte.
               </p>
             </a>
             <a class="route-card" href="/reference/overview/">
@@ -362,7 +371,7 @@ import "../styles/tokens.css";
   }
 
   .adapter-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 
   .route-grid {


### PR DESCRIPTION
## Why

The Ember adapter seams landed in #286, which unblocks wiring Ember into the public docs matrix. Ember should now appear beside the other framework guides, with clear experimental v2 addon status language.

## What changed

- Adds an Ember framework guide covering:
  - ordinary JavaScript models;
  - `fromStarbeam()` as the Glimmer autotracking bridge;
  - `setupResource()` for component-owned resources;
  - `setupService()` / `useService()` for owner-scoped services;
  - `elementResourceModifier()` for DOM element resources.
- Adds Ember to the docs sidebar, homepage framework cards, framework overview, install chooser, reference pages, concept matrices, and root README.
- Marks the Ember documentation integration PER as done in the documentation dashboard.

## Notes for reviewers

The guide keeps the adapter status explicit: Ember is currently an experimental v2 addon, and API names may still be refined. It also calls out that raw Starbeam reads in Ember templates do not subscribe on their own; template-facing reads go through `fromStarbeam()`.
