### PR TITLE
feat(ember): add reactive getter decorator

### DIFF
--- a/packages/ember/ember-test-app/tests/integration/reactive-decorator-test.gts
+++ b/packages/ember/ember-test-app/tests/integration/reactive-decorator-test.gts
@@ -1,0 +1,310 @@
+import { on } from "@ember/modifier";
+import { click, render, settled } from "@ember/test-helpers";
+import { cached } from "@glimmer/tracking";
+import { tracked } from "@glimmer/tracking";
+import Component from "@glimmer/component";
+import { reactive as collections } from "@starbeam/collections";
+import { reactive } from "@starbeam/ember/decorators";
+import { Cell } from "@starbeam/reactive";
+import { setupRenderingTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+import { RecordedEvents } from "#test-helpers/recorded-events";
+
+module("@reactive | rendering", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("updates a template read when Starbeam state changes", async function (assert) {
+    const count = Cell(1);
+
+    class Counter extends Component {
+      @reactive
+      get doubled(): number {
+        return count.current * 2;
+      }
+
+      increment = () => {
+        count.current += 1;
+      };
+
+      <template>
+        <p data-test-doubled>{{this.doubled}}</p>
+        <button type="button" data-test-increment {{on "click" this.increment}}>
+          increment
+        </button>
+      </template>
+    }
+
+    await render(<template><Counter /></template>);
+    assert.dom("[data-test-doubled]").hasText("2");
+
+    await click("[data-test-increment]");
+    assert.dom("[data-test-doubled]").hasText("4");
+
+    count.current = 10;
+    await settled();
+    assert.dom("[data-test-doubled]").hasText("20");
+  });
+
+  test("reads a domain-shaped getter over private Starbeam storage", async function (assert) {
+    interface LineItem {
+      readonly quantity: number;
+      readonly unitCents: number;
+    }
+
+    class Cart {
+      readonly #items = collections.Map<string, LineItem>();
+
+      get totalCents(): number {
+        let total = 0;
+        for (const item of this.#items.values()) {
+          total += item.quantity * item.unitCents;
+        }
+        return total;
+      }
+
+      add(id: string, item: LineItem): void {
+        this.#items.set(id, item);
+      }
+    }
+
+    const cart = new Cart();
+    cart.add("coffee", { quantity: 1, unitCents: 300 });
+
+    class CartTotal extends Component {
+      @reactive
+      get total(): number {
+        return cart.totalCents;
+      }
+
+      addBagel = () => {
+        cart.add("bagel", { quantity: 2, unitCents: 250 });
+      };
+
+      <template>
+        <p data-test-total>{{this.total}}</p>
+        <button type="button" data-test-add {{on "click" this.addBagel}}>
+          add bagel
+        </button>
+      </template>
+    }
+
+    await render(<template><CartTotal /></template>);
+    assert.dom("[data-test-total]").hasText("300");
+
+    await click("[data-test-add]");
+    assert.dom("[data-test-total]").hasText("800");
+  });
+
+  test("updates when @tracked state used by the Starbeam compute changes", async function (assert) {
+    const count = Cell(2);
+
+    class Mixed extends Component {
+      @tracked multiplier = 2;
+
+      @reactive
+      get scaled(): number {
+        return count.current * this.multiplier;
+      }
+
+      incrementCount = () => {
+        count.current += 1;
+      };
+
+      triple = () => {
+        this.multiplier = 3;
+      };
+
+      <template>
+        <p data-test-scaled>{{this.scaled}}</p>
+        <button type="button" data-test-count {{on "click" this.incrementCount}}>
+          increment count
+        </button>
+        <button type="button" data-test-triple {{on "click" this.triple}}>
+          triple
+        </button>
+      </template>
+    }
+
+    await render(<template><Mixed /></template>);
+    assert.dom("[data-test-scaled]").hasText("4", "initial: count=2 * mult=2");
+
+    await click("[data-test-triple]");
+    assert
+      .dom("[data-test-scaled]")
+      .hasText("6", "rerenders when the @tracked field changes");
+
+    await click("[data-test-count]");
+    assert
+      .dom("[data-test-scaled]")
+      .hasText("9", "rerenders when the starbeam cell changes");
+  });
+
+  test("refreshes dynamic Starbeam dependencies", async function (assert) {
+    const left = Cell(1);
+    const right = Cell(10);
+
+    class Picker extends Component {
+      @tracked side: "left" | "right" = "left";
+
+      @reactive
+      get selected(): string {
+        return this.side === "left"
+          ? `left=${left.current}`
+          : `right=${right.current}`;
+      }
+
+      chooseRight = () => {
+        this.side = "right";
+      };
+      bumpLeft = () => {
+        left.current += 1;
+      };
+      bumpRight = () => {
+        right.current += 1;
+      };
+
+      <template>
+        <p data-test-selected>{{this.selected}}</p>
+        <button type="button" data-test-right {{on "click" this.chooseRight}}>
+          choose right
+        </button>
+        <button type="button" data-test-bump-left {{on "click" this.bumpLeft}}>
+          bump left
+        </button>
+        <button type="button" data-test-bump-right {{on "click" this.bumpRight}}>
+          bump right
+        </button>
+      </template>
+    }
+
+    await render(<template><Picker /></template>);
+    assert.dom("[data-test-selected]").hasText("left=1");
+
+    await click("[data-test-right]");
+    assert.dom("[data-test-selected]").hasText("right=10");
+
+    await click("[data-test-bump-left]");
+    assert.dom("[data-test-selected]").hasText("right=10");
+
+    await click("[data-test-bump-right]");
+    assert.dom("[data-test-selected]").hasText("right=11");
+  });
+
+  test("can gain its first Starbeam dependency after initial render", async function (assert) {
+    const count = Cell(1);
+
+    class Toggle extends Component {
+      @tracked enabled = false;
+
+      @reactive
+      get value(): string {
+        return this.enabled ? `on=${count.current}` : "off";
+      }
+
+      enable = () => {
+        this.enabled = true;
+      };
+      increment = () => {
+        count.current += 1;
+      };
+
+      <template>
+        <p data-test-value>{{this.value}}</p>
+        <button type="button" data-test-enable {{on "click" this.enable}}>
+          enable
+        </button>
+        <button type="button" data-test-increment {{on "click" this.increment}}>
+          increment
+        </button>
+      </template>
+    }
+
+    await render(<template><Toggle /></template>);
+    assert.dom("[data-test-value]").hasText("off");
+
+    await click("[data-test-enable]");
+    assert.dom("[data-test-value]").hasText("on=1");
+
+    await click("[data-test-increment]");
+    assert.dom("[data-test-value]").hasText("on=2");
+  });
+
+  test("stops recomputing after the component is torn down", async function (assert) {
+    const count = Cell(1);
+    const events = new RecordedEvents();
+
+    class Recorder extends Component {
+      @reactive
+      get value(): number {
+        events.record("compute");
+        return count.current;
+      }
+
+      <template>
+        <p data-test-value>{{this.value}}</p>
+      </template>
+    }
+
+    class Toggle extends Component {
+      @tracked visible = true;
+      hide = () => {
+        this.visible = false;
+      };
+
+      <template>
+        {{#if this.visible}}<Recorder />{{/if}}
+        <button type="button" data-test-hide {{on "click" this.hide}}>hide</button>
+      </template>
+    }
+
+    await render(<template><Toggle /></template>);
+    assert.dom("[data-test-value]").hasText("1");
+    events.expect(assert, ["compute"], "computed once on first render");
+
+    count.current = 2;
+    await settled();
+    assert.dom("[data-test-value]").hasText("2");
+    events.expect(assert, ["compute"], "recomputes when the cell changes");
+
+    await click("[data-test-hide]");
+    assert.dom("[data-test-value]").doesNotExist();
+
+    count.current = 3;
+    await settled();
+    events.expect(assert, [], "no compute after unmount");
+  });
+
+  test("updates a @cached getter that reads through the decorator", async function (assert) {
+    const count = Cell(2);
+
+    class Derived extends Component {
+      @reactive
+      get value(): number {
+        return count.current;
+      }
+
+      @cached
+      get doubled(): number {
+        return this.value * 2;
+      }
+
+      increment = () => {
+        count.current += 1;
+      };
+
+      <template>
+        <p data-test-doubled>{{this.doubled}}</p>
+        <button type="button" data-test-increment {{on "click" this.increment}}>
+          increment
+        </button>
+      </template>
+    }
+
+    await render(<template><Derived /></template>);
+    assert.dom("[data-test-doubled]").hasText("4");
+
+    await click("[data-test-increment]");
+    assert.dom("[data-test-doubled]").hasText("6");
+  });
+});

--- a/packages/ember/ember/README.md
+++ b/packages/ember/ember/README.md
@@ -19,6 +19,8 @@ your Ember app.
 
 ## Public APIs
 
+- `@reactive`: getter decorator for template-facing Starbeam reads (subpath:
+  `@starbeam/ember/decorators`).
 - `fromStarbeam(compute, options?)`: bridge a Starbeam compute into Glimmer's
   autotracking system.
 - `setupResource(blueprint, parent)`: create a Starbeam resource scoped to a
@@ -33,21 +35,27 @@ your Ember app.
 
 ```gjs
 import Component from "@glimmer/component";
-import { fromStarbeam } from "@starbeam/ember";
+import { reactive } from "@starbeam/ember/decorators";
 import { cart } from "./cart";
 
 export default class CartTotal extends Component {
-  total = fromStarbeam(() => cart.totalCents, { parent: this });
+  @reactive
+  get total() {
+    return cart.totalCents;
+  }
 
   <template>
-    <p>{{this.total.current}}</p>
+    <p>{{this.total}}</p>
   </template>
 }
 ```
 
-`fromStarbeam()` returns a read-only `current` getter. Keep Starbeam cells and
-collections private inside your domain objects; expose domain-shaped getters and
-wrap those reads at the Ember boundary.
+Keep Starbeam cells and collections private inside your domain objects; expose
+domain-shaped getters and wrap those reads at the Ember boundary. `@reactive`
+uses `fromStarbeam()` internally and ties the bridge lifetime to the component.
+
+`fromStarbeam()` is also available directly when you need an explicit bridge. It
+returns a read-only `current` getter.
 
 Pass `options.parent` to tie the subscription to a destroyable (component,
 modifier, helper, owner). Without `parent`, the caller must invoke

--- a/packages/ember/ember/decorators.ts
+++ b/packages/ember/ember/decorators.ts
@@ -1,0 +1,1 @@
+export { reactive } from "./src/decorators.js";

--- a/packages/ember/ember/package.json
+++ b/packages/ember/ember/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./index.ts",
     "./addon-main.js": "./addon-main.cjs",
+    "./decorators": "./decorators.ts",
     "./modifier": "./modifier.ts"
   },
   "publishConfig": {
@@ -17,6 +18,11 @@
         "default": "./dist/index.js"
       },
       "./addon-main.js": "./addon-main.cjs",
+      "./decorators": {
+        "types": "./dist/decorators.d.ts",
+        "import": "./dist/decorators.js",
+        "default": "./dist/decorators.js"
+      },
       "./modifier": {
         "types": "./dist/modifier.d.ts",
         "import": "./dist/modifier.js",
@@ -28,6 +34,7 @@
   },
   "starbeam": {
     "entry": {
+      "decorators": "./decorators.ts",
       "index": "./index.ts",
       "modifier": "./modifier.ts"
     },

--- a/packages/ember/ember/src/decorators.ts
+++ b/packages/ember/ember/src/decorators.ts
@@ -1,0 +1,57 @@
+import type { StarbeamValue } from "./reactive.js";
+import { fromStarbeam } from "./reactive.js";
+
+type Getter<T> = () => T;
+
+const REACTIVE_VALUES = new WeakMap<
+  object,
+  Map<PropertyKey, StarbeamValue<unknown>>
+>();
+
+function getValueFor<T>(
+  instance: object,
+  key: PropertyKey,
+  getter: Getter<T>,
+): StarbeamValue<T> {
+  let values = REACTIVE_VALUES.get(instance);
+
+  if (!values) {
+    values = new Map();
+    REACTIVE_VALUES.set(instance, values);
+  }
+
+  let value = values.get(key) as StarbeamValue<T> | undefined;
+
+  if (!value) {
+    value = fromStarbeam(() => getter.call(instance), { parent: instance });
+    values.set(key, value);
+  }
+
+  return value;
+}
+
+/**
+ * Bridge a getter that reads Starbeam state into Ember's autotracking system.
+ *
+ * The decorated getter returns the computed value directly. Ember templates,
+ * `@cached` getters, helpers, and modifiers can read it as a normal Glimmer
+ * value while Starbeam invalidations dirty the internal Glimmer tag.
+ */
+export function reactive<T>(
+  _target: object,
+  key: string | symbol,
+  descriptor: TypedPropertyDescriptor<T>,
+): TypedPropertyDescriptor<T> {
+  const getter = descriptor.get;
+
+  if (!getter) {
+    throw new Error("@reactive can only decorate getters");
+  }
+
+  return {
+    ...descriptor,
+    get(this: object): T {
+      return getValueFor(this, key, getter).current;
+    },
+  };
+}

--- a/packages/ember/ember/tsconfig.json
+++ b/packages/ember/ember/tsconfig.json
@@ -8,6 +8,12 @@
     "declarationMap": true,
     "emitDeclarationOnly": true
   },
-  "include": ["env.d.ts", "index.ts", "modifier.ts", "src/**/*"],
+  "include": [
+    "env.d.ts",
+    "index.ts",
+    "decorators.ts",
+    "modifier.ts",
+    "src/**/*"
+  ],
   "exclude": ["dist/**/*"]
 }

--- a/workspace/dev-compile/src/rollup/plugins/typescript.ts
+++ b/workspace/dev-compile/src/rollup/plugins/typescript.ts
@@ -22,6 +22,7 @@ export const PUBLIC_OBJECT_PROPERTY_KEYS = [
   "dependencies",
   "description",
   "directive",
+  "dirty",
   "done",
   "eq",
   "finalize",


### PR DESCRIPTION
## Why

The Ember adapter seam landed with the lower-level `fromStarbeam()` bridge, but the resulting template-facing examples were noisy for Ember users: components had to expose `.current` and manually set up a bridge for values that should read like normal Ember getters.

This adds the first Ember-native decorator layer so Starbeam reads can look idiomatic in components while preserving the bridge semantics underneath.

## What changed

- Adds `@reactive` as a getter decorator exported from `@starbeam/ember/decorators`.
- Caches one `fromStarbeam()` bridge per instance/property and ties its lifetime to the decorated instance.
- Adds rendering coverage for Starbeam updates, dynamic dependencies, first dependency acquisition, teardown behavior, and `@cached` interop.
- Updates the Ember README to show the decorator-first API.
- Reserves `dirty` from production property mangling so `TrackedTag.dirty()` remains callable in generated artifacts.

## Reviewer notes

`@reactive` deliberately supports legacy getter decorators only. Auto-accessor decorators are not part of this PR because the current Ember/GTS decorator transform does not support that path.

## User-facing changes

Ember users can now write template-facing Starbeam reads as decorated getters:

```gts
import { reactive } from "@starbeam/ember/decorators";

export default class CartTotal extends Component {
  @reactive
  get total() {
    return cart.totalCents;
  }

  <template>
    <p>{{this.total}}</p>
  </template>
}
```
