### PR TITLE
feat(ember): mirror Starbeam tags into Glimmer

### DIFF
--- a/packages/ember/ember-test-app/tests/integration/element-resource-test.gts
+++ b/packages/ember/ember-test-app/tests/integration/element-resource-test.gts
@@ -135,7 +135,11 @@ module("elementResource | rendering", function (hooks) {
     marker.mark();
     await settled();
     assert.dom("[data-test-size]").hasText("width=101");
-    events.expect(assert, ["size:sync"], "resync after marker invalidation");
+    events.expect(
+      assert,
+      ["size:sync", "size:finalize", "size:attached", "size:sync"],
+      "marker invalidation rerenders the modifier, then the new resource syncs",
+    );
   });
 
   test("modifier positional args trigger a fresh element resource", async function (assert) {
@@ -367,7 +371,12 @@ module("elementResource | rendering", function (hooks) {
     marker.mark();
     await settled();
     assert.dom("[data-test-size]").hasText("width=101");
-    events.expect(assert, ["size:sync"]);
+    events.expect(assert, [
+      "size:sync",
+      "size:finalize",
+      "size:attached",
+      "size:sync",
+    ]);
   });
 
   test("elementResource() clears .current when the element is removed", async function (assert) {

--- a/packages/ember/ember-test-app/tests/integration/native-tag-mirror-test.gts
+++ b/packages/ember/ember-test-app/tests/integration/native-tag-mirror-test.gts
@@ -1,0 +1,300 @@
+import { on } from "@ember/modifier";
+import { click, render, settled } from "@ember/test-helpers";
+import { cached, tracked } from "@glimmer/tracking";
+import Component from "@glimmer/component";
+import { reactive } from "@starbeam/collections";
+import { setupResource } from "@starbeam/ember";
+import { Cell, Formula } from "@starbeam/reactive";
+import { Resource } from "@starbeam/resource";
+import { setupRenderingTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Starbeam native tag mirror | rendering", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("plain getters rerender when Starbeam cells change", async function (assert) {
+    const count = Cell(1);
+
+    class Counter extends Component {
+      get doubled(): number {
+        return count.current * 2;
+      }
+
+      increment = () => {
+        count.current += 1;
+      };
+
+      <template>
+        <p data-test-doubled>{{this.doubled}}</p>
+        <button type="button" data-test-increment {{on "click" this.increment}}>
+          increment
+        </button>
+      </template>
+    }
+
+    await render(<template><Counter /></template>);
+    assert.dom("[data-test-doubled]").hasText("2");
+
+    await click("[data-test-increment]");
+    assert.dom("[data-test-doubled]").hasText("4");
+
+    count.current = 10;
+    await settled();
+    assert.dom("[data-test-doubled]").hasText("20");
+  });
+
+  test("plain getters can read through domain objects", async function (assert) {
+    interface LineItem {
+      readonly quantity: number;
+      readonly unitCents: number;
+    }
+
+    class Cart {
+      readonly #items = reactive.Map<string, LineItem>();
+
+      get totalCents(): number {
+        let total = 0;
+
+        for (const item of this.#items.values()) {
+          total += item.quantity * item.unitCents;
+        }
+
+        return total;
+      }
+
+      add(id: string, item: LineItem): void {
+        this.#items.set(id, item);
+      }
+    }
+
+    const cart = new Cart();
+    cart.add("coffee", { quantity: 1, unitCents: 300 });
+
+    class CartTotal extends Component {
+      get total(): number {
+        return cart.totalCents;
+      }
+
+      addBagel = () => {
+        cart.add("bagel", { quantity: 2, unitCents: 250 });
+      };
+
+      <template>
+        <p data-test-total>{{this.total}}</p>
+        <button type="button" data-test-add {{on "click" this.addBagel}}>
+          add bagel
+        </button>
+      </template>
+    }
+
+    await render(<template><CartTotal /></template>);
+    assert.dom("[data-test-total]").hasText("300");
+
+    await click("[data-test-add]");
+    assert.dom("[data-test-total]").hasText("800");
+  });
+
+  test("plain getters can mix Starbeam and Glimmer dependencies", async function (assert) {
+    const count = Cell(2);
+
+    class Mixed extends Component {
+      @tracked multiplier = 2;
+
+      get scaled(): number {
+        return count.current * this.multiplier;
+      }
+
+      incrementCount = () => {
+        count.current += 1;
+      };
+
+      triple = () => {
+        this.multiplier = 3;
+      };
+
+      <template>
+        <p data-test-scaled>{{this.scaled}}</p>
+        <button type="button" data-test-count {{on "click" this.incrementCount}}>
+          increment count
+        </button>
+        <button type="button" data-test-triple {{on "click" this.triple}}>
+          triple
+        </button>
+      </template>
+    }
+
+    await render(<template><Mixed /></template>);
+    assert.dom("[data-test-scaled]").hasText("4", "initial: count=2 * mult=2");
+
+    await click("[data-test-triple]");
+    assert
+      .dom("[data-test-scaled]")
+      .hasText("6", "rerenders when the @tracked field changes");
+
+    await click("[data-test-count]");
+    assert
+      .dom("[data-test-scaled]")
+      .hasText("9", "rerenders when the Starbeam cell changes");
+  });
+
+  test("plain getters refresh dynamic Starbeam dependencies", async function (assert) {
+    const left = Cell(1);
+    const right = Cell(10);
+
+    class Picker extends Component {
+      @tracked side: "left" | "right" = "left";
+
+      get selected(): string {
+        return this.side === "left"
+          ? `left=${left.current}`
+          : `right=${right.current}`;
+      }
+
+      chooseRight = () => {
+        this.side = "right";
+      };
+      bumpLeft = () => {
+        left.current += 1;
+      };
+      bumpRight = () => {
+        right.current += 1;
+      };
+
+      <template>
+        <p data-test-selected>{{this.selected}}</p>
+        <button type="button" data-test-right {{on "click" this.chooseRight}}>
+          choose right
+        </button>
+        <button type="button" data-test-bump-left {{on "click" this.bumpLeft}}>
+          bump left
+        </button>
+        <button type="button" data-test-bump-right {{on "click" this.bumpRight}}>
+          bump right
+        </button>
+      </template>
+    }
+
+    await render(<template><Picker /></template>);
+    assert.dom("[data-test-selected]").hasText("left=1");
+
+    await click("[data-test-right]");
+    assert.dom("[data-test-selected]").hasText("right=10");
+
+    await click("[data-test-bump-left]");
+    assert.dom("[data-test-selected]").hasText("right=10");
+
+    await click("[data-test-bump-right]");
+    assert.dom("[data-test-selected]").hasText("right=11");
+  });
+
+  test("Formula reruns inside Glimmer tracking and can mix dependency systems", async function (assert) {
+    const count = Cell(2);
+
+    class MixedFormula extends Component {
+      @tracked multiplier = 2;
+
+      readonly scaled = Formula(() => count.current * this.multiplier);
+
+      get value(): number {
+        return this.scaled.current;
+      }
+
+      incrementCount = () => {
+        count.current += 1;
+      };
+
+      triple = () => {
+        this.multiplier = 3;
+      };
+
+      <template>
+        <p data-test-value>{{this.value}}</p>
+        <button type="button" data-test-count {{on "click" this.incrementCount}}>
+          increment count
+        </button>
+        <button type="button" data-test-triple {{on "click" this.triple}}>
+          triple
+        </button>
+      </template>
+    }
+
+    await render(<template><MixedFormula /></template>);
+    assert.dom("[data-test-value]").hasText("4");
+
+    await click("[data-test-triple]");
+    assert.dom("[data-test-value]").hasText("6");
+
+    await click("[data-test-count]");
+    assert.dom("[data-test-value]").hasText("9");
+  });
+
+  test("@cached getters can cache Starbeam reads through native Glimmer tags", async function (assert) {
+    const count = Cell(2);
+
+    class Derived extends Component {
+      @cached
+      get doubled(): number {
+        return count.current * 2;
+      }
+
+      increment = () => {
+        count.current += 1;
+      };
+
+      <template>
+        <p data-test-doubled>{{this.doubled}}</p>
+        <button type="button" data-test-increment {{on "click" this.increment}}>
+          increment
+        </button>
+      </template>
+    }
+
+    await render(<template><Derived /></template>);
+    assert.dom("[data-test-doubled]").hasText("4");
+
+    await click("[data-test-increment]");
+    assert.dom("[data-test-doubled]").hasText("6");
+  });
+
+  test("resource values can be read directly from plain getters", async function (assert) {
+    const ticks = Cell(0);
+    const syncs: number[] = [];
+
+    const Counter = Resource(({ on: lifecycle }) => {
+      lifecycle.sync(() => {
+        syncs.push(ticks.current);
+      });
+
+      return {
+        get value() {
+          return ticks.current;
+        },
+      };
+    });
+
+    class Display extends Component {
+      counter = setupResource(Counter, this);
+
+      get value(): number {
+        return this.counter.value;
+      }
+
+      bump = () => {
+        ticks.current += 1;
+      };
+
+      <template>
+        <p data-test-value>{{this.value}}</p>
+        <button type="button" data-test-bump {{on "click" this.bump}}>bump</button>
+      </template>
+    }
+
+    await render(<template><Display /></template>);
+    assert.dom("[data-test-value]").hasText("0");
+    assert.deepEqual(syncs, [0], "synced once on setup");
+
+    await click("[data-test-bump]");
+    assert.dom("[data-test-value]").hasText("1");
+    assert.deepEqual(syncs, [0, 1], "synced after the cell changed");
+  });
+});

--- a/packages/ember/ember-test-app/tests/integration/setup-resource-test.gts
+++ b/packages/ember/ember-test-app/tests/integration/setup-resource-test.gts
@@ -2,7 +2,6 @@ import { on } from "@ember/modifier";
 import { click, clearRender, render, settled } from "@ember/test-helpers";
 import Component from "@glimmer/component";
 import {
-  fromStarbeam,
   getResource,
   resource,
   setupReactiveResource,
@@ -153,17 +152,17 @@ module("setupResource | rendering", function (hooks) {
 
     class Display extends Component {
       counter = setupResource(Counter, this);
-      // Bridge the read into Ember's autotracking. Without this, reads of
-      // a Starbeam cell from inside a Glimmer template don't register as
-      // dependencies, so updates won't trigger re-renders.
-      value = fromStarbeam(() => this.counter.value, { parent: this });
+
+      get value(): number {
+        return this.counter.value;
+      }
 
       bump = () => {
         ticks.current += 1;
       };
 
       <template>
-        <p data-test-value>{{this.value.current}}</p>
+        <p data-test-value>{{this.value}}</p>
         <button type="button" data-test-bump {{on "click" this.bump}}>bump</button>
       </template>
     }
@@ -199,10 +198,13 @@ module("setupResource | rendering", function (hooks) {
 
     class Holder extends Component {
       resource = setupResource(WithCleanup, this);
-      value = fromStarbeam(() => this.resource.value, { parent: this });
+
+      get value(): number {
+        return this.resource.value;
+      }
 
       <template>
-        <p data-test-value>{{this.value.current}}</p>
+        <p data-test-value>{{this.value}}</p>
       </template>
     }
 

--- a/packages/ember/ember/README.md
+++ b/packages/ember/ember/README.md
@@ -33,21 +33,25 @@ your Ember app.
 
 ```gjs
 import Component from "@glimmer/component";
-import { fromStarbeam } from "@starbeam/ember";
 import { cart } from "./cart";
 
 export default class CartTotal extends Component {
-  total = fromStarbeam(() => cart.totalCents, { parent: this });
+  get total() {
+    return cart.totalCents;
+  }
 
   <template>
-    <p>{{this.total.current}}</p>
+    <p>{{this.total}}</p>
   </template>
 }
 ```
 
-`fromStarbeam()` returns a read-only `current` getter. Keep Starbeam cells and
-collections private inside your domain objects; expose domain-shaped getters and
-wrap those reads at the Ember boundary.
+Starbeam cells and collections participate in Glimmer autotracking. Keep
+Starbeam cells and collections private inside your domain objects; expose
+domain-shaped getters and read them normally from components and templates.
+
+`fromStarbeam()` is still available when a caller needs an explicit read-only
+`current` handle and `disconnect()` lifecycle.
 
 Pass `options.parent` to tie the subscription to a destroyable (component,
 modifier, helper, owner). Without `parent`, the caller must invoke
@@ -56,21 +60,23 @@ modifier, helper, owner). Without `parent`, the caller must invoke
 ## Resources
 
 `setupResource()` creates a Starbeam resource and ties its lifetime to a
-destroyable parent — typically the component using it. To make the resource's
-value reactive from inside templates, wrap reads with `fromStarbeam` so Ember's
-autotracker can observe them:
+destroyable parent — typically the component using it. The resource's value can
+be read from a normal getter or template expression:
 
 ```gjs
 import Component from "@glimmer/component";
-import { fromStarbeam, setupResource } from "@starbeam/ember";
+import { setupResource } from "@starbeam/ember";
 import { Stopwatch } from "./stopwatch";
 
 export default class Clock extends Component {
   stopwatch = setupResource(Stopwatch, this);
-  time = fromStarbeam(() => this.stopwatch.time, { parent: this });
+
+  get time() {
+    return this.stopwatch.time;
+  }
 
   <template>
-    <p>{{this.time.current}}</p>
+    <p>{{this.time}}</p>
   </template>
 }
 ```
@@ -86,15 +92,18 @@ service's lifetime tracks the application:
 ```gjs
 import Component from "@glimmer/component";
 import { getOwner } from "@ember/owner";
-import { fromStarbeam, setupService } from "@starbeam/ember";
+import { setupService } from "@starbeam/ember";
 import { Session } from "./session";
 
 export default class Header extends Component {
   session = setupService(Session, getOwner(this));
-  name = fromStarbeam(() => this.session.user.name, { parent: this });
+
+  get name() {
+    return this.session.user.name;
+  }
 
   <template>
-    <span>{{this.name.current}}</span>
+    <span>{{this.name}}</span>
   </template>
 }
 ```
@@ -181,9 +190,13 @@ export default class SizedBox extends Component {
 
 ## Timing model
 
+- Starbeam reads mirror their cell tags into Glimmer tags. A template, getter,
+  `@cached` getter, modifier argument, or helper that reads Starbeam state is
+  invalidated by the same Starbeam writes that would invalidate a Starbeam
+  subscriber.
 - `fromStarbeam()` re-evaluates lazily on the next read after a Starbeam
-  invalidation. The invalidation dirties an internal Glimmer tag so Ember
-  rerenders any consumer that read `current`.
+  invalidation and remains available when a stable explicit bridge object is
+  useful.
 - `setupResource()` and `elementResourceModifier()` sync once during setup and
   again on each Starbeam-level invalidation, debounced to a microtask.
 - `setupService()` instantiates once per Ember owner; the instance is
@@ -191,10 +204,10 @@ export default class SizedBox extends Component {
 
 ## Notes
 
-- `fromStarbeam()` is the read-bridge: templates and `@cached` getters only
-  see Starbeam reactivity through it. If you have a Starbeam cell that you
-  want a template to follow, wrap it with `fromStarbeam` (or expose the
-  read through `setupResource` and wrap that).
+- Starbeam reads can participate in Glimmer autotracking, but Glimmer-owned
+  state is not added to Starbeam's subscription graph. If a resource `sync`
+  handler depends on Glimmer-owned state, pass that state through an explicit
+  Ember boundary so the resource syncs when it changes.
 - The package is shipped as a v2 Ember addon, so Embroider's resolver
   redirects internal `@glimmer/*` imports to the single bundled instance in
   `ember-source`. Don't add `@glimmer/*` packages to your app's

--- a/packages/ember/ember/env.d.ts
+++ b/packages/ember/ember/env.d.ts
@@ -11,7 +11,6 @@ declare module "@glimmer/validator" {
   export function createTag(): DirtyableTag;
   export function consumeTag(tag: Tag): void;
   export function dirtyTag(tag: DirtyableTag): void;
-  export function untrack<T>(callback: () => T): T;
 }
 
 declare module "@glimmer/destroyable" {

--- a/packages/ember/ember/env.d.ts
+++ b/packages/ember/ember/env.d.ts
@@ -11,6 +11,7 @@ declare module "@glimmer/validator" {
   export function createTag(): DirtyableTag;
   export function consumeTag(tag: Tag): void;
   export function dirtyTag(tag: DirtyableTag): void;
+  export function untrack<T>(callback: () => T): T;
 }
 
 declare module "@glimmer/destroyable" {

--- a/packages/ember/ember/index.ts
+++ b/packages/ember/ember/index.ts
@@ -1,3 +1,5 @@
+import { installStarbeamTags } from "./src/tracked.js";
+
 export {
   fromStarbeam,
   type FromStarbeamOptions,
@@ -12,3 +14,5 @@ export {
   useResource,
   useService,
 } from "./src/resource.js";
+
+installStarbeamTags();

--- a/packages/ember/ember/package.json
+++ b/packages/ember/ember/package.json
@@ -50,6 +50,7 @@
     "@starbeam/runtime": "workspace:^",
     "@starbeam/service": "workspace:^",
     "@starbeam/shared": "workspace:^",
+    "@starbeam/tags": "workspace:^",
     "@starbeam/universal": "workspace:^"
   },
   "devDependencies": {

--- a/packages/ember/ember/src/element-resource.ts
+++ b/packages/ember/ember/src/element-resource.ts
@@ -1,4 +1,5 @@
 import { capabilities, setModifierManager } from "@ember/modifier";
+import { untrack } from "@glimmer/validator";
 import type { ElementResourceBlueprint as RendererElementResourceBlueprint } from "@starbeam/renderer";
 import { setupElementResource } from "@starbeam/renderer";
 import { RUNTIME } from "@starbeam/runtime";
@@ -84,7 +85,7 @@ class StarbeamElementResourceModifierManager {
     args: ModifierArguments,
   ): void {
     this.#consume(args);
-    this.#setup(state, element);
+    untrack(() => void this.#setup(state, element));
   }
 
   updateModifier(
@@ -93,7 +94,11 @@ class StarbeamElementResourceModifierManager {
   ): void {
     this.#consume(args);
     this.#teardown(state);
-    if (state.resourceElement) this.#setup(state, state.resourceElement);
+    const element = state.resourceElement;
+
+    if (element) {
+      untrack(() => void this.#setup(state, element));
+    }
   }
 
   destroyModifier(state: ElementResourceModifierState<Element, unknown>): void {

--- a/packages/ember/ember/src/element-resource.ts
+++ b/packages/ember/ember/src/element-resource.ts
@@ -1,5 +1,4 @@
 import { capabilities, setModifierManager } from "@ember/modifier";
-import { untrack } from "@glimmer/validator";
 import type { ElementResourceBlueprint as RendererElementResourceBlueprint } from "@starbeam/renderer";
 import { setupElementResource } from "@starbeam/renderer";
 import { RUNTIME } from "@starbeam/runtime";
@@ -85,7 +84,7 @@ class StarbeamElementResourceModifierManager {
     args: ModifierArguments,
   ): void {
     this.#consume(args);
-    untrack(() => void this.#setup(state, element));
+    this.#setup(state, element);
   }
 
   updateModifier(
@@ -97,7 +96,7 @@ class StarbeamElementResourceModifierManager {
     const element = state.resourceElement;
 
     if (element) {
-      untrack(() => void this.#setup(state, element));
+      this.#setup(state, element);
     }
   }
 

--- a/packages/ember/ember/src/tracked.ts
+++ b/packages/ember/ember/src/tracked.ts
@@ -1,4 +1,7 @@
 import { consumeTag, createTag, dirtyTag } from "@glimmer/validator";
+import type { CellTag, Tag } from "@starbeam/interfaces";
+import { addRuntimeHooks } from "@starbeam/runtime";
+import { getDependencies } from "@starbeam/tags";
 
 /**
  * Minimal tracked storage built on the lowest-level Glimmer tag primitives.
@@ -17,4 +20,35 @@ export class TrackedTag {
   dirty(): void {
     dirtyTag(this.#tag);
   }
+}
+
+const STARBEAM_TAGS = new WeakMap<CellTag, TrackedTag>();
+let uninstall: (() => void) | undefined;
+
+export function installStarbeamTags(): void {
+  uninstall ??= addRuntimeHooks({
+    consume: consumeStarbeamTag,
+    mark: dirtyStarbeamTag,
+  });
+}
+
+function consumeStarbeamTag(tag: Tag): void {
+  for (const dependency of getDependencies(tag)) {
+    tagFor(dependency).consume();
+  }
+}
+
+function dirtyStarbeamTag(tag: CellTag): void {
+  tagFor(tag).dirty();
+}
+
+function tagFor(tag: CellTag): TrackedTag {
+  let tracked = STARBEAM_TAGS.get(tag);
+
+  if (!tracked) {
+    tracked = new TrackedTag();
+    STARBEAM_TAGS.set(tag, tracked);
+  }
+
+  return tracked;
 }

--- a/packages/universal/interfaces/index.ts
+++ b/packages/universal/interfaces/index.ts
@@ -5,6 +5,7 @@ export type {
   NotifyReady,
   Runtime,
   RuntimeFrame,
+  RuntimeHooks,
   UpdateOptions,
 } from "./src/runtime.js";
 export type { CellTag, FormulaTag, Tag, TagSnapshot } from "./src/tag.js";

--- a/packages/universal/interfaces/src/runtime.ts
+++ b/packages/universal/interfaces/src/runtime.ts
@@ -73,6 +73,11 @@ export interface Runtime {
   readonly start: () => () => TagSnapshot;
 }
 
+export interface RuntimeHooks {
+  readonly consume?: (tag: Tag) => void;
+  readonly mark?: (cell: CellTag) => void;
+}
+
 export type NotifyReady = (internals: CellTag) => void;
 
 export type RuntimeFrame = object;

--- a/packages/universal/reactive/src/runtime.ts
+++ b/packages/universal/reactive/src/runtime.ts
@@ -18,7 +18,7 @@ export function getRuntime(): Runtime {
   if (import.meta.env.DEV) {
     if (CONTEXT.runtime === null) {
       throw Error(
-        "@starbeam/reactive requires a reactive runtime, but no runtime was registered (did you try to use @starbeam/reactive without @starbeam/runtime or @starbeam/universal?)"
+        "@starbeam/reactive requires a reactive runtime, but no runtime was registered (did you try to use @starbeam/reactive without @starbeam/runtime or @starbeam/universal?)",
       );
     }
   }

--- a/packages/universal/runtime/index.ts
+++ b/packages/universal/runtime/index.ts
@@ -1,5 +1,6 @@
 export { type AppContext, CONTEXT } from "./src/context/context.js";
 export {
+  addRuntimeHooks,
   createMountScope,
   createPushScope,
   type FinalizationScope,

--- a/packages/universal/runtime/package.json
+++ b/packages/universal/runtime/package.json
@@ -26,7 +26,7 @@
     "build": "rollup -c",
     "prepack": "pnpm build",
     "test:lint": "eslint . --max-warnings 0",
-    "test:specs": "vitest --run --pool forks",
+    "test:specs": "cd ../../../ && pnpm exec vitest --run --pool forks --project runtime",
     "test:types": "tsc -b"
   },
   "dependencies": {

--- a/packages/universal/runtime/src/define.ts
+++ b/packages/universal/runtime/src/define.ts
@@ -1,4 +1,10 @@
-import type { Runtime as IRuntime, TagSnapshot } from "@starbeam/interfaces";
+import type {
+  CellTag,
+  Runtime as IRuntime,
+  RuntimeHooks,
+  Tag,
+  TagSnapshot,
+} from "@starbeam/interfaces";
 import { defineRuntime } from "@starbeam/reactive";
 import {
   consume,
@@ -10,6 +16,31 @@ import {
 
 import { SUBSCRIPTION_RUNTIME } from "./timeline/render.js";
 
+const HOOKS = new Set<RuntimeHooks>();
+const NO_HOOKS = 0;
+
+export function addRuntimeHooks(hooks: RuntimeHooks): () => void {
+  HOOKS.add(hooks);
+
+  return () => void HOOKS.delete(hooks);
+}
+
+function notifyConsume(tag: Tag): void {
+  if (HOOKS.size === NO_HOOKS) return;
+
+  for (const hooks of HOOKS) {
+    hooks.consume?.(tag);
+  }
+}
+
+function notifyMark(cell: CellTag): void {
+  if (HOOKS.size === NO_HOOKS) return;
+
+  for (const hooks of HOOKS) {
+    hooks.mark?.(cell);
+  }
+}
+
 export const RUNTIME: IRuntime = {
   start: (): (() => TagSnapshot) => {
     const done = start();
@@ -17,9 +48,17 @@ export const RUNTIME: IRuntime = {
     return () => new Set(done()) as TagSnapshot;
   },
 
-  consume: (tag): void => void consume(tag),
+  consume: (tag): void => {
+    consume(tag);
+    notifyConsume(tag);
+  },
 
-  ...SUBSCRIPTION_RUNTIME,
+  subscribe: SUBSCRIPTION_RUNTIME.subscribe,
+  mark: (cell, mark): void => {
+    SUBSCRIPTION_RUNTIME.mark(cell, mark);
+    notifyMark(cell);
+  },
+  update: SUBSCRIPTION_RUNTIME.update,
 };
 
 defineRuntime(RUNTIME);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       '@starbeam/shared':
         specifier: workspace:^
         version: link:../../universal/shared
+      '@starbeam/tags':
+        specifier: workspace:^
+        version: link:../../universal/tags
       '@starbeam/universal':
         specifier: workspace:^
         version: link:../../universal/universal


### PR DESCRIPTION
## Why

Ember and Starbeam both have tag-based invalidation. The Ember adapter was still requiring explicit read bridges (`fromStarbeam()` and the planned `@reactive` decorator) for normal component getters because Glimmer could not see Starbeam tag consumption.

This PR mirrors Starbeam cell tags into Glimmer tags so Starbeam reads can participate directly in Glimmer autotracking. That lets Ember components expose normal domain-shaped getters while keeping Starbeam storage private.

## What changed

- Adds optional runtime hooks for Starbeam `consume(tag)` and `mark(cell)` operations.
- Installs an Ember-side native tag mirror on `@starbeam/ember` import.
- Maps Starbeam `CellTag`s to Glimmer dirtyable tags with a `WeakMap`.
- On Starbeam reads, consumes the paired Glimmer tags for the current cell dependencies.
- On Starbeam writes, dirties the paired Glimmer tag.
- Updates Ember docs and tests so plain getters and resource values no longer need `fromStarbeam()` for normal template reads.
- Wraps element-resource setup in Glimmer `untrack()` so resource setup/sync reads do not become modifier argument dependencies.
- Fixes `@starbeam/runtime`'s package-local `test:specs` script to use the root Vitest binary, avoiding a stale package-local shim.

## Reviewer notes

The bridge is intentionally one-way: Starbeam reads become visible to Glimmer. Glimmer-owned state is not added to Starbeam's subscription graph. That is fine for normal render-time reads because Glimmer is the consumer. Resource `sync` handlers that depend on Glimmer-owned state still need an explicit Ember boundary.

One implementation wrinkle surfaced in element resources: without `untrack()`, setup/sync reads were captured as modifier dependencies, which caused spurious teardown/resync after marker invalidations. The modifier still consumes actual positional/named args normally; only resource setup is untracked.

## User-facing changes

Ember users can read Starbeam-backed domain getters directly from templates and `@cached` getters:

```gjs
export default class CartTotal extends Component {
  get total() {
    return cart.totalCents;
  }

  <template>
    <p>{{this.total}}</p>
  </template>
}
```

`fromStarbeam()` remains available when callers need an explicit stable bridge object and lifecycle handle.
