### PR TITLE
docs: add Ember adapter guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Framework apps add the adapter for the framework that owns rendering:
 
 - `@starbeam/react`
 - `@starbeam/preact`
+- `@starbeam/ember`
 - `@starbeam/vue`
 - `@starbeam/svelte`
 
@@ -55,7 +56,7 @@ See [Install Starbeam] for the package chooser.
 - [Start]: build a first Starbeam model.
 - [Install Starbeam]: choose packages for your app or library.
 - [Core concepts]: learn root state, derived reads, resources, and services.
-- [Framework guides]: connect Starbeam to React, Preact, Vue, or Svelte.
+- [Framework guides]: connect Starbeam to React, Preact, Ember, Vue, or Svelte.
 - [Library-author guide]: write reusable framework-neutral abstractions.
 - [Reference]: see the package reference.
 - [Advanced docs]: orient to adapter and runtime internals.

--- a/workspace/docs/astro.config.mjs
+++ b/workspace/docs/astro.config.mjs
@@ -48,6 +48,7 @@ export default defineConfig({
             { label: "Overview", link: "/frameworks/overview/" },
             { label: "React", link: "/frameworks/react/" },
             { label: "Preact", link: "/frameworks/preact/" },
+            { label: "Ember", link: "/frameworks/ember/" },
             { label: "Vue", link: "/frameworks/vue/" },
             { label: "Svelte", link: "/frameworks/svelte/" },
           ],

--- a/workspace/docs/src/content/docs/concepts/element-resources.md
+++ b/workspace/docs/src/content/docs/concepts/element-resources.md
@@ -65,6 +65,7 @@ that framework's native dialect.
 | --------- | ---------------------------- | ------------------- |
 | React     | `useElementResource()`       | callback ref        |
 | Preact    | `useElementResource()`       | callback ref        |
+| Ember     | `elementResourceModifier()`  | modifier            |
 | Vue       | `elementResourceDirective()` | custom directive    |
 | Svelte    | `elementResource()`          | Svelte 5 attachment |
 

--- a/workspace/docs/src/content/docs/concepts/lifecycle.md
+++ b/workspace/docs/src/content/docs/concepts/lifecycle.md
@@ -119,6 +119,9 @@ sync, cleanup, and finalize fit into the framework that owns the component.
 - [Preact](/frameworks/preact/) uses `useResource()`. The resource belongs to
   the Preact component; sync is scheduled through Preact effects, and finalize
   runs when the component unmounts.
+- [Ember](/frameworks/ember/) uses `setupResource()`. The resource belongs to an
+  Ember destroyable; sync is scheduled from Starbeam invalidations, and finalize
+  runs when the destroyable is torn down.
 - [Vue](/frameworks/vue/) uses `setupResource()`. The resource is created from
   Vue setup, sync is scheduled through Vue's component lifecycle, and finalize
   runs when Vue unmounts the component.

--- a/workspace/docs/src/content/docs/concepts/services.md
+++ b/workspace/docs/src/content/docs/concepts/services.md
@@ -108,7 +108,8 @@ Services do not replace resources. They choose a different owner for a resource.
 
 ## Next steps
 
-- [React](/frameworks/react/), [Preact](/frameworks/preact/), and
-  [Vue](/frameworks/vue/) show current service APIs.
+- [React](/frameworks/react/), [Preact](/frameworks/preact/),
+  [Ember](/frameworks/ember/), and [Vue](/frameworks/vue/) show current service
+  APIs.
 - [Svelte](/frameworks/svelte/) documents the current Svelte adapter scope.
 - [Reference](/reference/overview/) maps the package surface.

--- a/workspace/docs/src/content/docs/concepts/services.md
+++ b/workspace/docs/src/content/docs/concepts/services.md
@@ -59,6 +59,7 @@ Use the service API from the framework adapter that owns your app.
 | --------- | --------------------------------------- | -------------------------------------------------------------------- |
 | React     | `Starbeam` provider plus `useService()` | The provider establishes the app lifetime.                           |
 | Preact    | `install(options)` plus `useService()`  | The installed adapter owns the app lifetime.                         |
+| Ember     | `setupService()` or `useService()`      | Services are scoped to the Ember owner.                              |
 | Vue       | `Starbeam` plugin plus `setupService()` | Install the plugin on the Vue app.                                   |
 | Svelte    | Not exposed yet                         | The Svelte adapter does not expose app-scoped service helpers today. |
 

--- a/workspace/docs/src/content/docs/experiments/overview.md
+++ b/workspace/docs/src/content/docs/experiments/overview.md
@@ -51,7 +51,7 @@ for Starbeam-backed rendering without a framework adapter.
 Useful for exploring:
 
 - how Starbeam can drive text, attributes, elements, and fragments;
-- renderer ideas without React, Preact, Vue, or Svelte;
+- renderer ideas without React, Preact, Ember, Vue, or Svelte;
 - small implementation examples for people studying render integration.
 
 It is not intended to be a full app framework. App authors should normally use a

--- a/workspace/docs/src/content/docs/frameworks/ember.md
+++ b/workspace/docs/src/content/docs/frameworks/ember.md
@@ -79,29 +79,36 @@ export class Cart {
 `#items` is the reactive root state. `itemCount`, `totalCents`, and `add()` are
 ordinary JavaScript above it.
 
-## Read the model from Ember
+## Read app models through services
 
-Read Starbeam-backed domain objects from normal Ember getters and templates.
+Ember apps usually put long-lived app state behind services. Model the service
+as a Starbeam resource, then read the service value from normal Ember getters
+and templates.
 
 ```gjs
 import { on } from "@ember/modifier";
+import { getOwner } from "@ember/owner";
 import Component from "@glimmer/component";
+import { setupService } from "@starbeam/ember";
+import { Resource } from "@starbeam/universal";
 
 import { Cart } from "./cart";
 
-const cart = new Cart();
+const CartService = Resource(() => new Cart());
 
 export default class CartSummary extends Component {
+  cart = setupService(CartService, getOwner(this));
+
   get itemCount() {
-    return cart.itemCount;
+    return this.cart.itemCount;
   }
 
   get total() {
-    return `$${(cart.totalCents / 100).toFixed(2)}`;
+    return `$${(this.cart.totalCents / 100).toFixed(2)}`;
   }
 
   addTea = () => {
-    cart.add({ name: "Tea", priceCents: 500 });
+    this.cart.add({ name: "Tea", priceCents: 500 });
   };
 
   <template>
@@ -116,9 +123,9 @@ export default class CartSummary extends Component {
 ```
 
 The getters are ordinary Ember getters. During render, Glimmer sees Starbeam
-storage reads through mirrored Glimmer tags. When `cart.add()` mutates the
-reactive map, Ember rerenders any template or cached getter that consumed the
-Starbeam-backed read.
+storage reads through mirrored Glimmer tags. When `addTea()` mutates the cart,
+Ember rerenders any template or cached getter that consumed the Starbeam-backed
+read.
 
 ## Mixing Starbeam and Ember state
 

--- a/workspace/docs/src/content/docs/frameworks/ember.md
+++ b/workspace/docs/src/content/docs/frameworks/ember.md
@@ -82,7 +82,6 @@ ordinary JavaScript above it.
 ## Read the model from Ember
 
 Read Starbeam-backed domain objects from normal Ember getters and templates.
-There is no `.current` wrapper at the template boundary.
 
 ```gjs
 import { on } from "@ember/modifier";
@@ -123,46 +122,46 @@ Starbeam-backed read.
 
 ## Mixing Starbeam and Ember state
 
-Because `Formula()` re-evaluates every time it is read, it can be used from an
-Ember getter that also reads Glimmer-tracked state. Glimmer owns the render
-tracking frame and sees both dependency systems while the getter runs.
+Ember owns the render tracking frame. A getter can combine Starbeam-backed model
+state with Ember `@tracked` state, and Glimmer will rerender when either side
+changes.
 
 ```gjs
 import { on } from "@ember/modifier";
 import { tracked } from "@glimmer/tracking";
 import Component from "@glimmer/component";
-import { Cell, Formula } from "@starbeam/universal";
 
-const count = Cell(2);
+import { cart } from "./cart";
 
-export default class MultipliedCount extends Component {
-  @tracked multiplier = 2;
+export default class DiscountedTotal extends Component {
+  @tracked discountPercent = 0;
 
-  scaled = Formula(() => count.current * this.multiplier);
+  get total() {
+    const discount = this.discountPercent / 100;
+    const discounted = cart.totalCents * (1 - discount);
 
-  get value() {
-    return this.scaled.current;
+    return `$${(discounted / 100).toFixed(2)}`;
   }
 
-  triple = () => {
-    this.multiplier = 3;
+  applyDiscount = () => {
+    this.discountPercent = 10;
   };
 
-  increment = () => {
-    count.current += 1;
+  addTea = () => {
+    cart.add({ name: "Tea", priceCents: 500 });
   };
 
   <template>
-    <p>{{this.value}}</p>
-    <button type="button" {{on "click" this.triple}}>Triple</button>
-    <button type="button" {{on "click" this.increment}}>Increment</button>
+    <p>{{this.total}}</p>
+    <button type="button" {{on "click" this.applyDiscount}}>10% off</button>
+    <button type="button" {{on "click" this.addTea}}>Add tea</button>
   </template>
 }
 ```
 
-Use `Formula()` when a computation might read framework-owned state. Use
-`CachedFormula()` only when the dependencies are Starbeam-owned or explicitly
-bridged into Starbeam storage.
+Use lower-level reactive primitives only when you are building adapter-level
+utilities or reusable reactive abstractions. App-facing Ember code should prefer
+domain-shaped objects and getters.
 
 ## Add lifecycle with `setupResource()`
 
@@ -308,8 +307,8 @@ tracked `current` value.
 
 ## Explicit bridge objects
 
-`fromStarbeam()` remains available when you want a stable object with a `current`
-getter and an explicit `disconnect()` lifecycle. Most app-facing Ember reads do
+`fromStarbeam()` remains available for lower-level integrations that need a
+stable object with explicit disconnect lifecycle. Most app-facing Ember reads do
 not need it.
 
 ## Notes
@@ -318,8 +317,7 @@ not need it.
   packages. Do not add separate `@glimmer/*` packages to an app to "fix"
   resolution; duplicate validator instances break tag bridging.
 - The adapter is still experimental. Prefer domain-shaped examples and avoid
-  building APIs around `fromStarbeam()` unless you specifically need an explicit
-  bridge object.
+  building app APIs around lower-level bridge objects.
 
 ## Next steps
 

--- a/workspace/docs/src/content/docs/frameworks/ember.md
+++ b/workspace/docs/src/content/docs/frameworks/ember.md
@@ -1,0 +1,331 @@
+---
+title: Ember
+description: "The Ember adapter mirrors Starbeam reads into Glimmer autotracking and connects resources, services, and element-backed resources to Ember lifetimes."
+---
+
+Ember is a native autotracking boundary for a Starbeam model. Your state can stay
+ordinary JavaScript: classes, getters, methods, maps, and resources. The Ember
+adapter mirrors Starbeam reads into Glimmer tags, so templates, component
+getters, `@cached` getters, helpers, and modifiers can follow Starbeam-backed
+state through normal Ember rendering.
+
+> Experimental. The adapter ships as a v2 Ember addon for Ember 4.12+ with
+> Embroider. API names may still be refined.
+
+## Install
+
+Install the Ember adapter with the framework-neutral Starbeam packages you will
+use for root state and resources:
+
+```sh
+pnpm add @starbeam/ember @starbeam/universal @starbeam/collections
+```
+
+`ember-source` is a peer dependency. `ember-modifier` is optional unless you use
+element-resource modifiers.
+
+## Keep the model ordinary JavaScript
+
+Start by marking the storage that changes. The rest of the model can be normal
+domain code.
+
+```ts
+import { reactive } from "@starbeam/collections";
+
+interface LineItem {
+  readonly id: string;
+  readonly name: string;
+  readonly priceCents: number;
+  readonly quantity: number;
+}
+
+interface ProductInput {
+  readonly name: string;
+  readonly priceCents: number;
+}
+
+export class Cart {
+  #items = reactive.Map<string, LineItem>();
+  #nextItemId = 1;
+
+  get items(): readonly LineItem[] {
+    return [...this.#items.values()];
+  }
+
+  get itemCount(): number {
+    return this.items.reduce((total, item) => total + item.quantity, 0);
+  }
+
+  get totalCents(): number {
+    return this.items.reduce(
+      (sum, item) => sum + item.priceCents * item.quantity,
+      0,
+    );
+  }
+
+  add(product: ProductInput): void {
+    const id = `item-${this.#nextItemId++}`;
+
+    this.#items.set(id, {
+      id,
+      name: product.name,
+      priceCents: product.priceCents,
+      quantity: 1,
+    });
+  }
+}
+```
+
+`#items` is the reactive root state. `itemCount`, `totalCents`, and `add()` are
+ordinary JavaScript above it.
+
+## Read the model from Ember
+
+Read Starbeam-backed domain objects from normal Ember getters and templates.
+There is no `.current` wrapper at the template boundary.
+
+```gjs
+import { on } from "@ember/modifier";
+import Component from "@glimmer/component";
+
+import { Cart } from "./cart";
+
+const cart = new Cart();
+
+export default class CartSummary extends Component {
+  get itemCount() {
+    return cart.itemCount;
+  }
+
+  get total() {
+    return `$${(cart.totalCents / 100).toFixed(2)}`;
+  }
+
+  addTea = () => {
+    cart.add({ name: "Tea", priceCents: 500 });
+  };
+
+  <template>
+    <section>
+      <p>{{this.itemCount}} items</p>
+      <p>{{this.total}}</p>
+
+      <button type="button" {{on "click" this.addTea}}>Add tea</button>
+    </section>
+  </template>
+}
+```
+
+The getters are ordinary Ember getters. During render, Glimmer sees Starbeam
+storage reads through mirrored Glimmer tags. When `cart.add()` mutates the
+reactive map, Ember rerenders any template or cached getter that consumed the
+Starbeam-backed read.
+
+## Mixing Starbeam and Ember state
+
+Because `Formula()` re-evaluates every time it is read, it can be used from an
+Ember getter that also reads Glimmer-tracked state. Glimmer owns the render
+tracking frame and sees both dependency systems while the getter runs.
+
+```gjs
+import { on } from "@ember/modifier";
+import { tracked } from "@glimmer/tracking";
+import Component from "@glimmer/component";
+import { Cell, Formula } from "@starbeam/universal";
+
+const count = Cell(2);
+
+export default class MultipliedCount extends Component {
+  @tracked multiplier = 2;
+
+  scaled = Formula(() => count.current * this.multiplier);
+
+  get value() {
+    return this.scaled.current;
+  }
+
+  triple = () => {
+    this.multiplier = 3;
+  };
+
+  increment = () => {
+    count.current += 1;
+  };
+
+  <template>
+    <p>{{this.value}}</p>
+    <button type="button" {{on "click" this.triple}}>Triple</button>
+    <button type="button" {{on "click" this.increment}}>Increment</button>
+  </template>
+}
+```
+
+Use `Formula()` when a computation might read framework-owned state. Use
+`CachedFormula()` only when the dependencies are Starbeam-owned or explicitly
+bridged into Starbeam storage.
+
+## Add lifecycle with `setupResource()`
+
+Use a `Resource` when state needs setup, sync, or cleanup. `setupResource()` ties
+the resource to an Ember destroyable, usually the component that owns it.
+
+```gjs
+import Component from "@glimmer/component";
+import { setupResource } from "@starbeam/ember";
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
+
+const Clock = Resource(({ on }) => {
+  const clock = reactive.object({ now: new Date() });
+
+  on.sync(() => {
+    clock.now = new Date();
+
+    const timer = setInterval(() => {
+      clock.now = new Date();
+    }, 1000);
+
+    return () => clearInterval(timer);
+  });
+
+  return clock;
+});
+
+export default class ClockLabel extends Component {
+  clock = setupResource(Clock, this);
+
+  get time() {
+    return this.clock.now.toLocaleTimeString();
+  }
+
+  <template>
+    <time>{{this.time}}</time>
+  </template>
+}
+```
+
+The resource returns a domain-shaped value. Ember reads that value normally, and
+Starbeam reruns the resource sync when Starbeam-level dependencies change.
+
+### Resource sync and Ember-owned state
+
+Starbeam can mirror its reads into Glimmer, but Glimmer-owned state is not added
+to Starbeam's subscription graph. That is fine for render-time reads, where
+Glimmer is the consumer.
+
+Resource `sync` is different: Starbeam owns that sync subscription. If a sync
+handler depends on Ember-owned `@tracked` state or args, pass that state through
+an explicit Ember boundary so the resource syncs when it changes. Do not rely on
+Starbeam to subscribe to Glimmer state from inside `on.sync()`.
+
+## App-scoped services
+
+Use `setupService()` or `useService()` for resource-backed state that should live
+with the Ember owner, not with one component.
+
+```gjs
+import { getOwner } from "@ember/owner";
+import Component from "@glimmer/component";
+import { setupService } from "@starbeam/ember";
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
+
+const SessionService = Resource(() => {
+  return reactive.object({ userName: "Guest" });
+});
+
+export default class CurrentUser extends Component {
+  session = setupService(SessionService, getOwner(this));
+
+  get userName() {
+    return this.session.userName;
+  }
+
+  <template>
+    <p>{{this.userName}}</p>
+  </template>
+}
+```
+
+Two components in the same owner that ask for the same blueprint receive the
+same instance. The instance is finalized when the owner is destroyed.
+
+## DOM element resources
+
+Use `elementResourceModifier()` when a resource needs a DOM element from Ember.
+The modifier owns the element lifetime. Pass `into` to publish the resource value
+into tracked component state.
+
+```gjs
+import { on } from "@ember/modifier";
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { reactive } from "@starbeam/collections";
+import { Resource } from "@starbeam/universal";
+import { elementResourceModifier } from "@starbeam/ember/modifier";
+
+function ElementSize(element) {
+  return Resource(({ on }) => {
+    const size = reactive.object({ width: 0, height: 0 });
+
+    on.sync(() => {
+      const observer = new ResizeObserver(([entry]) => {
+        if (!entry) return;
+
+        size.width = entry.contentRect.width;
+        size.height = entry.contentRect.height;
+      });
+
+      observer.observe(element);
+      return () => observer.disconnect();
+    });
+
+    return size;
+  });
+}
+
+export default class SizedBox extends Component {
+  @tracked size = null;
+
+  measure = elementResourceModifier(ElementSize, {
+    into: (value) => (this.size = value),
+  });
+
+  get label() {
+    return this.size
+      ? `${Math.round(this.size.width)} × ${Math.round(this.size.height)}`
+      : "Measuring…";
+  }
+
+  <template>
+    <section {{this.measure}}>{{this.label}}</section>
+  </template>
+}
+```
+
+`elementResource()` is also available as a handle that pairs a modifier with a
+tracked `current` value.
+
+## Explicit bridge objects
+
+`fromStarbeam()` remains available when you want a stable object with a `current`
+getter and an explicit `disconnect()` lifecycle. Most app-facing Ember reads do
+not need it.
+
+## Notes
+
+- The adapter imports Glimmer tag primitives from Ember's bundled Glimmer
+  packages. Do not add separate `@glimmer/*` packages to an app to "fix"
+  resolution; duplicate validator instances break tag bridging.
+- The adapter is still experimental. Prefer domain-shaped examples and avoid
+  building APIs around `fromStarbeam()` unless you specifically need an explicit
+  bridge object.
+
+## Next steps
+
+- Read [Core concepts](/concepts/overview/) for the model behind the adapter.
+- Read [Resources and lifecycle](/concepts/lifecycle/) for setup, sync, and
+  cleanup.
+- Read [Element resources and DOM attachment](/concepts/element-resources/) for
+  DOM-backed resources.
+- Read [Reference](/reference/overview/) for the public package surface.

--- a/workspace/docs/src/content/docs/frameworks/ember.md
+++ b/workspace/docs/src/content/docs/frameworks/ember.md
@@ -314,9 +314,8 @@ tracked `current` value.
 
 ## Explicit bridge objects
 
-`fromStarbeam()` remains available for lower-level integrations that need a
-stable object with explicit disconnect lifecycle. Most app-facing Ember reads do
-not need it.
+Use `fromStarbeam()` for lower-level integrations that need a stable object with
+explicit disconnect lifecycle. Most app-facing Ember reads do not need it.
 
 ## Notes
 

--- a/workspace/docs/src/content/docs/frameworks/overview.md
+++ b/workspace/docs/src/content/docs/frameworks/overview.md
@@ -1,14 +1,14 @@
 ---
 title: Framework guides
-description: "Starbeam's framework adapters connect the same reactive model to React, Preact, Vue, and Svelte as each adapter matures."
+description: "Starbeam's framework adapters connect the same reactive model to React, Preact, Ember, Vue, and Svelte as each adapter matures."
 ---
 
 Starbeam's state model is framework-neutral. Framework adapters make it feel
 native by connecting Starbeam's reactive model to each framework's rendering and
 lifecycle rules.
 
-The goal is not one framework with incidental ports. React, Preact, Vue, and
-Svelte are public docs targets, with adapter coverage maturing at different
+The goal is not one framework with incidental ports. React, Preact, Ember, Vue,
+and Svelte are public docs targets, with adapter coverage maturing at different
 speeds.
 
 ## Same model, native edges
@@ -24,7 +24,8 @@ The core model stays the same in every framework:
 The framework-specific layer should feel small. It is the bridge between
 Starbeam's model and the framework's rendering and lifecycle rules. Your domain
 model can still expose normal getters, methods, and objects; the adapter is the
-place that connects those reads and resources to React, Preact, Vue, or Svelte.
+place that connects those reads and resources to React, Preact, Ember, Vue, or
+Svelte.
 
 Need the package list first? Start with [Install Starbeam](/start/install/).
 
@@ -34,6 +35,8 @@ Need the package list first? Start with [Install Starbeam](/start/install/).
   services, and element resources.
 - [**Preact**](/frameworks/preact/): adapter installation, reactive reads,
   resources, services, and element resources.
+- [**Ember**](/frameworks/ember/): native Glimmer autotracking for Starbeam
+  reads, plus resources, services, and element resources.
 - [**Vue**](/frameworks/vue/): setup helpers and directives for reactive state,
   resources, services, and element resources.
 - [**Svelte**](/frameworks/svelte/): current Svelte 5 slice with experimental

--- a/workspace/docs/src/content/docs/library-authors/overview.md
+++ b/workspace/docs/src/content/docs/library-authors/overview.md
@@ -4,8 +4,8 @@ description: "Write reusable Starbeam abstractions that stay framework-neutral a
 ---
 
 This guide is for authors of reusable Starbeam-backed libraries: models,
-resources, and utilities that app authors can use from React, Preact, Vue,
-Svelte, or framework-neutral code.
+resources, and utilities that app authors can use from React, Preact, Ember,
+Vue, Svelte, or framework-neutral code.
 
 The goal is the same as app code: mark root state, then expose ordinary
 JavaScript above it. Your library should give consumers domain-shaped values,

--- a/workspace/docs/src/content/docs/reference/framework-adapters.md
+++ b/workspace/docs/src/content/docs/reference/framework-adapters.md
@@ -1,6 +1,6 @@
 ---
 title: Framework adapters
-description: "Reference for Starbeam's React, Preact, Vue, and Svelte adapter surfaces."
+description: "Reference for Starbeam's React, Preact, Ember, Vue, and Svelte adapter surfaces."
 ---
 
 Framework adapters connect Starbeam reads, resources, services, and element
@@ -10,12 +10,13 @@ Use the guide for your framework for full examples. This page is a quick API map
 
 ## Adapter matrix
 
-| Framework | Read boundary                                 | Resources                         | Services                                         | Element resources                               |
-| --------- | --------------------------------------------- | --------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
-| React     | `useReactive(compute, bridge?)`               | `useResource(blueprint, bridge?)` | `Starbeam` plus `useService(blueprint)`          | `useElementResource(build, bridge?)`            |
-| Preact    | `install(options)` tracks render reads        | `useResource(blueprint, deps?)`   | `useService(blueprint)`                          | `useElementResource(build, bridge?)`            |
-| Vue       | `useReactive()` or `setupReactive(blueprint)` | `setupResource(blueprint)`        | `Starbeam` plugin plus `setupService(blueprint)` | `elementResourceDirective(blueprint, options?)` |
-| Svelte    | `fromStarbeam(compute)`                       | Not exposed yet                   | Not exposed yet                                  | `elementResource(blueprint)`                    |
+| Framework | Read boundary                                 | Resources                          | Services                                         | Element resources                               |
+| --------- | --------------------------------------------- | ---------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| React     | `useReactive(compute, bridge?)`               | `useResource(blueprint, bridge?)`  | `Starbeam` plus `useService(blueprint)`          | `useElementResource(build, bridge?)`            |
+| Preact    | `install(options)` tracks render reads        | `useResource(blueprint, deps?)`    | `useService(blueprint)`                          | `useElementResource(build, bridge?)`            |
+| Ember     | Glimmer autotracking sees Starbeam reads      | `setupResource(blueprint, parent)` | `setupService(blueprint, owner?)`                | `elementResourceModifier(blueprint, options?)`  |
+| Vue       | `useReactive()` or `setupReactive(blueprint)` | `setupResource(blueprint)`         | `Starbeam` plugin plus `setupService(blueprint)` | `elementResourceDirective(blueprint, options?)` |
+| Svelte    | `fromStarbeam(compute)`                       | Not exposed yet                    | Not exposed yet                                  | `elementResource(blueprint)`                    |
 
 ## React
 
@@ -61,6 +62,24 @@ Package: `@starbeam/vue`
 | `elementResourceDirective(blueprint, options?)` | Attach element-backed work to a Vue directive.                   |
 | `elementResource(blueprint)`                    | Experimental lower-level handle with a directive and ref.        |
 
+## Ember
+
+Package: `@starbeam/ember`
+
+| API                                            | Use for                                                        |
+| ---------------------------------------------- | -------------------------------------------------------------- |
+| Native Glimmer tag mirror                      | Make Starbeam reads visible to Ember templates and getters.    |
+| `fromStarbeam(compute, options?)`              | Explicit read bridge object with `current` and `disconnect()`. |
+| `setupResource(blueprint, parent)`             | Attach a resource to an Ember destroyable lifetime.            |
+| `setupReactiveResource(blueprint, parent)`     | Explicit `current` wrapper for a resource value.               |
+| `setupService(blueprint, owner?)`              | Resolve owner-scoped service state.                            |
+| `useResource(parent, blueprint)` / `resource`  | Helper-backed resource setup.                                  |
+| `elementResourceModifier(blueprint, options?)` | Attach element-backed work to an Ember modifier.               |
+| `elementResource(blueprint)`                   | Handle pairing a modifier with a tracked `current` value.      |
+
+Plain templates and getters can read Starbeam-backed domain objects directly.
+Use `fromStarbeam()` when a stable explicit bridge object is useful.
+
 ## Svelte
 
 Package: `@starbeam/svelte`
@@ -80,6 +99,7 @@ Deeper integration is tracked in
 
 - [React guide](/frameworks/react/)
 - [Preact guide](/frameworks/preact/)
+- [Ember guide](/frameworks/ember/)
 - [Vue guide](/frameworks/vue/)
 - [Svelte guide](/frameworks/svelte/)
 - [Resources](/reference/resources/)

--- a/workspace/docs/src/content/docs/reference/overview.md
+++ b/workspace/docs/src/content/docs/reference/overview.md
@@ -18,10 +18,11 @@ If you are choosing what to install first, start with
 - `@starbeam/universal`: framework-neutral lifecycle APIs such as `Resource`,
   plus compatibility exports for lower-level primitives. See
   [Universal APIs](/reference/universal/).
-- Framework adapters: `@starbeam/react`, `@starbeam/preact`, `@starbeam/vue`, and
-  `@starbeam/svelte` connect Starbeam to framework rendering and lifecycle. The
-  Svelte adapter is a current experimental slice with reads and element resources
-  but no component-resource or service helpers yet. See
+- Framework adapters: `@starbeam/react`, `@starbeam/preact`, `@starbeam/ember`,
+  `@starbeam/vue`, and `@starbeam/svelte` connect Starbeam to framework
+  rendering and lifecycle. The Svelte adapter is a current experimental slice
+  with reads and element resources but no component-resource or service helpers
+  yet. See
   [Framework adapters](/reference/framework-adapters/).
 
 ## Lifecycle and composition packages

--- a/workspace/docs/src/content/docs/reference/services.md
+++ b/workspace/docs/src/content/docs/reference/services.md
@@ -11,12 +11,13 @@ App authors usually use service helpers from their framework adapter. The direct
 
 ## App-facing adapter APIs
 
-| Framework | API                                              | Notes                                                     |
-| --------- | ------------------------------------------------ | --------------------------------------------------------- |
-| React     | `Starbeam` provider plus `useService(blueprint)` | The provider establishes the app lifetime.                |
-| Preact    | `install(options)` plus `useService(blueprint)`  | The installed adapter owns the app lifetime.              |
-| Vue       | `Starbeam` plugin plus `setupService(blueprint)` | Install the plugin on the Vue app.                        |
-| Svelte    | Not exposed yet                                  | The Svelte adapter does not expose service helpers today. |
+| Framework | API                                                                  | Notes                                                     |
+| --------- | -------------------------------------------------------------------- | --------------------------------------------------------- |
+| React     | `Starbeam` provider plus `useService(blueprint)`                     | The provider establishes the app lifetime.                |
+| Preact    | `install(options)` plus `useService(blueprint)`                      | The installed adapter owns the app lifetime.              |
+| Ember     | `setupService(blueprint, owner?)` or `useService(parent, blueprint)` | Services are scoped to the Ember owner.                   |
+| Vue       | `Starbeam` plugin plus `setupService(blueprint)`                     | Install the plugin on the Vue app.                        |
+| Svelte    | Not exposed yet                                                      | The Svelte adapter does not expose service helpers today. |
 
 ## Direct package
 

--- a/workspace/docs/src/content/docs/reference/services.md
+++ b/workspace/docs/src/content/docs/reference/services.md
@@ -15,7 +15,7 @@ App authors usually use service helpers from their framework adapter. The direct
 | --------- | -------------------------------------------------------------------- | --------------------------------------------------------- |
 | React     | `Starbeam` provider plus `useService(blueprint)`                     | The provider establishes the app lifetime.                |
 | Preact    | `install(options)` plus `useService(blueprint)`                      | The installed adapter owns the app lifetime.              |
-| Ember     | `setupService(blueprint, owner?)` or `useService(parent, blueprint)` | Services are scoped to the Ember owner.                   |
+| Ember     | `setupService(blueprint, owner?)` or `useService(context, blueprint)` | Services are scoped to the Ember owner.                   |
 | Vue       | `Starbeam` plugin plus `setupService(blueprint)`                     | Install the plugin on the Vue app.                        |
 | Svelte    | Not exposed yet                                                      | The Svelte adapter does not expose service helpers today. |
 

--- a/workspace/docs/src/content/docs/start/install.md
+++ b/workspace/docs/src/content/docs/start/install.md
@@ -13,6 +13,7 @@ Install the packages you import directly. Most apps need one framework adapter,
 | A framework-neutral model | `@starbeam/universal @starbeam/collections`                  | `reactive` collections, domain objects, and `Resource`                                 |
 | A React app               | `@starbeam/react @starbeam/universal @starbeam/collections`  | `useReactive()`, `useResource()`, `useService()`, `useElementResource()`               |
 | A Preact app              | `@starbeam/preact @starbeam/universal @starbeam/collections` | `install(options)`, direct render reads, resource/service hooks                        |
+| An Ember app              | `@starbeam/ember @starbeam/universal @starbeam/collections`  | direct Glimmer-tracked reads, `setupResource()`, `setupService()`, element modifiers   |
 | A Vue app                 | `@starbeam/vue @starbeam/universal @starbeam/collections`    | `useReactive()`, `setupResource()`, `setupService()`, element-resource directives      |
 | A Svelte app              | `@starbeam/svelte @starbeam/universal @starbeam/collections` | current Svelte 5 slice: experimental `fromStarbeam()` and element-resource attachments |
 | A reusable library        | `@starbeam/universal @starbeam/collections`                  | framework-neutral state and domain-shaped APIs                                         |
@@ -102,6 +103,25 @@ import {
 Vue uses `useReactive()` for direct template reads, `setupReactive()` when you
 want a specific Starbeam read as a Vue ref, and directives for element resources:
 [Vue](/frameworks/vue/).
+
+### Ember
+
+```sh
+pnpm add @starbeam/ember @starbeam/universal @starbeam/collections
+```
+
+```ts
+import { setupResource, setupService } from "@starbeam/ember";
+import {
+  elementResource,
+  elementResourceModifier,
+} from "@starbeam/ember/modifier";
+```
+
+Ember's adapter mirrors Starbeam reads into Glimmer autotracking, so templates
+and getters can read Starbeam-backed domain objects directly. Use
+`setupResource()` for component-owned resources, `setupService()` for
+owner-scoped services, and modifiers for element resources: [Ember](/frameworks/ember/).
 
 ### Svelte
 

--- a/workspace/docs/src/content/docs/start/introduction.md
+++ b/workspace/docs/src/content/docs/start/introduction.md
@@ -20,9 +20,9 @@ pnpm add @starbeam/universal @starbeam/collections
 ```
 
 Framework apps usually install these packages plus the adapter for their
-framework, such as `@starbeam/react`, `@starbeam/preact`, `@starbeam/vue`, or
-`@starbeam/svelte`. This page stays framework-neutral; framework guides cover
-the adapter APIs.
+framework, such as `@starbeam/react`, `@starbeam/preact`, `@starbeam/ember`,
+`@starbeam/vue`, or `@starbeam/svelte`. This page stays framework-neutral;
+framework guides cover the adapter APIs.
 
 Choosing packages for a framework app or reusable library? See
 [Install Starbeam](/start/install/).
@@ -183,4 +183,4 @@ as JavaScript.
 - Read [Resources and lifecycle](/concepts/lifecycle/) when work needs setup,
   sync, or cleanup.
 - Read [Framework guides](/frameworks/overview/) to see how adapters connect this
-  model to React, Preact, Vue, and Svelte.
+  model to React, Preact, Ember, Vue, and Svelte.

--- a/workspace/docs/src/pages/index.astro
+++ b/workspace/docs/src/pages/index.astro
@@ -163,6 +163,15 @@ import "../styles/tokens.css";
                 services, and element resources to Vue components.
               </p>
             </a>
+            <a class="adapter-card" href="/frameworks/ember/">
+              <span aria-hidden="true">Ember</span>
+              <h3>Ember</h3>
+              <p>
+                Glimmer autotracking sees Starbeam reads directly, while
+                helpers and modifiers connect resources, services, and element
+                resources to Ember lifetimes.
+              </p>
+            </a>
             <a class="adapter-card" href="/frameworks/svelte/">
               <span aria-hidden="true">Svelte</span>
               <h3>Svelte</h3>
@@ -212,8 +221,8 @@ import "../styles/tokens.css";
             <a class="route-card" href="/frameworks/overview/">
               <h3>Frameworks</h3>
               <p>
-                Connect the same Starbeam model to React, Preact, Vue, or
-                Svelte.
+                Connect the same Starbeam model to React, Preact, Ember, Vue,
+                or Svelte.
               </p>
             </a>
             <a class="route-card" href="/reference/overview/">


### PR DESCRIPTION
## Why

The Ember adapter now mirrors Starbeam reads into Glimmer autotracking (#290), so the docs should teach the current Ember model instead of the older explicit `fromStarbeam()` bridge-first story.

## What changed

- Adds a fresh Ember framework guide covering:
  - ordinary Starbeam-backed domain objects;
  - direct reads from Ember getters and templates;
  - combining Starbeam-backed domain getters with Ember `@tracked` state;
  - `setupResource()` and the resource `sync` caveat for Ember-owned state;
  - `setupService()` / `useService()` for owner-scoped services;
  - `elementResourceModifier()` and `elementResource()` for DOM-backed resources;
  - `fromStarbeam()` as an explicit advanced bridge object.
- Adds Ember to docs navigation, install chooser, framework overview, homepage cards, reference matrices, concept pages, and the root README.

## Reviewer notes

This replaces the closed draft docs PR #287 rather than reviving that branch. The key shift is that plain Ember getters can now read Starbeam-backed domain objects directly; `fromStarbeam()` is no longer the default template-facing path.

## User-facing changes

Ember now appears as a first-class framework guide in the docs, with examples based on the native Glimmer tag mirror from #290.
