### PR TITLE
Fix npm provenance repository metadata

### DIFF
--- a/packages/ember/ember/package.json
+++ b/packages/ember/ember/package.json
@@ -88,5 +88,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/ember/ember",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/preact/preact/package.json
+++ b/packages/preact/preact/package.json
@@ -64,5 +64,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/preact/preact",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/react/react/package.json
+++ b/packages/react/react/package.json
@@ -66,5 +66,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/react/react",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/react/use-strict-lifecycle/package.json
+++ b/packages/react/use-strict-lifecycle/package.json
@@ -52,5 +52,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/react/use-strict-lifecycle",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/svelte/svelte/package.json
+++ b/packages/svelte/svelte/package.json
@@ -58,5 +58,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/svelte/svelte",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/universal/collections/package.json
+++ b/packages/universal/collections/package.json
@@ -54,5 +54,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/universal/collections",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/universal/core/package.json
+++ b/packages/universal/core/package.json
@@ -42,5 +42,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/universal/core",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/universal/interfaces/package.json
+++ b/packages/universal/interfaces/package.json
@@ -32,5 +32,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/universal/interfaces",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/universal/reactive/package.json
+++ b/packages/universal/reactive/package.json
@@ -50,5 +50,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/universal/reactive",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/universal/renderer/package.json
+++ b/packages/universal/renderer/package.json
@@ -48,5 +48,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/universal/renderer",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/universal/resource/package.json
+++ b/packages/universal/resource/package.json
@@ -51,5 +51,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/universal/resource",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/universal/runtime/package.json
+++ b/packages/universal/runtime/package.json
@@ -53,5 +53,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/universal/runtime",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/universal/service/package.json
+++ b/packages/universal/service/package.json
@@ -51,5 +51,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/universal/service",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/universal/shared/package.json
+++ b/packages/universal/shared/package.json
@@ -41,5 +41,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/universal/shared",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/universal/tags/package.json
+++ b/packages/universal/tags/package.json
@@ -48,5 +48,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/universal/tags",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/universal/universal/package.json
+++ b/packages/universal/universal/package.json
@@ -57,5 +57,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/universal/universal",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/vue/vue/package.json
+++ b/packages/vue/vue/package.json
@@ -63,5 +63,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/vue/vue",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/x/store/package.json
+++ b/packages/x/store/package.json
@@ -40,5 +40,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/x/store",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }

--- a/packages/x/vanilla/package.json
+++ b/packages/x/vanilla/package.json
@@ -42,5 +42,10 @@
     "semverIncrementAs": {
       "major": "minor"
     }
+  },
+  "repository": {
+    "directory": "packages/x/vanilla",
+    "type": "git",
+    "url": "https://github.com/starbeamjs/starbeam"
   }
 }


### PR DESCRIPTION
## Summary
- Add explicit GitHub repository metadata to every release-plan package.
- Include each package directory so npm provenance can validate monorepo publishes.

## Why

The stable publish workflow for #292 failed during npm provenance validation because published package metadata had an empty repository URL. The expected provenance repository is https://github.com/starbeamjs/starbeam.

## Validation
- pre-commit: `pnpm test:workspace:types`
- pre-commit: `pnpm test:workspace:lint`
- `pnpm exec prettier --check ...package.json`
- metadata audit script verified repository URL and directory for all release-plan packages
- `git diff --check`