### PR TITLE
Use public access for stable npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,6 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Publish to NPM
-        run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish
+        run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish --access public
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Pass `--access public` to `release-plan publish` in the stable publish workflow.

## Why

The stable publish retry got past npm provenance validation after #293, but new scoped packages still failed with:

> Cannot generate provenance for new or private package, you must set `access` to public.

`release-plan` already supports forwarding `--access`; this makes the CI publish command explicit for scoped packages.

## Validation
- pre-commit: `pnpm test:workspace:types`
- pre-commit: `pnpm test:workspace:lint`
- `git diff --check`