### PR TITLE
Use npm token for stable publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,3 +38,4 @@ jobs:
         run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish --access public
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Pass `NODE_AUTH_TOKEN` into the stable publish step.

## Why

The remaining stable publish failures are for new scoped packages (`@starbeam/ember` and `@starbeam/svelte`). npm is rejecting the OIDC-only publish with a 404/permission error, so we need the workflow to use the `NPM_TOKEN` secret when publishing those package names.

## Validation
- pre-commit: `pnpm test:workspace:types`
- pre-commit: `pnpm test:workspace:lint`
- `git diff --check`