### PR TITLE
Disable provenance for token stable publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Publish to NPM
-        run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish --access public
+        run: NPM_CONFIG_PROVENANCE=false pnpm release-plan publish --access public
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Disable npm provenance generation for the temporary token-based stable publish path.

## Why

We need to finish publishing `@starbeam/ember` and `@starbeam/svelte`, which are new scoped packages. The token path is now authenticated, but npm still prompts for web login when provenance is enabled. This makes the temporary token fallback publish without provenance.

After this release, we should prefer trusted publishing for packages that support it.

## Validation
- pre-commit: `pnpm test:workspace:lint`
- pre-commit: `pnpm test:workspace:types`
- `git diff --check`