### PR TITLE
Restore provenance stable publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,6 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Publish to NPM
-        run: NPM_CONFIG_PROVENANCE=false pnpm release-plan publish --access public
+        run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish --access public
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Restore stable publish to provenance/OIDC mode.
- Remove the temporary `NODE_AUTH_TOKEN` path from the stable release workflow.

## Why

The temporary npm token path was only needed to finish publishing the two new scoped packages in the 0.9.0 release. That publish completed successfully, and the repository `NPM_TOKEN` secret has been removed.

## Validation
- pre-commit: `pnpm test:workspace:types`
- pre-commit: `pnpm test:workspace:lint`
- `git diff --check`