### PR TITLE
Clarify React render candidates and activation

### DIFF
--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -312,8 +312,9 @@ first development Strict Mode render and other speculative render work.
 Abandoned render candidates are simply discarded: they are not deactivated, and
 they receive no teardown. No layout or effect-backed lifecycle handlers ran for
 them, so they must be safe for the garbage collector to reclaim without cleanup.
-That includes finalizers registered while constructing the candidate: they run
-only for candidates that React commits and later cleans up.
+FinalizationRegistry-backed cleanup may run later if the candidate is collected,
+but that timing is nondeterministic and not part of React's lifecycle. User code
+must not rely on it for timely external teardown.
 
 Code that runs while constructing a render candidate must not directly perform
 external work that requires cleanup. External synchronization, subscriptions,
@@ -356,11 +357,12 @@ commits it.
 
 Render-time setup may run for candidates that React later abandons. Those
 discarded candidates have no committed lifetime and therefore no cleanup. This
-includes finalizers registered while constructing the candidate. This is why
-user code that allocates, subscribes, or otherwise needs cleanup must do that
-work in committed lifecycle timing. `on.sync` is the boundary for external
-synchronization: it begins after commit in passive effect timing, and its
-cleanup runs when the committed lifetime ends.
+includes React lifecycle cleanup for finalizers registered while constructing
+the candidate. Any GC-backed finalization is best-effort and nondeterministic.
+This is why user code that allocates, subscribes, or otherwise needs cleanup
+must do that work in committed lifecycle timing. `on.sync` is the boundary for
+external synchronization: it begins after commit in passive effect timing, and
+its cleanup runs when the committed lifetime ends.
 
 This is non-negotiable. A user's committed lifecycle work must be allowed to
 allocate, subscribe, and own resources on the assumption that cleanup will fire

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -302,11 +302,31 @@ to survive all of that correctly, using only primitives the host has sanctioned.
 
 ## 14. The React adapter's lifecycle
 
-A component in the React adapter proceeds through four named lifecycle points:
+The React adapter distinguishes render candidate construction from committed
+activation.
 
-- **activate** — the component has a fresh reactive identity. Setup functions
-  run. Fires on initial mount and again on every remount (strict-mode remount,
-  `Activity` reveal, fast refresh).
+During render, the adapter may construct a fresh reactive identity so JSX can
+read Starbeam values on the first render. That identity is a **render
+candidate**. React may abandon a render candidate before commit, including the
+first development Strict Mode render and other speculative render work.
+Abandoned render candidates are simply discarded: they are not deactivated, and
+they receive no teardown. No layout or effect-backed lifecycle handlers ran for
+them, so they must be safe for the garbage collector to reclaim without cleanup.
+That includes finalizers registered while constructing the candidate: they run
+only for candidates that React commits and later cleans up.
+
+Code that runs while constructing a render candidate must not directly perform
+external work that requires cleanup. External synchronization, subscriptions,
+and other cleanup-bearing work belong in the committed lifecycle timing exposed
+by the resource lifecycle, especially `on.sync`.
+
+Once React commits a render candidate, a component in the React adapter proceeds
+through four named committed lifecycle points:
+
+- **activate** — React committed a render candidate, and it now owns the
+  component's reactive identity. Cleanup-bearing lifecycle work can be paired
+  with a later deactivation. Fires on initial mount and again on every remount
+  (strict-mode remount, `Activity` reveal, fast refresh).
 - **attach** — the component is in the DOM and effects are eligible to run.
   Layout-timing work is registered here.
 - **ready** — effects have run; the component is idle.
@@ -327,15 +347,25 @@ deactivated, and the next time it appears it will be freshly activated.
 
 ## 15. Lifetime is correct across every kind of remount
 
-Setup runs once per logical activation. If React destroys and recreates a
-component's effects — for strict mode, `Activity`, fast refresh, or any future
-reason — the adapter treats the recreation as a new activation: cleanup runs,
-setup runs again, a fresh reactive identity is produced.
+Each committed activation gets its own reactive identity. If React destroys and
+recreates a component's effects — for strict mode, `Activity`, fast refresh, or
+any future reason — the adapter treats the recreation as a new committed
+activation: cleanup runs for the previous committed identity, a fresh render
+candidate is constructed, and the candidate becomes active only after React
+commits it.
 
-This is non-negotiable. A user's setup function must be allowed to allocate,
-subscribe, and own resources on the assumption that cleanup will fire exactly
-when the identity is torn down, and that a subsequent activation will start from
-nothing.
+Render-time setup may run for candidates that React later abandons. Those
+discarded candidates have no committed lifetime and therefore no cleanup. This
+includes finalizers registered while constructing the candidate. This is why
+user code that allocates, subscribes, or otherwise needs cleanup must do that
+work in committed lifecycle timing. `on.sync` is the boundary for external
+synchronization: it begins after commit in passive effect timing, and its
+cleanup runs when the committed lifetime ends.
+
+This is non-negotiable. A user's committed lifecycle work must be allowed to
+allocate, subscribe, and own resources on the assumption that cleanup will fire
+exactly when the committed identity is torn down, and that a subsequent
+activation will start from nothing.
 
 ---
 

--- a/packages/react/react/README.md
+++ b/packages/react/react/README.md
@@ -92,6 +92,14 @@ export function MeasuredPanel() {
 
 ### Timing model
 
+Starbeam resource values are constructed during React render so they can be
+used immediately in JSX. That render work may be speculative: React can discard
+a render candidate without committing effects or running cleanup.
+
+Use `on.sync` for external synchronization. The first `on.sync` handler begins
+after React commits, in passive effect timing, and its cleanup runs when the
+committed lifetime ends.
+
 React supplies refs after render. That means an element-backed resource starts as
 `pending`, then becomes `attached` after React calls the callback ref and the
 component rerenders.

--- a/packages/react/react/src/hooks/lifecycle.ts
+++ b/packages/react/react/src/hooks/lifecycle.ts
@@ -18,7 +18,9 @@ import { createResource } from "./setup.js";
  *
  * The `buildLifecycle` function takes an internal builder from
  * `@starbeam/use-strict-lifecycle` and converts into the public API for
- * renderer lifecycles.
+ * renderer lifecycles. APIs exposed through this object are registered during
+ * render candidate construction, but the work they schedule is tied to
+ * committed React lifecycle timing.
  */
 export function buildLifecycle(
   builder: Builder<unknown>,

--- a/packages/react/react/src/hooks/setup.ts
+++ b/packages/react/react/src/hooks/setup.ts
@@ -157,9 +157,10 @@ export function createResource<T>(
     // without ever running effects or cleanup.
     //
     // The same rule applies to finalizers registered while constructing this
-    // scope: they run from the committed cleanup below only if this render
-    // candidate commits. An abandoned candidate gets no React cleanup, so its
-    // constructor must not rely on finalizers for external teardown.
+    // scope: committed cleanup below runs only if this render candidate
+    // commits. An abandoned candidate gets no React cleanup. GC-backed
+    // finalization may happen later, but it is nondeterministic, so the
+    // constructor must not rely on finalizers for timely external teardown.
     const [scope, { sync, value }] = pushingScope(() =>
       starbeamSetupResource(lastBlueprint.current),
     );

--- a/packages/react/react/src/hooks/setup.ts
+++ b/packages/react/react/src/hooks/setup.ts
@@ -26,12 +26,18 @@ import { sameDeps } from "../utils.js";
 import { buildLifecycle } from "./lifecycle.js";
 
 /**
- * The `useSetup` function takes a setup function and runs it during the setup
- * phase.
+ * The `useSetup` function takes a setup function and runs it while React is
+ * rendering. The returned value is available to JSX in that same render.
  *
- * **Note**: The setup function may run multiple times if React re-runs the
- * render function with fresh component state. This happens most commonly in
- * strict mode, but it can also happen in the real world.
+ * **Note**: Because the setup function runs during render, it may be
+ * speculative. React may run it multiple times with fresh component state and
+ * discard some of those render candidates without committing effects or
+ * cleanup. This happens most commonly in strict mode, but it can also happen
+ * in the real world.
+ *
+ * Do not perform external work that requires cleanup directly in the setup
+ * function. Use the resource lifecycle, especially `on.sync`, for external
+ * synchronization; those handlers run only after React commits.
  */
 export function useSetup<T>(blueprint: SetupBlueprint<T>): T {
   const app = useStarbeamApp({ allowMissing: true });
@@ -140,14 +146,20 @@ export function createResource<T>(
     validate: deps,
     with: sameDeps,
   }).render((builder) => {
-    // Set up the resource within a new finalization scope, which corresponds to
-    // this render lifecycle. This runs the constructor and returns a sync
-    // function that hasn't run yet.
+    // Set up the resource within a new finalization scope for this render
+    // candidate. This runs the constructor during render so the resource value
+    // is available to JSX, and returns a sync function that hasn't run yet.
     //
-    // We'll run the sync function on layout. If we ran the sync function now,
-    // we would not be guaranteed that its associated cleanup will run, since
-    // React is allowed to run the render function multiple times without ever
-    // running effects or cleanup.
+    // After React commits, the layout callback below registers the sync
+    // function and schedules it for passive effect timing. If we ran the sync
+    // function now, we would not be guaranteed that its associated cleanup will
+    // run, since React is allowed to run the render function multiple times
+    // without ever running effects or cleanup.
+    //
+    // The same rule applies to finalizers registered while constructing this
+    // scope: they run from the committed cleanup below only if this render
+    // candidate commits. An abandoned candidate gets no React cleanup, so its
+    // constructor must not rely on finalizers for external teardown.
     const [scope, { sync, value }] = pushingScope(() =>
       starbeamSetupResource(lastBlueprint.current),
     );

--- a/packages/react/react/tests/activation-probes.spec.ts
+++ b/packages/react/react/tests/activation-probes.spec.ts
@@ -14,9 +14,11 @@ import { RecordedEvents, TestResource } from "@starbeam-workspace/test-utils";
  * TestResource blueprint that records setup/sync/cleanup/finalize).
  *
  * Under strict mode, React renders the component twice and throws away
- * the first render. Per §14/§15, that discarded render is an activation
- * boundary: setup code should run twice, resources should be torn down
- * and rebuilt, fresh reactive identity should be allocated.
+ * the first render. Per §14/§15, that discarded render constructs a
+ * speculative render candidate, not a committed activation. It gets no
+ * teardown because no layout or effect-backed lifecycle handlers ran.
+ * React then commits the second render candidate and performs the strict-mode
+ * remount cycle, which creates another committed candidate.
  *
  * Observation: the existing unit tests for these hooks only assert the
  * DOM output, which is identical whether the hook honors §14 or not.
@@ -50,7 +52,7 @@ function trackedFormula(events: RecordedEvents, cell: Reactive<number>) {
 // ---------------------------------------------------------------------------
 
 testReact<void, number>(
-  "§14: useReactive(() => reactive.current) — fresh activation per strict-mode render",
+  "§14: useReactive(() => reactive.current) — render candidates vs committed activation",
   async (root, mode) => {
     const cell = Cell(INITIAL);
     const events = new RecordedEvents();
@@ -65,11 +67,11 @@ testReact<void, number>(
       });
 
     mode.match({
-      // Strict mode: 3 reads — one per activation (R1 discarded, R2
-      // committed, post-layout remount). The formula evaluates once
-      // per activation; the consumer reads its value once per render.
+      // Strict mode: 3 reads — one per render candidate (R1 speculative,
+      // R2 committed, R3 strict-mode remount). The formula evaluates once
+      // per candidate; the consumer reads its value once per render.
       strict: () => void events.expect("read", "read", "read"),
-      // Loose mode: 1 activation, 1 read.
+      // Loose mode: 1 render candidate, 1 committed activation, 1 read.
       loose: () => void events.expect("read"),
     });
   },
@@ -81,7 +83,7 @@ testReact<void, number>(
 // ---------------------------------------------------------------------------
 
 testReact<void, number>(
-  "§14: useResource — fresh activation per strict-mode render (baseline: matches resource-stages)",
+  "§14: useResource — render candidates and strict-mode remount (baseline: matches resource-stages)",
   async (root, mode) => {
     const { resource, events } = TestResource();
 
@@ -95,8 +97,9 @@ testReact<void, number>(
 
     mode.match({
       // Matches `resource-stages.spec.ts > the basics > strict mode`:
-      // first activation sets up, is torn down, second activation
-      // sets up again and syncs.
+      // R1 constructs a speculative render candidate; R2 constructs and
+      // commits a candidate that syncs, cleans up, and finalizes during
+      // strict-mode remount; R3 constructs the remount candidate and syncs.
       strict: () =>
         void events.expect(
           "setup",
@@ -117,7 +120,7 @@ testReact<void, number>(
 // ---------------------------------------------------------------------------
 
 testReact<void, number>(
-  "§14: useSetup(blueprint) — blueprint runs per activation",
+  "§14: useSetup(blueprint) — blueprint runs per render candidate",
   async (root, mode) => {
     const events = new RecordedEvents();
 
@@ -135,31 +138,27 @@ testReact<void, number>(
     mode.match({
       // Strict mode's first mount runs the blueprint three times:
       //
-      //   1. R1's render: blueprint runs via `useInitializedRef`'s
-      //      initial path. React will discard this render; no layout
-      //      effect commits for it.
-      //   2. R2's render: blueprint runs again via the `isUpdate &&
-      //      state === mounting` rebuild added in PR #163. React will
-      //      commit this render.
+      //   1. R1's render: blueprint runs for a speculative render candidate
+      //      via `useInitializedRef`'s initial path. React will discard this
+      //      render; no layout or effect-backed lifecycle handlers run for it.
+      //   2. R2's render: blueprint runs for the committed render candidate
+      //      via the `isUpdate && state === mounting` rebuild added in
+      //      PR #163. React will commit this render.
       //   3. Strict mode's mandatory remount cycle: layout cleanup
-      //      fires on the committed instance, then layout fires again
-      //      with `state === unmounted` and rebuilds the instance via
-      //      the remount path, running the blueprint once more.
+      //      fires on the committed identity, then layout fires again
+      //      with `state === unmounted` and rebuilds the remount candidate,
+      //      running the blueprint once more.
       //
       // Matches `resource-stages.spec.ts` baseline, which asserts the
       // same `setup, setup, …, setup` sequence around the `sync` /
       // `cleanup` / `finalize` events that a Resource blueprint adds
       // on top.
       //
-      // How this maps to INVARIANTS §14/§15's "setup runs once per
-      // logical activation" is an open interpretation — §15 ties
-      // "activation" to effect commit/destruction, under which R1's
-      // setup is a wasted call (no committed effects to pair with) and
-      // R2 + remount are the two pairable activations. PR #163
-      // introduces the R1→R2 rebuild deliberately, treating the
-      // discarded render as its own "fresh reactive identity" —
-      // observable behavior is consistent either way because R1's
-      // instance is unreachable after React discards the render.
+      // INVARIANTS §14/§15 separate render candidate construction from
+      // committed activation. `useSetup` runs during render, so it runs for
+      // R1, R2, and R3. Cleanup-bearing work must be registered with the
+      // committed lifecycle; R1's candidate is unreachable after React
+      // discards the render and receives no teardown.
       strict: () => void events.expect("setup", "setup", "setup"),
       loose: () => void events.expect("setup"),
     });

--- a/packages/react/use-strict-lifecycle/src/lifecycle.ts
+++ b/packages/react/use-strict-lifecycle/src/lifecycle.ts
@@ -191,8 +191,8 @@ export function useLifecycle<V, A>(
         } else if (state.current === State.mounting) {
           // Strict mode's second render, before any `useLayoutEffect` has
           // fired. React is about to throw the first render's work away,
-          // so per INVARIANTS §14/§15 we treat it as a fresh activation
-          // and rebuild the instance.
+          // so per INVARIANTS §14/§15 we rebuild the instance as the fresh
+          // render candidate for the committed render.
           //
           // `on.layout` handlers never ran on the discarded instance, so
           // any cleanup they would have registered doesn't exist yet; the


### PR DESCRIPTION
## Why

React can run render-phase code speculatively and abandon it before commit, but Starbeam intentionally constructs render-usable resource values during render so JSX can use them immediately. The existing lifecycle wording blurred that render candidate with committed activation, which made the Strict Mode probes harder to interpret.

## What changed

- Clarify that React render candidates are speculative and may be discarded without teardown.
- Define committed activation as the point where React has committed the candidate and cleanup-bearing work can be paired with deactivation.
- Document `on.sync` as the boundary for external synchronization and cleanup-bearing resource work.
- Update React lifecycle comments and activation probe descriptions to use the same vocabulary.
- Preserve the existing runtime behavior and test expectations.

## Reviewer notes

This is a Prepare / Execute / Review (PER) clarification PR. It intentionally does not change lifecycle control flow, resource behavior, or test assertions.

## User-facing changes

Clarifies React adapter lifecycle docs and resource timing guidance.
