### PR TITLE
Clarify resource sync cleanup vs finalization

### DIFF
--- a/packages/universal/resource/README.md
+++ b/packages/universal/resource/README.md
@@ -1,7 +1,7 @@
 # @starbeam/resource
 
 `@starbeam/resource` defines framework-agnostic resources: stable values with a
-caller-scheduled sync phase and finalization cleanup.
+caller-scheduled sync phase, sync cleanup, and owning-scope finalization.
 
 The primary audience is resource authors and framework-agnostic library authors.
 App authors use this package when they are authoring reusable resources. Adapter
@@ -93,12 +93,14 @@ Registers the sync handler for the resource. The caller or framework schedules
 `sync`; creating a resource does not run sync work by itself.
 
 If the handler returns a cleanup function, Starbeam runs it before the next sync
-and when the owning scope finalizes.
+and when the owning scope finalizes. This is the normal place to stop external
+work started by the sync, such as timers, subscriptions, sockets, and observers.
 
 ### `resource.on.finalize(handler)`
 
-Registers cleanup for the resource's owning scope. Finalizers run when that
-scope finalizes.
+Registers lower-level finalization for the resource's owning scope. Finalizers
+run when that scope finalizes. They are not a replacement for cleanup returned
+from `resource.on.sync()`.
 
 ### `setupResource(intoBlueprint)`
 
@@ -144,8 +146,10 @@ define setup, sync, optional finalization, and a stable value directly.
 - Setup creates the stable resource value.
 - Sync work is scheduled by the caller or framework adapter.
 - A sync cleanup runs before the next sync and when the owning scope finalizes.
+  Use it to stop external work started by the sync.
 - Child resources created with `resource.use()` sync after the parent resource.
-- Finalizers run when the owning scope finalizes.
+- Finalizers run when the owning scope finalizes. They are for lower-level scope
+  finalization, not ordinary external-work teardown.
 
 ## What this package does not do
 

--- a/packages/universal/runtime/README.md
+++ b/packages/universal/runtime/README.md
@@ -138,7 +138,7 @@ As we discussed, the _timeline_ describes changes in the _data universe_ and hel
 
 On the other hand, you may encounter objects in the real world that require you to tear them down when you're done using them, and you may want to convert those objects into data in the _data universe_. That's where resource sync cleanup comes in.
 
-Resource sync allows you to set up a stateful connection to some external data, such as a WebSocket, ResizeObserver or even a `fetch` request, associate it with an **owner**, and clean up the connection when the sync is replaced or the _owner_ is finalized.
+Resource sync cleanup lets a resource clean up a stateful connection to external data, such as a WebSocket, ResizeObserver or even a `fetch` request, when the sync is replaced or the _owner_ is finalized. The sync callback sets up the connection; its returned cleanup disconnects it.
 
 For example, a component may set up a [ResizeObserver] to keep track of the size of one of the elements it creates. When the component is deactivated, the component wants to disconnect the `ResizeObserver` so that it doesn't leak.
 
@@ -156,6 +156,7 @@ Starbeam uses resource sync cleanup to make cleanup composable. Instead of makin
 Let's see how this all fits together. We'll use the resource pattern from `@starbeam/resource` to create an `ElementSize` resource.
 
 ```ts
+import { reactive } from "@starbeam/collections";
 import { Resource } from "@starbeam/resource";
 
 export function ElementSize(element: Element) {

--- a/packages/universal/runtime/README.md
+++ b/packages/universal/runtime/README.md
@@ -132,23 +132,23 @@ On the other hand, _Render_ phases are frozen in time. They **may not** move the
 
 > TODO: Describe how to subscribe to changes in a formula
 
-## Structured Finalizer
+## Resource Sync Cleanup
 
 As we discussed, the _timeline_ describes changes in the _data universe_ and helps a consumer coordinate the two-phase process of reflecting the _data universe_ onto the output. Both _data cells_ and _formulas_ are pure data: they can be automatically cleaned up by the garbage collector when nobody retains a reference to them.
 
-On the other hand, you may encounter objects in the real world that require you to tear them down when you're done using them, and you may want to convert those objects into data in the _data universe_. That's where the **structured finalizer** comes in.
+On the other hand, you may encounter objects in the real world that require you to tear them down when you're done using them, and you may want to convert those objects into data in the _data universe_. That's where resource sync cleanup comes in.
 
-The _structured finalizer_ allows you to set up a stateful connection to some external data, such as a WebSocket, ResizeObserver or even a `fetch` request, associate it with an **owner**, and automatically finalize the connection when the _owner_ is finalized.
+Resource sync allows you to set up a stateful connection to some external data, such as a WebSocket, ResizeObserver or even a `fetch` request, associate it with an **owner**, and clean up the connection when the sync is replaced or the _owner_ is finalized.
 
-For example, a component may set up a [ResizeObserver] to keep track of the size of one of the elements it creates. When the component is deactivated, the component wants to finalize the `ResizeObserver` so that it doesn't leak.
+For example, a component may set up a [ResizeObserver] to keep track of the size of one of the elements it creates. When the component is deactivated, the component wants to disconnect the `ResizeObserver` so that it doesn't leak.
 
 ### Composition is King
 
-Starbeam uses the _structured finalizer_ approach to make finalization composable. Instead of making the component responsible for setting up the `ResizeObserver` and specifying how to finalize the `ResizeObserver` when the component it finalized, it can delegate responsibility to an `ElementSize` resource:
+Starbeam uses resource sync cleanup to make cleanup composable. Instead of making the component responsible for setting up the `ResizeObserver` and specifying how to disconnect the `ResizeObserver` when the component is finalized, it can delegate responsibility to an `ElementSize` resource:
 
 1. Create an object that represents the `ResizeObserver`.
 2. Convert events on the `ResizeObserver` into data in the _data universe_.
-3. Specify what should happen when that object is finalized.
+3. Return cleanup for the object from the resource sync.
 4. _Link_ that object to the component.
 
 ### Example: The Resource Pattern
@@ -162,16 +162,18 @@ export function ElementSize(element: Element) {
   return Resource((resource) => {
     const size = reactive(getSize(element));
 
-    const observer = new ResizeObserver();
+    resource.on.sync(() => {
+      const observer = new ResizeObserver(() => {
+        const { width, height } = getSize(element);
 
-    observer.observe(element, () => {
-      const { width, height } = getSize(element);
+        size.width = width;
+        size.height = height;
+      });
 
-      size.width = width;
-      size.height = height;
+      observer.observe(element);
+
+      return () => observer.disconnect();
     });
-
-    resource.on.finalize(() => observer.disconnect());
 
     return size;
   });
@@ -220,25 +222,29 @@ First, we create a reactive object with the element's width and height.
 const size = reactive(getSize(element));
 ```
 
-Next, we create a `ResizeObserver` and observe the element.
+Next, the sync creates a `ResizeObserver` and observes the element.
 
 ```ts
-const observer = new ResizeObserver();
+resource.on.sync(() => {
+  const observer = new ResizeObserver(() => {
+    const { width, height } = getSize(element);
 
-observer.observe(element, () => {
-  const { width, height } = getSize(element);
+    size.width = width;
+    size.height = height;
+  });
 
-  size.width = width;
-  size.height = height;
+  observer.observe(element);
+
+  return () => observer.disconnect();
 });
 ```
 
 When the `ResizeObserver` fires, we update the `width` and `height` properties of the reactive object. **Importantly**, the `ResizeObserver`'s callback runs in the _Action_ phase, like all asynchronous callbacks invoked by the browser. This means that we can freely mutate anything in the _data universe_. Any part of the rendered output that cares about the reactive object will run in the next _Render_ phase, which Starbeam will automatically schedule.
 
-Ok, that's great, `ResizeObserver` requires us to disconnect from it when we no longer need it. If we don't disconnect, the observer will leak. No problem! That's the whole point of the `Resource` API. Let's tell Starbeam what to do when the resource is finalized.
+Ok, that's great, `ResizeObserver` requires us to disconnect from it when we no longer need it. If we don't disconnect, the observer will leak. No problem! That's the whole point of the `Resource` API. Let's return cleanup from the sync that created the observer.
 
 ```ts
-resource.on.finalize(() => observer.disconnect());
+return () => observer.disconnect();
 ```
 
 > This code is not responsible for attaching the `ElementSize` resource to any particular owner. That will happen inside the framework adapters, which know how to turn your framework's concept of component into a Starbeam owner.

--- a/packages/universal/service/README.md
+++ b/packages/universal/service/README.md
@@ -28,12 +28,12 @@ import { Resource } from "@starbeam/resource";
 const UserSession = Resource(({ on }) => {
   const user = Cell<{ id: string; name: string } | null>(null);
 
-  const unsubscribe = subscribeToSession((nextUser) => {
-    user.current = nextUser;
-  });
+  on.sync(() => {
+    const unsubscribe = subscribeToSession((nextUser) => {
+      user.current = nextUser;
+    });
 
-  on.finalize(() => {
-    unsubscribe();
+    return () => unsubscribe();
   });
 
   return {

--- a/workspace/docs/src/content/docs/concepts/lifecycle.md
+++ b/workspace/docs/src/content/docs/concepts/lifecycle.md
@@ -70,9 +70,9 @@ Resources separate the value you return from the work needed to keep that value
 connected to the outside world.
 
 - **Setup** creates the stable value the resource returns.
-- **Sync** starts or refreshes work after the owner is ready.
+- **Sync** starts or refreshes external work after the owner is ready.
 - **Sync cleanup** stops work from the previous sync before the next sync runs.
-- **Finalize** stops work when the owning lifetime ends.
+- **Finalize** runs lower-level owning-scope finalizers.
 
 `on.sync()` registers the sync work. Starbeam runs it when the framework adapter
 schedules the resource. If the sync callback returns a function, Starbeam runs
@@ -81,29 +81,42 @@ that cleanup before the next sync and again when the owner finalizes.
 That is why the timer cleanup belongs inside `on.sync()`: each sync owns the
 timer it created.
 
-`on.finalize()` is for cleanup that should run once when the owning lifetime
-ends.
+Use the same pattern for subscriptions, sockets, observers, and other external
+work. Start the external work in `on.sync()` and return the cleanup from that
+sync.
 
 ```ts
 import { reactive } from "@starbeam/collections";
 import { Resource } from "@starbeam/universal";
 
 const Connection = Resource(({ on }) => {
-  const connection = reactive.object({ status: "connecting" });
-  const socket = new WebSocket("wss://example.com");
+  const connection = reactive.object({ status: "idle" });
 
-  socket.addEventListener("open", () => {
-    connection.status = "open";
-  });
+  on.sync(() => {
+    connection.status = "connecting";
 
-  on.finalize(() => {
-    socket.close();
-    connection.status = "closed";
+    const socket = new WebSocket("wss://example.com");
+    const onOpen = () => {
+      connection.status = "open";
+    };
+
+    socket.addEventListener("open", onOpen);
+
+    return () => {
+      socket.removeEventListener("open", onOpen);
+      socket.close();
+      connection.status = "closed";
+    };
   });
 
   return connection;
 });
 ```
+
+`on.finalize()` is lower-level. It registers work for the owning Starbeam
+scope's finalization, not for each sync. Use it when you are working with
+Starbeam-owned scopes or integration machinery. It is not a replacement for the
+cleanup returned from `on.sync()`.
 
 Most app code does not call sync or finalize directly. Framework adapters attach
 resources to framework lifetimes and schedule the work for you.

--- a/workspace/docs/src/content/docs/reference/resources.md
+++ b/workspace/docs/src/content/docs/reference/resources.md
@@ -32,7 +32,7 @@ import { Resource, ResourceList, setupResource } from "@starbeam/resource";
 | ------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `Resource(constructor)`         | Define a resource blueprint.                                                                        |
 | `resource.use(childBlueprint)`  | Set up a child resource under the current resource.                                                 |
-| `resource.on.sync(handler)`     | Register sync work. Returned cleanup runs before the next sync and owner finalization.            |
+| `resource.on.sync(handler)`     | Register sync work. Returned cleanup runs before the next sync and when the owner finalizes.        |
 | `resource.on.finalize(handler)` | Register lower-level owning-scope finalization, not ordinary external-work teardown.                |
 | `ResourceList(list, options)`   | Keep a keyed list of child resources stable by key.                                                 |
 

--- a/workspace/docs/src/content/docs/reference/resources.md
+++ b/workspace/docs/src/content/docs/reference/resources.md
@@ -3,8 +3,9 @@ title: Resources
 description: "Reference for Starbeam resource authoring APIs."
 ---
 
-Resources model stable values with setup, sync, cleanup, and finalization. Start
-with [Resources and lifecycle](/concepts/lifecycle/) for the concept guide.
+Resources model stable values with setup, sync cleanup, and owning-scope
+finalization. Start with [Resources and lifecycle](/concepts/lifecycle/) for the
+concept guide.
 
 App code usually imports `Resource` from `@starbeam/universal`. Reusable resource
 helpers and manual integrations may import direct APIs from `@starbeam/resource`.
@@ -27,13 +28,13 @@ import { Resource, ResourceList, setupResource } from "@starbeam/resource";
 
 ## Authoring APIs
 
-| API                             | Use for                                                                                              |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `Resource(constructor)`         | Define a resource blueprint.                                                                         |
-| `resource.use(childBlueprint)`  | Set up a child resource under the current resource.                                                  |
-| `resource.on.sync(handler)`     | Register sync work. Cleanup returned from the handler runs before the next sync and on finalization. |
-| `resource.on.finalize(handler)` | Register cleanup that runs when the resource scope finalizes.                                        |
-| `ResourceList(list, options)`   | Keep a keyed list of child resources stable by key.                                                  |
+| API                             | Use for                                                                                             |
+| ------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `Resource(constructor)`         | Define a resource blueprint.                                                                        |
+| `resource.use(childBlueprint)`  | Set up a child resource under the current resource.                                                 |
+| `resource.on.sync(handler)`     | Register sync work. Returned cleanup runs before the next sync and owner finalization.            |
+| `resource.on.finalize(handler)` | Register lower-level owning-scope finalization, not ordinary external-work teardown.                |
+| `ResourceList(list, options)`   | Keep a keyed list of child resources stable by key.                                                 |
 
 ## Low-level APIs
 
@@ -50,8 +51,11 @@ Most app code should use framework adapter APIs such as React/Preact
 
 - Setup creates the stable value.
 - Sync work is scheduled by the caller or framework adapter.
-- Sync cleanup runs before the next sync and when the owner finalizes.
-- Finalizers run when the owning scope finalizes.
+- Sync cleanup is the normal place to stop external work. It runs before the
+  next sync and when the owner finalizes.
+- Finalizers run when the owning scope finalizes. They are for lower-level scope
+  finalization, not for timely teardown of sockets, timers, observers, or
+  subscriptions created during setup.
 - Child resources sync after their parent.
 
 ## Related docs


### PR DESCRIPTION
## Summary

Clarifies that `on.sync()` is the normal boundary for external work and returned cleanup, while `on.finalize()` is lower-level owning-scope finalization.

Updates the resource lifecycle guide, resource reference, package READMEs, and examples so sockets, subscriptions, and observers are started inside sync and cleaned up by the sync cleanup.

## Validation

- `pnpm test:workspace:lint`
- `pnpm --filter @starbeam-workspace/docs test:types`
- pre-commit lint + types
