### PR TITLE
Add low-level resource finalization hook

### DIFF
--- a/packages/ember/ember-test-app/tests/integration/setup-service-test.gts
+++ b/packages/ember/ember-test-app/tests/integration/setup-service-test.gts
@@ -80,7 +80,7 @@ module("setupService | rendering", function (hooks) {
     let finalizes = 0;
 
     const Session = Resource(({ on }) => {
-      on.finalize(() => {
+      on.lowLevel.finalize(() => {
         finalizes += 1;
       });
 

--- a/packages/preact/preact/tests/dom-attachment-probe.spec.ts
+++ b/packages/preact/preact/tests/dom-attachment-probe.spec.ts
@@ -55,7 +55,7 @@ function useElementAttachmentProbeForTest(
           element.dataset["starbeamAttachment"] = "attached";
         });
 
-        on.finalize(() => {
+        on.lowLevel.finalize(() => {
           events.record("resource:finalize");
         });
 

--- a/packages/preact/preact/tests/element-resource.spec.ts
+++ b/packages/preact/preact/tests/element-resource.spec.ts
@@ -32,7 +32,7 @@ function ElementSizeForTest(
       element.dataset["starbeamAttachment"] = "attached";
     });
 
-    on.finalize(() => {
+    on.lowLevel.finalize(() => {
       events.record("resource:finalize");
     });
 

--- a/packages/preact/preact/tests/resources.spec.ts
+++ b/packages/preact/preact/tests/resources.spec.ts
@@ -120,7 +120,7 @@ function ResourceForDeps(id: string, events: RecordedEvents) {
       return () => void events.record(`${id}:cleanup`);
     });
 
-    on.finalize(() => {
+    on.lowLevel.finalize(() => {
       events.record(`${id}:finalize`);
     });
 

--- a/packages/preact/preact/tests/sync.spec.ts
+++ b/packages/preact/preact/tests/sync.spec.ts
@@ -1,7 +1,3 @@
- 
- 
- 
- 
 // @vitest-environment jsdom
 
 import { install, setupSync } from "@starbeam/preact";
@@ -36,7 +32,7 @@ describe("setupSync", () => {
         return () => void actions.record("cleanup");
       });
 
-      on.finalize(() => {
+      on.lowLevel.finalize(() => {
         actions.record("finalize");
       });
     });

--- a/packages/react/react/tests/dom-attachment-probe.spec.ts
+++ b/packages/react/react/tests/dom-attachment-probe.spec.ts
@@ -51,7 +51,7 @@ function useElementAttachmentProbeForTest(
           element.dataset["starbeamAttachment"] = "attached";
         });
 
-        on.finalize(() => {
+        on.lowLevel.finalize(() => {
           events.record("resource:finalize");
         });
 

--- a/packages/react/react/tests/element-resource.spec.ts
+++ b/packages/react/react/tests/element-resource.spec.ts
@@ -29,7 +29,7 @@ function ElementSizeForTest(
       element.dataset["starbeamAttachment"] = "attached";
     });
 
-    on.finalize(() => {
+    on.lowLevel.finalize(() => {
       events.record("resource:finalize");
     });
 

--- a/packages/svelte/svelte/tests/element-resource.spec.ts
+++ b/packages/svelte/svelte/tests/element-resource.spec.ts
@@ -40,7 +40,7 @@ function ElementSizeForTest(
         width.set(Number(element.dataset["width"] ?? INITIAL_WIDTH));
       });
 
-      on.finalize(() => {
+      on.lowLevel.finalize(() => {
         events.record("size:finalize");
       });
 

--- a/packages/universal/renderer/tests/element-resource.spec.ts
+++ b/packages/universal/renderer/tests/element-resource.spec.ts
@@ -23,7 +23,7 @@ function ElementSizeForTest(
       width.set(Number(element.dataset["width"] ?? INITIAL_WIDTH));
     });
 
-    on.finalize(() => {
+    on.lowLevel.finalize(() => {
       events.record("size:finalize");
     });
 

--- a/packages/universal/renderer/tests/smoke.spec.ts
+++ b/packages/universal/renderer/tests/smoke.spec.ts
@@ -252,7 +252,7 @@ describe("RendererManager", () => {
 
     const Service = Resource(({ on }) => {
       events.record("setup");
-      on.finalize(() => void events.record("finalize"));
+      on.lowLevel.finalize(() => void events.record("finalize"));
 
       return {};
     });
@@ -373,7 +373,9 @@ class TestManager implements RendererManager<object> {
   createNotifier = (instance: object): (() => void) =>
     this.#createNotifier(instance);
 
-  createScheduler = (_instance: object): {
+  createScheduler = (
+    _instance: object,
+  ): {
     readonly onSchedule: (handler: Handler) => void;
     readonly schedule: () => void;
   } => ({

--- a/packages/universal/resource/README.md
+++ b/packages/universal/resource/README.md
@@ -96,11 +96,15 @@ If the handler returns a cleanup function, Starbeam runs it before the next sync
 and when the owning scope finalizes. This is the normal place to stop external
 work started by the sync, such as timers, subscriptions, sockets, and observers.
 
-### `resource.on.finalize(handler)`
+### `resource.on.lowLevel.finalize(handler)`
 
 Registers lower-level finalization for the resource's owning scope. Finalizers
 run when that scope finalizes. They are not a replacement for cleanup returned
 from `resource.on.sync()`.
+
+### `resource.on.finalize(handler)`
+
+Deprecated alias for `resource.on.lowLevel.finalize(handler)`.
 
 ### `setupResource(intoBlueprint)`
 
@@ -133,8 +137,9 @@ then syncs the child resources.
 
 ### `SyncTo(constructor)`
 
-Creates a lower-level sync blueprint with `on.sync()` and `on.finalize()` but no
-child-resource helper. Prefer `Resource()` for resource authoring.
+Creates a lower-level sync blueprint with `on.sync()` and
+`on.lowLevel.finalize()` but no child-resource helper. Prefer `Resource()` for
+resource authoring.
 
 ### `PrimitiveSyncTo(define)`
 

--- a/packages/universal/resource/src/sync/high-level.ts
+++ b/packages/universal/resource/src/sync/high-level.ts
@@ -35,13 +35,13 @@ export class DefineSync {
     },
 
     lowLevel: {
-      finalize: (handler: SyncHandler): void => {
+      finalize: (handler: Cleanup): void => {
         this.#finalize = handler;
       },
     },
 
     /** @deprecated Use `on.lowLevel.finalize()` instead. */
-    finalize: (handler: SyncHandler): void => {
+    finalize: (handler: Cleanup): void => {
       this.#finalize = handler;
     },
   };

--- a/packages/universal/resource/src/sync/high-level.ts
+++ b/packages/universal/resource/src/sync/high-level.ts
@@ -34,6 +34,13 @@ export class DefineSync {
       this.#sync = handler;
     },
 
+    lowLevel: {
+      finalize: (handler: SyncHandler): void => {
+        this.#finalize = handler;
+      },
+    },
+
+    /** @deprecated Use `on.lowLevel.finalize()` instead. */
     finalize: (handler: SyncHandler): void => {
       this.#finalize = handler;
     },

--- a/packages/universal/resource/tests/resource-list/high-level.spec.ts
+++ b/packages/universal/resource/tests/resource-list/high-level.spec.ts
@@ -55,7 +55,7 @@ describe("ResourceList", () => {
     ): ResourceBlueprint<{ active: boolean; desc: string }> => {
       const active = Cell(false);
       return Resource(({ on }) => {
-        on.finalize(() => {
+        on.lowLevel.finalize(() => {
           active.set(false);
         });
 
@@ -120,7 +120,7 @@ describe("ResourceList", () => {
     ): ResourceBlueprint<{ active: boolean; desc: string }> => {
       const active = Cell(false);
       return Resource(({ on }) => {
-        on.finalize(() => {
+        on.lowLevel.finalize(() => {
           active.set(false);
         });
 
@@ -182,7 +182,7 @@ describe("ResourceList", () => {
         const subscription = new Subscription(item.name);
         subscription.connect();
 
-        on.finalize(() => {
+        on.lowLevel.finalize(() => {
           subscription.disconnect();
         });
 

--- a/packages/universal/resource/tests/resource-list/syncing.spec.ts
+++ b/packages/universal/resource/tests/resource-list/syncing.spec.ts
@@ -35,7 +35,7 @@ describe("a ResourceList's children sync", () => {
           return () => void childEvents.record("cleanup");
         });
 
-        on.finalize(() => {
+        on.lowLevel.finalize(() => {
           childEvents.record("finalize");
         });
 

--- a/packages/universal/resource/tests/resource.spec.ts
+++ b/packages/universal/resource/tests/resource.spec.ts
@@ -34,7 +34,7 @@ describe("resources", () => {
           };
         });
 
-        on.finalize(() => {
+        on.lowLevel.finalize(() => {
           events.record("sync:finalize");
         });
       }).setup();
@@ -135,7 +135,7 @@ describe("resources", () => {
         };
       });
 
-      on.finalize(() => {
+      on.lowLevel.finalize(() => {
         events.record("sync:finalize");
       });
 
@@ -206,7 +206,7 @@ describe("resources", () => {
         };
       });
 
-      on.finalize(() => {
+      on.lowLevel.finalize(() => {
         events.record("finalize");
       });
 
@@ -293,7 +293,7 @@ describe("resources", () => {
         };
       });
 
-      on.finalize(() => {
+      on.lowLevel.finalize(() => {
         events.record("child:finalize");
       });
 
@@ -320,7 +320,7 @@ describe("resources", () => {
         };
       });
 
-      on.finalize(() => {
+      on.lowLevel.finalize(() => {
         events.record("parent:finalize");
       });
 
@@ -613,7 +613,7 @@ class ResourceWrapper<T, U> {
 
           this.#expect(
             {
-              events: this.#isFinalized ? [] : currentAction.events ?? [],
+              events: this.#isFinalized ? [] : (currentAction.events ?? []),
               value: expectedValue,
             },
             `${action.label} (${i + 1}/${runs}): after`,
@@ -772,7 +772,7 @@ class ResourceWrapper<T, U> {
       };
     } else {
       return {
-        events: this.#isFinalized ? [] : options.events ?? [],
+        events: this.#isFinalized ? [] : (options.events ?? []),
         value: options.value ?? UNCHANGED,
       };
     }

--- a/packages/universal/resource/tests/sync.spec.ts
+++ b/packages/universal/resource/tests/sync.spec.ts
@@ -177,7 +177,7 @@ describe("Sync", () => {
           };
         });
 
-        on.finalize(() => {
+        on.lowLevel.finalize(() => {
           events.record("finalize");
         });
       });
@@ -592,7 +592,7 @@ class Children<T, U> implements Iterable<Child<T, U>> {
 
         this.#events.expectEvents(expectedEvents);
       },
-       
+
       { entryFn: this.expect },
     );
   }
@@ -913,7 +913,7 @@ function buildTestSync<Setup extends undefined | (() => unknown)>(
       };
     });
 
-    on.finalize(() => {
+    on.lowLevel.finalize(() => {
       localEvents.record("finalize");
       test?.finalize?.();
     });

--- a/packages/universal/service/tests/service.spec.ts
+++ b/packages/universal/service/tests/service.spec.ts
@@ -20,7 +20,7 @@ describe("service", () => {
         invalidate.read();
       });
 
-      on.finalize(() => void events.record("finalize"));
+      on.lowLevel.finalize(() => void events.record("finalize"));
       return {
         get count() {
           return count.current;
@@ -68,7 +68,7 @@ describe("service", () => {
           invalidate.read();
         });
 
-        on.finalize(() => void events.record("finalize"));
+        on.lowLevel.finalize(() => void events.record("finalize"));
 
         return {
           mark() {

--- a/packages/universal/universal/tests/resource-list.spec.ts
+++ b/packages/universal/universal/tests/resource-list.spec.ts
@@ -38,7 +38,7 @@ describe("ResourceList", () => {
             active.set(true);
           });
 
-          on.finalize(() => {
+          on.lowLevel.finalize(() => {
             active.set(false);
           });
 

--- a/packages/vue/vue/tests/dom-attachment-probe.spec.ts
+++ b/packages/vue/vue/tests/dom-attachment-probe.spec.ts
@@ -27,7 +27,7 @@ function ElementAttachmentForTest(
       element.dataset["starbeamAttachment"] = "attached";
     });
 
-    on.finalize(() => {
+    on.lowLevel.finalize(() => {
       events.record("resource:finalize");
     });
 

--- a/packages/vue/vue/tests/element-resource.spec.ts
+++ b/packages/vue/vue/tests/element-resource.spec.ts
@@ -28,7 +28,7 @@ function ElementAttachmentForTest(
       element.dataset["starbeamAttachment"] = "attached";
     });
 
-    on.finalize(() => {
+    on.lowLevel.finalize(() => {
       events.record("resource:finalize");
     });
 
@@ -52,7 +52,7 @@ function ElementSizeForTest(
       width.set(Number(element.dataset["width"] ?? INITIAL_WIDTH));
     });
 
-    on.finalize(() => {
+    on.lowLevel.finalize(() => {
       events.record("size:finalize");
     });
 

--- a/workspace/docs/src/content/docs/concepts/lifecycle.md
+++ b/workspace/docs/src/content/docs/concepts/lifecycle.md
@@ -113,10 +113,10 @@ const Connection = Resource(({ on }) => {
 });
 ```
 
-`on.finalize()` is lower-level. It registers work for the owning Starbeam
-scope's finalization, not for each sync. Use it when you are working with
-Starbeam-owned scopes or integration machinery. It is not a replacement for the
-cleanup returned from `on.sync()`.
+`on.lowLevel.finalize()` is lower-level. It registers work for the owning
+Starbeam scope's finalization, not for each sync. Use it when you are working
+with Starbeam-owned scopes or integration machinery. It is not a replacement for
+the cleanup returned from `on.sync()`.
 
 Most app code does not call sync or finalize directly. Framework adapters attach
 resources to framework lifetimes and schedule the work for you.

--- a/workspace/docs/src/content/docs/concepts/lifecycle.md
+++ b/workspace/docs/src/content/docs/concepts/lifecycle.md
@@ -118,8 +118,9 @@ Starbeam scope's finalization, not for each sync. Use it when you are working
 with Starbeam-owned scopes or integration machinery. It is not a replacement for
 the cleanup returned from `on.sync()`.
 
-Most app code does not call sync or finalize directly. Framework adapters attach
-resources to framework lifetimes and schedule the work for you.
+Most app code does not call sync or low-level finalization APIs directly.
+Framework adapters attach resources to framework lifetimes and schedule the work
+for you.
 
 ## Framework adapters connect resources to framework lifetimes
 

--- a/workspace/docs/src/content/docs/reference/resources.md
+++ b/workspace/docs/src/content/docs/reference/resources.md
@@ -28,13 +28,14 @@ import { Resource, ResourceList, setupResource } from "@starbeam/resource";
 
 ## Authoring APIs
 
-| API                             | Use for                                                                                             |
-| ------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `Resource(constructor)`         | Define a resource blueprint.                                                                        |
-| `resource.use(childBlueprint)`  | Set up a child resource under the current resource.                                                 |
-| `resource.on.sync(handler)`     | Register sync work. Returned cleanup runs before the next sync and when the owner finalizes.        |
-| `resource.on.finalize(handler)` | Register lower-level owning-scope finalization, not ordinary external-work teardown.                |
-| `ResourceList(list, options)`   | Keep a keyed list of child resources stable by key.                                                 |
+| API                                      | Use for                                                                                      |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `Resource(constructor)`                  | Define a resource blueprint.                                                                 |
+| `resource.use(childBlueprint)`           | Set up a child resource under the current resource.                                          |
+| `resource.on.sync(handler)`              | Register sync work. Returned cleanup runs before the next sync and when the owner finalizes. |
+| `resource.on.lowLevel.finalize(handler)` | Register lower-level owning-scope finalization, not ordinary external-work teardown.         |
+| `resource.on.finalize(handler)`          | Deprecated alias for `resource.on.lowLevel.finalize(handler)`.                               |
+| `ResourceList(list, options)`            | Keep a keyed list of child resources stable by key.                                          |
 
 ## Low-level APIs
 

--- a/workspace/test-utils/src/test-resource.ts
+++ b/workspace/test-utils/src/test-resource.ts
@@ -51,7 +51,7 @@ export function TestResource(
         return () => void localEvents.record("cleanup");
       });
 
-      on.finalize(() => {
+      on.lowLevel.finalize(() => {
         localEvents.record("finalize");
       });
 


### PR DESCRIPTION
## Why

`on.finalize()` looks like a peer of `on.sync()`, but it represents owning-scope finalization rather than ordinary external-work cleanup. That shape made the low-level escape hatch too easy to reach for in app-author resource code.

## What changed

- Added `on.lowLevel.finalize(handler)` as the explicit owning-scope finalization hook.
- Kept `on.finalize(handler)` as a deprecated compatibility alias.
- Updated resource docs and references to prefer `on.lowLevel.finalize()`.
- Migrated lifecycle/probe tests to the new low-level spelling.

## User-facing changes

Resource authors should prefer cleanup returned from `on.sync()` for timers, subscriptions, sockets, observers, and other external work. `on.lowLevel.finalize()` is available for lower-level Starbeam scope finalization. `on.finalize()` remains available for compatibility but is deprecated.
