### PR TITLE
Move finalize alias to compatibility note

### DIFF
--- a/packages/universal/resource/README.md
+++ b/packages/universal/resource/README.md
@@ -102,10 +102,6 @@ Registers lower-level finalization for the resource's owning scope. Finalizers
 run when that scope finalizes. They are not a replacement for cleanup returned
 from `resource.on.sync()`.
 
-### `resource.on.finalize(handler)`
-
-Deprecated alias for `resource.on.lowLevel.finalize(handler)`.
-
 ### `setupResource(intoBlueprint)`
 
 Low-level setup for adapter and manual integration code. It accepts a resource
@@ -155,6 +151,12 @@ define setup, sync, optional finalization, and a stable value directly.
 - Child resources created with `resource.use()` sync after the parent resource.
 - Finalizers run when the owning scope finalizes. They are for lower-level scope
   finalization, not ordinary external-work teardown.
+
+## Deprecated compatibility
+
+`resource.on.finalize(handler)` is a deprecated alias for
+`resource.on.lowLevel.finalize(handler)`. Prefer `resource.on.sync(handler)` and
+returned cleanup for ordinary external-work teardown.
 
 ## What this package does not do
 

--- a/packages/universal/resource/src/sync/high-level.ts
+++ b/packages/universal/resource/src/sync/high-level.ts
@@ -40,10 +40,8 @@ export class DefineSync {
       },
     },
 
-    /**
-     * @deprecated Compatibility alias. Use `on.lowLevel.finalize()` instead.
-     * This alias should not be documented as part of the normal authoring API.
-     */
+    // Keep this compatibility alias out of the normal authoring API docs.
+    /** @deprecated Compatibility alias. Use `on.lowLevel.finalize()` instead. */
     finalize: (handler: Cleanup): void => {
       this.#finalize = handler;
     },

--- a/packages/universal/resource/src/sync/high-level.ts
+++ b/packages/universal/resource/src/sync/high-level.ts
@@ -40,7 +40,10 @@ export class DefineSync {
       },
     },
 
-    /** @deprecated Use `on.lowLevel.finalize()` instead. */
+    /**
+     * @deprecated Compatibility alias. Use `on.lowLevel.finalize()` instead.
+     * This alias should not be documented as part of the normal authoring API.
+     */
     finalize: (handler: Cleanup): void => {
       this.#finalize = handler;
     },

--- a/workspace/docs/src/content/docs/reference/resources.md
+++ b/workspace/docs/src/content/docs/reference/resources.md
@@ -34,7 +34,6 @@ import { Resource, ResourceList, setupResource } from "@starbeam/resource";
 | `resource.use(childBlueprint)`           | Set up a child resource under the current resource.                                          |
 | `resource.on.sync(handler)`              | Register sync work. Returned cleanup runs before the next sync and when the owner finalizes. |
 | `resource.on.lowLevel.finalize(handler)` | Register lower-level owning-scope finalization, not ordinary external-work teardown.         |
-| `resource.on.finalize(handler)`          | Deprecated alias for `resource.on.lowLevel.finalize(handler)`.                               |
 | `ResourceList(list, options)`            | Keep a keyed list of child resources stable by key.                                          |
 
 ## Low-level APIs
@@ -58,6 +57,12 @@ Most app code should use framework adapter APIs such as React/Preact
   finalization, not for timely teardown of sockets, timers, observers, or
   subscriptions created during setup.
 - Child resources sync after their parent.
+
+## Deprecated compatibility
+
+`resource.on.finalize(handler)` is a deprecated alias for
+`resource.on.lowLevel.finalize(handler)`. Prefer `resource.on.sync(handler)` and
+returned cleanup for ordinary external-work teardown.
 
 ## Related docs
 


### PR DESCRIPTION
## Why

`resource.on.finalize()` is a deprecated compatibility alias for `resource.on.lowLevel.finalize()`. Listing it in the main authoring table still makes it look like part of the normal resource API.

## What changed

- Removed `resource.on.finalize()` from the primary Resource authoring table.
- Moved the alias documentation into a separate deprecated compatibility section.
- Clarified the implementation comment so the alias is not documented as part of normal authoring.

## User-facing changes

Docs now point resource authors at `resource.on.lowLevel.finalize()` for owning-scope finalization and `resource.on.sync()` cleanup for ordinary external-work teardown. The deprecated alias still exists for compatibility.
