### PR TITLE
Hide finalize alias from authoring types

### DIFF
--- a/packages/universal/resource/index.ts
+++ b/packages/universal/resource/index.ts
@@ -1,10 +1,13 @@
 export type {
+  DefineResourceContext,
   IntoResourceBlueprint,
   ResourceBlueprint,
   ResourceConstructor,
+  SetupResource,
 } from "./src/resource.js";
 export { Resource, use as setupResource } from "./src/resource.js";
 export { ResourceList } from "./src/resource-list.js";
+export type { DefineSyncContext, SyncHooks } from "./src/sync/high-level.js";
 export { SyncTo } from "./src/sync/high-level.js";
 export type { Sync, SyncFn, SyncResult } from "./src/sync/primitive.js";
 export { PrimitiveSyncTo } from "./src/sync/primitive.js";

--- a/packages/universal/resource/src/resource.ts
+++ b/packages/universal/resource/src/resource.ts
@@ -5,11 +5,16 @@ import {
   mountFinalizationScope,
 } from "@starbeam/shared";
 
-import type { DefineSync } from "./sync/high-level.js";
+import type { DefineSyncContext, SyncHooks } from "./sync/high-level.js";
 import { SyncTo } from "./sync/high-level.js";
 import type { Sync, SyncFn, SyncResult } from "./sync/primitive.js";
 
-export type SetupResource<T> = (define: DefineResource) => T;
+export interface DefineResourceContext {
+  readonly on: SyncHooks;
+  readonly use: <T>(blueprint: ResourceBlueprint<T>) => T;
+}
+
+export type SetupResource<T> = (define: DefineResourceContext) => T;
 
 export type ResourceConstructor<T> = () => ResourceBlueprint<T>;
 
@@ -59,7 +64,7 @@ export class DefineResource {
   readonly #children = new Set<SyncFn<unknown>>();
   readonly on;
 
-  constructor(define: DefineSync) {
+  constructor(define: DefineSyncContext) {
     this.on = define.on;
   }
 

--- a/packages/universal/resource/src/sync/high-level.ts
+++ b/packages/universal/resource/src/sync/high-level.ts
@@ -3,7 +3,18 @@ import { linkToFinalizationScope } from "@starbeam/shared";
 import type { Cleanup, Sync, SyncHandler } from "./primitive.js";
 import { PrimitiveSyncTo } from "./primitive.js";
 
-export type SyncConstructor<T> = (define: DefineSync) => T;
+export interface SyncHooks {
+  readonly sync: (handler: SyncHandler) => void;
+  readonly lowLevel: {
+    readonly finalize: (handler: Cleanup) => void;
+  };
+}
+
+export interface DefineSyncContext {
+  readonly on: SyncHooks;
+}
+
+export type SyncConstructor<T> = (define: DefineSyncContext) => T;
 
 const INITIAL = 0;
 

--- a/packages/universal/resource/tests/type-surface.ts
+++ b/packages/universal/resource/tests/type-surface.ts
@@ -1,0 +1,19 @@
+import { Resource, SyncTo } from "@starbeam/resource";
+
+Resource(({ on }) => {
+  on.sync(() => undefined);
+  on.lowLevel.finalize(() => undefined);
+
+  // @ts-expect-error Deprecated alias is hidden from normal authoring.
+  on.finalize(() => undefined);
+
+  return {};
+});
+
+SyncTo(({ on }) => {
+  on.sync(() => undefined);
+  on.lowLevel.finalize(() => undefined);
+
+  // @ts-expect-error Deprecated alias is hidden from normal authoring.
+  on.finalize(() => undefined);
+});


### PR DESCRIPTION
## Why

`resource.on.finalize()` is only a deprecated compatibility alias, but it still appeared in the contextual TypeScript authoring surface. That meant editors could continue to suggest the old spelling even though the normal API is `resource.on.lowLevel.finalize()`.

## What changed

- Added explicit public authoring context types for resource/sync constructors.
- Kept the runtime compatibility alias on the implementation object.
- Exported the public context types from `@starbeam/resource`.
- Added a type-surface check that `on.finalize()` is hidden from normal `Resource` and `SyncTo` authoring.

## User-facing changes

TypeScript users should now see `on.sync()` and `on.lowLevel.finalize()` in normal authoring contexts. Existing runtime compatibility for `on.finalize()` remains in place.
