### PR TITLE
Add reactive table demo

### DIFF
--- a/demos/table-core/README.md
+++ b/demos/table-core/README.md
@@ -1,0 +1,46 @@
+# Starbeam table demo core
+
+Framework-neutral demo model for a small inventory table. The package has two
+layers:
+
+- `Table<Row>` is the reusable reactive table primitive.
+- `Inventory` is a domain wrapper that shows how an app can expose a small,
+  database-like API above that primitive.
+
+The important Starbeam idea is that the public API stays ordinary JavaScript.
+Call methods that look like writes to a tiny in-memory database, and reads like
+`inventory.view(...)` and `inventory.stats` update because the table uses
+reactive maps internally.
+
+```ts
+import { createTable } from "@starbeam-demos/table-core";
+
+const table = createTable<{ id: string; title: string; done: boolean }>();
+
+table.insert({ id: "write", title: "Write demo", done: false });
+table.update("write", (row) => ({ ...row, done: true }));
+
+console.log(table.rows);
+```
+
+The inventory wrapper is the first playable demo domain:
+
+```ts
+import { createInventory } from "@starbeam-demos/table-core";
+
+const inventory = createInventory();
+inventory.add({
+  id: "apples",
+  name: "Apples",
+  category: "produce",
+  price: 1.25,
+  stock: 12,
+});
+
+inventory.restock("apples", 3);
+console.log(inventory.stats.inventoryValue);
+```
+
+Framework apps can read the same model from their own adapter layer without
+importing framework code here. The React demo imports this package directly; the
+Preact, Vue, Svelte, and Ember demos can do the same later.

--- a/demos/table-core/index.ts
+++ b/demos/table-core/index.ts
@@ -1,0 +1,11 @@
+export type {
+  InventoryCategory,
+  InventoryItem,
+  InventoryStats,
+  InventoryViewOptions,
+  RowId,
+  TableRow,
+  TableView,
+  ViewOptions,
+} from "./src/table.js";
+export { createInventory, createTable, Inventory, Table } from "./src/table.js";

--- a/demos/table-core/index.ts
+++ b/demos/table-core/index.ts
@@ -8,4 +8,10 @@ export type {
   TableView,
   ViewOptions,
 } from "./src/table.js";
-export { createInventory, createTable, Inventory, Table } from "./src/table.js";
+export {
+  createInventory,
+  createTable,
+  Inventory,
+  LOW_STOCK_THRESHOLD,
+  Table,
+} from "./src/table.js";

--- a/demos/table-core/package.json
+++ b/demos/table-core/package.json
@@ -1,0 +1,26 @@
+{
+  "private": true,
+  "name": "@starbeam-demos/table-core",
+  "type": "module",
+  "version": "1.0.0",
+  "main": "index.ts",
+  "types": "index.ts",
+  "exports": {
+    "default": "./index.ts"
+  },
+  "starbeam": {
+    "type": "demo"
+  },
+  "scripts": {
+    "test:lint": "eslint . --max-warnings 0",
+    "test:specs": "vitest --run --pool forks --config ./vitest.config.mts",
+    "test:types": "tsc -b"
+  },
+  "dependencies": {
+    "@starbeam/collections": "workspace:^"
+  },
+  "devDependencies": {
+    "@starbeam/reactive": "workspace:^",
+    "vitest": "^4.1.4"
+  }
+}

--- a/demos/table-core/src/table.ts
+++ b/demos/table-core/src/table.ts
@@ -1,0 +1,238 @@
+import { reactive } from "@starbeam/collections";
+
+export type RowId = string;
+
+export interface TableRow {
+  readonly id: RowId;
+}
+
+export interface ViewOptions<Row extends TableRow> {
+  readonly filter?: (row: Row) => boolean;
+  readonly sort?: (left: Row, right: Row) => number;
+}
+
+export interface TableView<Row extends TableRow> {
+  readonly rows: readonly Row[];
+  readonly count: number;
+}
+
+export class Table<Row extends TableRow> {
+  readonly #rows = reactive.Map<RowId, Row>("table rows");
+
+  get size(): number {
+    return this.#rows.size;
+  }
+
+  get rows(): readonly Row[] {
+    return [...this.#rows.values()];
+  }
+
+  clear(): void {
+    this.#rows.clear();
+  }
+
+  delete(id: RowId): boolean {
+    return this.#rows.delete(id);
+  }
+
+  get(id: RowId): Row | undefined {
+    return this.#rows.get(id);
+  }
+
+  insert(row: Row): void {
+    if (this.#rows.has(row.id)) {
+      throw new Error(`Row already exists: ${row.id}`);
+    }
+
+    this.#rows.set(row.id, row);
+  }
+
+  update(id: RowId, updater: (row: Row) => Row): Row {
+    const row = this.#rows.get(id);
+
+    if (!row) {
+      throw new Error(`Row not found: ${id}`);
+    }
+
+    const next = updater(row);
+
+    if (next.id !== id) {
+      throw new Error("Table.update() cannot change a row id");
+    }
+
+    this.#rows.set(id, next);
+    return next;
+  }
+
+  upsert(row: Row): void {
+    this.#rows.set(row.id, row);
+  }
+
+  view(options: ViewOptions<Row> = {}): TableView<Row> {
+    let rows = this.rows;
+
+    if (options.filter) {
+      rows = rows.filter(options.filter);
+    }
+
+    if (options.sort) {
+      rows = [...rows].sort(options.sort);
+    }
+
+    return { rows, count: rows.length };
+  }
+}
+
+export function createTable<Row extends TableRow>(): Table<Row> {
+  return new Table<Row>();
+}
+
+export type InventoryCategory = "produce" | "bakery" | "pantry" | "dairy";
+
+export interface InventoryItem extends TableRow {
+  readonly name: string;
+  readonly category: InventoryCategory;
+  readonly price: number;
+  readonly stock: number;
+}
+
+export interface InventoryStats {
+  readonly categories: ReadonlyMap<InventoryCategory, number>;
+  readonly inventoryValue: number;
+  readonly lowStockCount: number;
+  readonly totalItems: number;
+}
+
+const EMPTY_COUNT = 0;
+const ONE_ITEM = 1;
+
+export class Inventory {
+  readonly #table = createTable<InventoryItem>();
+
+  get rows(): readonly InventoryItem[] {
+    return this.#table.rows;
+  }
+
+  get stats(): InventoryStats {
+    const categories = new Map<InventoryCategory, number>();
+    let inventoryValue = 0;
+    let lowStockCount = 0;
+
+    for (const item of this.rows) {
+      categories.set(
+        item.category,
+        (categories.get(item.category) ?? EMPTY_COUNT) + ONE_ITEM,
+      );
+      inventoryValue += item.price * item.stock;
+
+      if (item.stock <= LOW_STOCK_THRESHOLD) {
+        lowStockCount++;
+      }
+    }
+
+    return {
+      categories,
+      inventoryValue,
+      lowStockCount,
+      totalItems: this.rows.length,
+    };
+  }
+
+  add(item: InventoryItem): void {
+    this.#table.insert(item);
+  }
+
+  clear(): void {
+    this.#table.clear();
+  }
+
+  delete(id: RowId): boolean {
+    return this.#table.delete(id);
+  }
+
+  find(id: RowId): InventoryItem | undefined {
+    return this.#table.get(id);
+  }
+
+  restock(id: RowId, amount: number): InventoryItem {
+    return this.update(id, (item) => ({ ...item, stock: item.stock + amount }));
+  }
+
+  update(
+    id: RowId,
+    updater: (item: InventoryItem) => InventoryItem,
+  ): InventoryItem {
+    return this.#table.update(id, updater);
+  }
+
+  upsert(item: InventoryItem): void {
+    this.#table.upsert(item);
+  }
+
+  view(options: InventoryViewOptions = {}): TableView<InventoryItem> {
+    return this.#table.view({
+      filter: (item) => matchesInventoryFilters(item, options),
+      sort: sortInventory(options.sort),
+    });
+  }
+}
+
+export interface InventoryViewOptions {
+  readonly category?: InventoryCategory | "all";
+  readonly lowStockOnly?: boolean;
+  readonly search?: string;
+  readonly sort?: "name" | "category" | "stock" | "value";
+}
+
+export function createInventory(
+  items: Iterable<InventoryItem> = [],
+): Inventory {
+  const inventory = new Inventory();
+
+  for (const item of items) {
+    inventory.add(item);
+  }
+
+  return inventory;
+}
+
+const LOW_STOCK_THRESHOLD = 5;
+
+function matchesInventoryFilters(
+  item: InventoryItem,
+  options: InventoryViewOptions,
+): boolean {
+  if (options.category && options.category !== "all") {
+    if (item.category !== options.category) {
+      return false;
+    }
+  }
+
+  if (options.lowStockOnly === true && item.stock > LOW_STOCK_THRESHOLD) {
+    return false;
+  }
+
+  if (options.search) {
+    return item.name.toLowerCase().includes(options.search.toLowerCase());
+  }
+
+  return true;
+}
+
+function sortInventory(
+  sort: InventoryViewOptions["sort"] = "name",
+): (left: InventoryItem, right: InventoryItem) => number {
+  switch (sort) {
+    case "category":
+      return (left, right) =>
+        left.category.localeCompare(right.category) ||
+        left.name.localeCompare(right.name);
+    case "stock":
+      return (left, right) => left.stock - right.stock;
+    case "value":
+      return (left, right) =>
+        right.price * right.stock - left.price * left.stock;
+    case "name":
+      return (left, right) => left.name.localeCompare(right.name);
+  }
+}

--- a/demos/table-core/src/table.ts
+++ b/demos/table-core/src/table.ts
@@ -19,12 +19,16 @@ export interface TableView<Row extends TableRow> {
 export class Table<Row extends TableRow> {
   readonly #rows = reactive.Map<RowId, Row>("table rows");
 
+  #rowArray(): Row[] {
+    return [...this.#rows.values()];
+  }
+
   get size(): number {
     return this.#rows.size;
   }
 
   get rows(): readonly Row[] {
-    return [...this.#rows.values()];
+    return this.#rowArray();
   }
 
   clear(): void {
@@ -69,14 +73,14 @@ export class Table<Row extends TableRow> {
   }
 
   view(options: ViewOptions<Row> = {}): TableView<Row> {
-    let rows = this.rows;
+    let rows = this.#rowArray();
 
     if (options.filter) {
       rows = rows.filter(options.filter);
     }
 
     if (options.sort) {
-      rows = [...rows].sort(options.sort);
+      rows = rows.sort(options.sort);
     }
 
     return { rows, count: rows.length };
@@ -105,6 +109,7 @@ export interface InventoryStats {
 
 const EMPTY_COUNT = 0;
 const ONE_ITEM = 1;
+export const LOW_STOCK_THRESHOLD = 5;
 
 export class Inventory {
   readonly #table = createTable<InventoryItem>();
@@ -115,10 +120,11 @@ export class Inventory {
 
   get stats(): InventoryStats {
     const categories = new Map<InventoryCategory, number>();
+    const rows = this.rows;
     let inventoryValue = 0;
     let lowStockCount = 0;
 
-    for (const item of this.rows) {
+    for (const item of rows) {
       categories.set(
         item.category,
         (categories.get(item.category) ?? EMPTY_COUNT) + ONE_ITEM,
@@ -134,7 +140,7 @@ export class Inventory {
       categories,
       inventoryValue,
       lowStockCount,
-      totalItems: this.rows.length,
+      totalItems: rows.length,
     };
   }
 
@@ -195,8 +201,6 @@ export function createInventory(
 
   return inventory;
 }
-
-const LOW_STOCK_THRESHOLD = 5;
 
 function matchesInventoryFilters(
   item: InventoryItem,

--- a/demos/table-core/tests/table.spec.ts
+++ b/demos/table-core/tests/table.spec.ts
@@ -1,0 +1,121 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+import { CachedFormula } from "@starbeam/reactive";
+import { describe, expect, test } from "vitest";
+
+import type { InventoryItem, TableRow } from "../index.js";
+import { createInventory, createTable } from "../index.js";
+
+interface Todo extends TableRow {
+  readonly title: string;
+  readonly done: boolean;
+}
+
+const APPLES: InventoryItem = {
+  id: "apples",
+  name: "Apples",
+  category: "produce",
+  price: 1.25,
+  stock: 12,
+};
+
+const BREAD: InventoryItem = {
+  id: "bread",
+  name: "Bread",
+  category: "bakery",
+  price: 4,
+  stock: 3,
+};
+
+describe("Table", () => {
+  test("inserts, updates, deletes, and clears rows", () => {
+    const table = createTable<Todo>();
+
+    table.insert({ id: "write", title: "Write demo", done: false });
+    table.insert({ id: "ship", title: "Ship demo", done: false });
+
+    expect(table.size).toBe(2);
+    expect(table.get("write")?.title).toBe("Write demo");
+
+    table.update("write", (row) => ({ ...row, done: true }));
+    expect(table.get("write")?.done).toBe(true);
+
+    expect(table.delete("ship")).toBe(true);
+    expect(table.rows.map((row) => row.id)).toEqual(["write"]);
+
+    table.clear();
+    expect(table.size).toBe(0);
+  });
+
+  test("derived formulas update as rows change", () => {
+    const inventory = createInventory([APPLES, BREAD]);
+    const lowStockNames = CachedFormula(() => {
+      return inventory
+        .view({ lowStockOnly: true })
+        .rows.map((item) => item.name)
+        .join(", ");
+    });
+    const value = CachedFormula(() => inventory.stats.inventoryValue);
+
+    expect(lowStockNames.current).toBe("Bread");
+    expect(value.current).toBe(27);
+
+    inventory.restock("bread", 4);
+    expect(lowStockNames.current).toBe("");
+    expect(value.current).toBe(43);
+
+    inventory.delete("apples");
+    expect(value.current).toBe(28);
+  });
+
+  test("derived formulas update after clearing and repopulating", () => {
+    const inventory = createInventory([APPLES, BREAD]);
+    const names = CachedFormula(() => {
+      return inventory.rows.map((item) => item.name).join(", ");
+    });
+    const stats = CachedFormula(() => inventory.stats);
+
+    expect(names.current).toBe("Apples, Bread");
+    expect(stats.current.totalItems).toBe(2);
+
+    inventory.clear();
+
+    expect(names.current).toBe("");
+    expect(stats.current.totalItems).toBe(0);
+
+    inventory.add({
+      id: "milk",
+      name: "Milk",
+      category: "dairy",
+      price: 5,
+      stock: 6,
+    });
+
+    expect(names.current).toBe("Milk");
+    expect(stats.current.totalItems).toBe(1);
+    expect(stats.current.inventoryValue).toBe(30);
+  });
+
+  test("inventory views filter and sort the same core rows", () => {
+    const inventory = createInventory([
+      APPLES,
+      BREAD,
+      {
+        id: "milk",
+        name: "Milk",
+        category: "dairy",
+        price: 5,
+        stock: 6,
+      },
+    ]);
+
+    expect(
+      inventory.view({ category: "bakery" }).rows.map((item) => item.name),
+    ).toEqual(["Bread"]);
+
+    expect(
+      inventory.view({ sort: "stock" }).rows.map((item) => item.name),
+    ).toEqual(["Bread", "Milk", "Apples"]);
+
+    expect(inventory.stats.categories.get("produce")).toBe(1);
+  });
+});

--- a/demos/table-core/tsconfig.json
+++ b/demos/table-core/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../.config/tsconfig/tsconfig.shared.json",
+  "compilerOptions": {
+    "composite": true,
+    "types": ["../../packages/env.d.ts"],
+    "declaration": true,
+    "declarationDir": "../../dist/types",
+    "declarationMap": true,
+    "emitDeclarationOnly": true
+  },
+  "exclude": ["dist/**/*"]
+}

--- a/demos/table-core/vitest.config.mts
+++ b/demos/table-core/vitest.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.spec.ts"],
+  },
+});

--- a/demos/table-react/README.md
+++ b/demos/table-react/README.md
@@ -1,0 +1,11 @@
+# `@starbeam-demos/table-react`
+
+Playable React shell for the framework-neutral inventory table demo.
+
+```sh
+pnpm --filter @starbeam-demos/table-react dev
+```
+
+The React app imports the same `@starbeam-demos/table-core` model that other
+framework demos can use later. Filters, edits, deletes, and summary panels all
+read from the Starbeam-backed inventory model.

--- a/demos/table-react/index.html
+++ b/demos/table-react/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Starbeam Inventory Table Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/demos/table-react/package.json
+++ b/demos/table-react/package.json
@@ -1,0 +1,26 @@
+{
+  "private": true,
+  "name": "@starbeam-demos/table-react",
+  "type": "module",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite --host 0.0.0.0",
+    "preview": "vite preview --host 0.0.0.0",
+    "test:lint": "eslint . --max-warnings 0",
+    "test:types": "tsc -b"
+  },
+  "dependencies": {
+    "@fontsource/geist-sans": "^5.2.5",
+    "@starbeam/react": "workspace:^",
+    "@starbeam-demos/table-core": "workspace:*",
+    "@vitejs/plugin-react": "^4.7.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "vite": "^8.0.8"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3"
+  }
+}

--- a/demos/table-react/src/App.tsx
+++ b/demos/table-react/src/App.tsx
@@ -4,6 +4,7 @@ import type {
   InventoryItem,
   InventoryViewOptions,
 } from "@starbeam-demos/table-core";
+import { LOW_STOCK_THRESHOLD } from "@starbeam-demos/table-core";
 import type { JSX } from "react";
 import { useId, useState } from "react";
 
@@ -28,7 +29,7 @@ type SortMode = NonNullable<InventoryViewOptions["sort"]>;
 
 const NO_ITEMS = 0;
 const ONE_ITEM = 1;
-const LOW_STOCK_THRESHOLD = 5;
+let nextCustomItemId = 1;
 
 export function App(): JSX.Element {
   const [category, setCategory] = useState<CategoryFilter>("all");
@@ -55,8 +56,7 @@ export function App(): JSX.Element {
       return;
     }
 
-    const slug = name.toLowerCase().replaceAll(/[^a-z0-9]+/gu, "-");
-    const id = `${slug}-${Date.now()}`;
+    const id = createInventoryId(name);
 
     inventory.add({
       id,
@@ -213,6 +213,12 @@ export function App(): JSX.Element {
       </section>
     </main>
   );
+}
+
+function createInventoryId(name: string): string {
+  const slug = name.toLowerCase().replaceAll(/[^a-z0-9]+/gu, "-");
+
+  return `${slug}-${nextCustomItemId++}`;
 }
 
 function InventoryRow({ item }: { readonly item: InventoryItem }): JSX.Element {

--- a/demos/table-react/src/App.tsx
+++ b/demos/table-react/src/App.tsx
@@ -1,0 +1,342 @@
+import { useReactive } from "@starbeam/react";
+import type {
+  InventoryCategory,
+  InventoryItem,
+  InventoryViewOptions,
+} from "@starbeam-demos/table-core";
+import type { JSX } from "react";
+import { useId, useState } from "react";
+
+import { inventory, resetInventory } from "./demo.js";
+
+const CATEGORIES: readonly InventoryCategory[] = [
+  "produce",
+  "bakery",
+  "pantry",
+  "dairy",
+];
+
+const CATEGORY_LABELS = {
+  produce: "Produce",
+  bakery: "Bakery",
+  pantry: "Pantry",
+  dairy: "Dairy",
+} satisfies Record<InventoryCategory, string>;
+
+type CategoryFilter = InventoryCategory | "all";
+type SortMode = NonNullable<InventoryViewOptions["sort"]>;
+
+const NO_ITEMS = 0;
+const ONE_ITEM = 1;
+const LOW_STOCK_THRESHOLD = 5;
+
+export function App(): JSX.Element {
+  const [category, setCategory] = useState<CategoryFilter>("all");
+  const [lowStockOnly, setLowStockOnly] = useState(false);
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<SortMode>("name");
+  const [draftName, setDraftName] = useState("");
+
+  const view = useReactive(
+    () => inventory.view({ category, lowStockOnly, search, sort }),
+    [category, lowStockOnly, search, sort],
+  );
+  const stats = useReactive(() => inventory.stats);
+
+  const categoryCounts = CATEGORIES.map((itemCategory) => ({
+    category: itemCategory,
+    count: stats.categories.get(itemCategory) ?? NO_ITEMS,
+  }));
+
+  function addItem(): void {
+    const name = draftName.trim();
+
+    if (name === "") {
+      return;
+    }
+
+    const slug = name.toLowerCase().replaceAll(/[^a-z0-9]+/gu, "-");
+    const id = `${slug}-${Date.now()}`;
+
+    inventory.add({
+      id,
+      name,
+      category: "pantry",
+      price: 3,
+      stock: 1,
+    });
+    setDraftName("");
+  }
+
+  return (
+    <main className="shell">
+      <section className="hero">
+        <p className="eyebrow">Starbeam demo</p>
+        <h1>Reactive inventory table</h1>
+        <p>
+          The table model lives in a framework-neutral package. This React app
+          only renders it and calls model methods from event handlers.
+        </p>
+      </section>
+
+      <section className="stats" aria-label="Inventory summary">
+        <StatCard label="Items" value={stats.totalItems.toString()} />
+        <StatCard label="Low stock" value={stats.lowStockCount.toString()} />
+        <StatCard
+          label="Inventory value"
+          value={formatCurrency(stats.inventoryValue)}
+        />
+      </section>
+
+      <section className="panel controls" aria-label="Inventory controls">
+        <label>
+          Search
+          <input
+            value={search}
+            onChange={(event) => {
+              setSearch(event.currentTarget.value);
+            }}
+            placeholder="Filter by name"
+          />
+        </label>
+
+        <label>
+          Category
+          <select
+            value={category}
+            onChange={(event) => {
+              setCategory(event.currentTarget.value as CategoryFilter);
+            }}
+          >
+            <option value="all">All</option>
+            {CATEGORIES.map((itemCategory) => (
+              <option key={itemCategory} value={itemCategory}>
+                {CATEGORY_LABELS[itemCategory]}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Sort
+          <select
+            value={sort}
+            onChange={(event) => {
+              setSort(event.currentTarget.value as SortMode);
+            }}
+          >
+            <option value="name">Name</option>
+            <option value="category">Category</option>
+            <option value="stock">Stock</option>
+            <option value="value">Value</option>
+          </select>
+        </label>
+
+        <label className="checkbox">
+          <input
+            type="checkbox"
+            checked={lowStockOnly}
+            onChange={(event) => {
+              setLowStockOnly(event.currentTarget.checked);
+            }}
+          />
+          Low stock only
+        </label>
+
+        <button
+          className="button-secondary"
+          type="button"
+          onClick={resetInventory}
+        >
+          Restore data
+        </button>
+      </section>
+
+      <div className="supporting-panels">
+        <section className="panel add-item" aria-label="Add inventory item">
+          <label>
+            Add an item
+            <input
+              value={draftName}
+              onChange={(event) => {
+                setDraftName(event.currentTarget.value);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  addItem();
+                }
+              }}
+              placeholder="Item name"
+            />
+          </label>
+          <button className="button-primary" type="button" onClick={addItem}>
+            Add
+          </button>
+        </section>
+
+        <section className="panel category-counts" aria-label="Category counts">
+          <h2>Categories</h2>
+          <dl>
+            {categoryCounts.map(({ category: itemCategory, count }) => (
+              <div key={itemCategory}>
+                <dt>{CATEGORY_LABELS[itemCategory]}</dt>
+                <dd>{count}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+      </div>
+
+      <section className="panel table-panel">
+        <div className="table-header">
+          <h2>Inventory</h2>
+          <span>{formatItemCount(view.count)}</span>
+        </div>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Category</th>
+              <th>Price</th>
+              <th>Stock</th>
+              <th>Value</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {view.rows.map((item) => (
+              <InventoryRow key={item.id} item={item} />
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </main>
+  );
+}
+
+function InventoryRow({ item }: { readonly item: InventoryItem }): JSX.Element {
+  const categoryId = useId();
+  const priceId = useId();
+  const stockId = useId();
+  const isLowStock = item.stock <= LOW_STOCK_THRESHOLD;
+
+  function updateItem(updater: (item: InventoryItem) => InventoryItem): void {
+    inventory.update(item.id, updater);
+  }
+
+  return (
+    <tr className={isLowStock ? "is-low-stock" : undefined}>
+      <td>
+        <input
+          aria-label={`${item.name} name`}
+          value={item.name}
+          onChange={(event) => {
+            updateItem((current) => ({
+              ...current,
+              name: event.currentTarget.value,
+            }));
+          }}
+        />
+      </td>
+      <td>
+        <label className="sr-only" htmlFor={categoryId}>
+          {item.name} category
+        </label>
+        <select
+          id={categoryId}
+          value={item.category}
+          onChange={(event) => {
+            updateItem((current) => ({
+              ...current,
+              category: event.currentTarget.value as InventoryCategory,
+            }));
+          }}
+        >
+          {CATEGORIES.map((category) => (
+            <option key={category} value={category}>
+              {CATEGORY_LABELS[category]}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td>
+        <label className="sr-only" htmlFor={priceId}>
+          {item.name} price
+        </label>
+        <input
+          id={priceId}
+          type="number"
+          min="0"
+          step="0.25"
+          value={item.price}
+          onChange={(event) => {
+            updateItem((current) => ({
+              ...current,
+              price: Number(event.currentTarget.value),
+            }));
+          }}
+        />
+      </td>
+      <td>
+        <label className="sr-only" htmlFor={stockId}>
+          {item.name} stock
+        </label>
+        <input
+          id={stockId}
+          type="number"
+          min="0"
+          value={item.stock}
+          onChange={(event) => {
+            updateItem((current) => ({
+              ...current,
+              stock: Number(event.currentTarget.value),
+            }));
+          }}
+        />
+      </td>
+      <td>
+        <span className="row-value">
+          {formatCurrency(item.price * item.stock)}
+        </span>
+      </td>
+      <td>
+        <button
+          className="button-danger"
+          type="button"
+          onClick={() => {
+            inventory.delete(item.id);
+          }}
+        >
+          Delete
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+}: {
+  readonly label: string;
+  readonly value: string;
+}): JSX.Element {
+  return (
+    <article className="stat-card">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </article>
+  );
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en", {
+    currency: "USD",
+    style: "currency",
+  }).format(value);
+}
+
+function formatItemCount(count: number): string {
+  return count === ONE_ITEM ? "1 item shown" : `${count} items shown`;
+}

--- a/demos/table-react/src/demo.ts
+++ b/demos/table-react/src/demo.ts
@@ -1,0 +1,43 @@
+import type { InventoryItem } from "@starbeam-demos/table-core";
+import { createInventory } from "@starbeam-demos/table-core";
+
+export const STARTING_ITEMS: readonly InventoryItem[] = [
+  {
+    id: "apples",
+    name: "Apples",
+    category: "produce",
+    price: 1.25,
+    stock: 12,
+  },
+  {
+    id: "bread",
+    name: "Sourdough Bread",
+    category: "bakery",
+    price: 4,
+    stock: 3,
+  },
+  {
+    id: "coffee",
+    name: "Coffee Beans",
+    category: "pantry",
+    price: 14,
+    stock: 8,
+  },
+  {
+    id: "milk",
+    name: "Oat Milk",
+    category: "dairy",
+    price: 5,
+    stock: 6,
+  },
+];
+
+export const inventory = createInventory(STARTING_ITEMS);
+
+export function resetInventory(): void {
+  inventory.clear();
+
+  for (const item of STARTING_ITEMS) {
+    inventory.add(item);
+  }
+}

--- a/demos/table-react/src/fontsource.d.ts
+++ b/demos/table-react/src/fontsource.d.ts
@@ -1,0 +1,1 @@
+declare module "@fontsource/geist-sans";

--- a/demos/table-react/src/main.tsx
+++ b/demos/table-react/src/main.tsx
@@ -1,0 +1,19 @@
+import "@fontsource/geist-sans";
+import "./styles.css";
+
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App.js";
+
+const element = document.getElementById("root");
+
+if (!element) {
+  throw new Error("Missing #root element");
+}
+
+createRoot(element).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/demos/table-react/src/styles.css
+++ b/demos/table-react/src/styles.css
@@ -1,0 +1,451 @@
+:root {
+  --bg: #f7f2e9;
+  --card: rgba(255, 253, 248, 0.86);
+  --card-strong: #fffaf1;
+  --ink: #18251f;
+  --muted: #667167;
+  --faint: #948d7d;
+  --line: rgba(74, 61, 42, 0.14);
+  --green: #1e684f;
+  --green-dark: #134635;
+  --mint: #d9f8e7;
+  --gold: #d79a3b;
+  --rose: #a44945;
+  --radius: 4px;
+  --radius-tight: 2px;
+  --space-1: 0.35rem;
+  --space-2: 0.55rem;
+  --space-3: 0.8rem;
+  --space-4: 1rem;
+  --space-5: 1.35rem;
+  --space-6: 1.75rem;
+  --shadow:
+    0 1px 2px rgba(60, 45, 25, 0.08), 0 12px 30px rgba(60, 45, 25, 0.05);
+
+  background:
+    radial-gradient(
+      circle at top left,
+      rgba(221, 184, 108, 0.24),
+      transparent 34rem
+    ),
+    radial-gradient(
+      circle at 85% 12%,
+      rgba(65, 125, 92, 0.18),
+      transparent 28rem
+    ),
+    var(--bg);
+  color: var(--ink);
+  font-family:
+    Geist,
+    "Geist Sans",
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button {
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-tight);
+  background: rgba(255, 250, 241, 0.82);
+  color: var(--ink);
+  cursor: pointer;
+  display: inline-flex;
+  font-weight: 650;
+  justify-content: center;
+  min-height: 2.5rem;
+  padding: 0.58rem 0.85rem;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease,
+    box-shadow 160ms ease;
+}
+
+button:hover {
+  background: var(--card-strong);
+  border-color: rgba(74, 61, 42, 0.24);
+  transform: translateY(-1px);
+}
+
+button:active {
+  transform: translateY(0);
+}
+
+.button-primary {
+  background: var(--green);
+  border-color: var(--green);
+  box-shadow: 0 8px 18px rgba(30, 104, 79, 0.22);
+  color: white;
+  font-weight: 750;
+}
+
+.button-primary:hover {
+  background: var(--green-dark);
+  border-color: var(--green-dark);
+  box-shadow: 0 10px 22px rgba(30, 104, 79, 0.28);
+}
+
+.button-secondary {
+  background: rgba(255, 253, 248, 0.64);
+  border-color: rgba(74, 61, 42, 0.24);
+  color: var(--ink);
+  font-weight: 650;
+}
+
+.button-secondary:hover {
+  background: rgba(255, 253, 248, 0.92);
+  border-color: rgba(30, 104, 79, 0.32);
+  color: var(--green-dark);
+}
+
+.button-danger {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  color: var(--rose);
+  padding: 0.55rem 0.65rem;
+}
+
+.button-danger:hover {
+  background: rgba(164, 73, 69, 0.08);
+  border-color: rgba(164, 73, 69, 0.12);
+  box-shadow: none;
+  color: #7d332f;
+}
+
+input,
+select {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-tight);
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--ink);
+  min-height: 2.5rem;
+  padding: 0.56rem 0.68rem;
+  transition:
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    background 140ms ease;
+  width: 100%;
+}
+
+input::placeholder {
+  color: rgba(102, 113, 103, 0.74);
+  font-weight: 600;
+}
+
+input:focus,
+select:focus {
+  background: white;
+  border-color: rgba(30, 104, 79, 0.46);
+  box-shadow: 0 0 0 4px rgba(30, 104, 79, 0.12);
+  outline: none;
+}
+
+label {
+  color: var(--muted);
+  display: grid;
+  font-size: 0.84rem;
+  font-weight: 700;
+  gap: var(--space-1);
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+th,
+td {
+  border-bottom: 1px solid rgba(74, 61, 42, 0.1);
+  padding: 0.7rem 0.65rem;
+  text-align: left;
+}
+
+th {
+  color: var(--faint);
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+tbody tr {
+  transition: background 140ms ease;
+}
+
+tbody tr:hover {
+  background: rgba(30, 104, 79, 0.045);
+}
+
+tbody tr.is-low-stock {
+  background: rgba(215, 154, 59, 0.08);
+}
+
+tbody td:first-child {
+  font-weight: 700;
+}
+
+.shell {
+  display: grid;
+  gap: var(--space-4);
+  margin: 0 auto;
+  max-width: 1180px;
+  padding: clamp(0.9rem, 2.4vw, 2rem);
+}
+
+.hero {
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 36%),
+    radial-gradient(
+      circle at 80% 20%,
+      rgba(217, 248, 231, 0.28),
+      transparent 20rem
+    ),
+    linear-gradient(135deg, #18372f, #27694e 60%, #1e4f40);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  color: white;
+  overflow: hidden;
+  padding: clamp(1.15rem, 2.4vw, 1.9rem);
+  position: relative;
+}
+
+.hero::after {
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.12) 1px, transparent 1px);
+  background-size: 44px 44px;
+  content: "";
+  inset: 0;
+  mask-image: linear-gradient(90deg, transparent, black 46%, transparent);
+  opacity: 0.28;
+  pointer-events: none;
+  position: absolute;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 4vw, 3.45rem);
+  letter-spacing: -0.06em;
+  line-height: 0.95;
+  margin: 0;
+}
+
+.hero p {
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 1rem;
+  line-height: 1.55;
+  margin: var(--space-3) 0 0;
+  max-width: 39rem;
+  position: relative;
+  z-index: 1;
+}
+
+.eyebrow {
+  color: var(--mint);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  margin: 0 0 var(--space-2);
+  position: relative;
+  text-transform: uppercase;
+  z-index: 1;
+}
+
+.stats,
+.controls,
+.add-item,
+.supporting-panels {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.stats {
+  gap: var(--space-3);
+}
+
+.controls,
+.add-item {
+  align-items: end;
+}
+
+.controls > button,
+.add-item > button {
+  min-height: 2.5rem;
+}
+
+.controls > .button-secondary {
+  justify-self: start;
+}
+
+.controls {
+  column-gap: var(--space-5);
+  grid-template-columns:
+    minmax(13rem, 1.35fr) minmax(9rem, 0.9fr) minmax(9rem, 0.9fr)
+    minmax(8rem, auto) auto;
+  row-gap: var(--space-4);
+}
+
+.panel,
+.stat-card {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: var(--space-4);
+}
+
+.stat-card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.72), transparent),
+    var(--card-strong);
+  display: grid;
+  gap: var(--space-3);
+  min-height: 5.4rem;
+}
+
+.stat-card span,
+.table-header span {
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.stat-card strong {
+  font-size: clamp(1.65rem, 2.6vw, 2.1rem);
+  letter-spacing: -0.05em;
+  line-height: 1;
+}
+
+.checkbox {
+  align-items: center;
+  align-self: end;
+  display: flex;
+  gap: var(--space-2);
+  min-height: 2.5rem;
+  padding: 0;
+}
+
+.checkbox input {
+  accent-color: var(--green);
+  min-height: auto;
+  padding: 0;
+  width: 1rem;
+}
+
+.add-item {
+  align-content: start;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.supporting-panels {
+  align-items: start;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.category-counts {
+  align-content: start;
+  align-items: center;
+  column-gap: var(--space-4);
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  row-gap: var(--space-3);
+}
+
+.category-counts h2 {
+  font-size: 0.95rem;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.category-counts dl {
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0;
+}
+
+.category-counts div {
+  background: rgba(255, 250, 241, 0.54);
+  border: 1px solid rgba(74, 61, 42, 0.09);
+  border-radius: var(--radius-tight);
+  display: grid;
+  gap: var(--space-1);
+  padding: var(--space-2);
+}
+
+.category-counts dt {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 650;
+}
+
+.category-counts dd {
+  color: var(--ink);
+  font-size: 1.14rem;
+  font-weight: 750;
+  line-height: 1;
+  margin: 0;
+}
+
+.table-panel {
+  overflow-x: auto;
+  padding: var(--space-5);
+}
+
+.table-header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: var(--space-5);
+}
+
+.table-header h2 {
+  font-size: 1.15rem;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+
+@media (max-width: 900px) {
+  .controls,
+  .supporting-panels {
+    grid-template-columns: 1fr;
+  }
+
+  .controls > .button-secondary {
+    justify-self: stretch;
+  }
+}
+
+.row-value {
+  color: var(--green-dark);
+  font-weight: 750;
+}
+
+.sr-only {
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/demos/table-react/tsconfig.json
+++ b/demos/table-react/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../.config/tsconfig/tsconfig.shared.json",
+  "compilerOptions": {
+    "composite": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "types": ["../../packages/env.d.ts"],
+    "noEmit": true
+  },
+  "include": ["src/**/*", "vite.config.mjs"],
+  "references": [{ "path": "../table-core/tsconfig.json" }]
+}

--- a/demos/table-react/vite.config.mjs
+++ b/demos/table-react/vite.config.mjs
@@ -1,0 +1,6 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -51,13 +51,15 @@ export default [
     files: [
       "packages/**/*.ts",
       "packages/**/*.tsx",
+      "demos/**/*.ts",
+      "demos/**/*.tsx",
       "workspace/**/*.ts",
       "workspace/**/*.mts",
       "@types/**/*.ts",
     ],
   }),
 
-  ...esmConfig({ files: ["**/rollup.config.{mjs,js}"] }),
+  ...esmConfig({ files: ["**/rollup.config.{mjs,js}", "**/vite.config.mjs"] }),
 
   ...tight({ files: ["vitest.*.{mts,ts}"] }),
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,50 @@ importers:
         specifier: ^4.1.4
         version: 4.1.4(@edge-runtime/vm@5.0.0)(@types/node@25.6.0)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  demos/table-core:
+    dependencies:
+      '@starbeam/collections':
+        specifier: workspace:^
+        version: link:../../packages/universal/collections
+    devDependencies:
+      '@starbeam/reactive':
+        specifier: workspace:^
+        version: link:../../packages/universal/reactive
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@edge-runtime/vm@5.0.0)(@types/node@25.6.0)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  demos/table-react:
+    dependencies:
+      '@fontsource/geist-sans':
+        specifier: ^5.2.5
+        version: 5.2.5
+      '@starbeam-demos/table-core':
+        specifier: workspace:*
+        version: link:../table-core
+      '@starbeam/react':
+        specifier: workspace:^
+        version: link:../../packages/react/react
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      vite:
+        specifier: ^8.0.8
+        version: 8.0.13(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+
   packages/ember/ember:
     dependencies:
       '@starbeam/interfaces':
@@ -3138,6 +3182,9 @@ packages:
   '@faker-js/faker@10.4.0':
     resolution: {integrity: sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==}
     engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
+
+  '@fontsource/geist-sans@5.2.5':
+    resolution: {integrity: sha512-anllOHyJbElRs9fV15TeDRqAeb1IKm4bSknPl6ZMoyPTx1BBy7logudcUwpNjmQLkzn4Q0JGQLRCUKJYoyST6A==}
 
   '@gar/promise-retry@1.0.3':
     resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
@@ -11768,6 +11815,8 @@ snapshots:
       '@expressive-code/core': 0.41.7
 
   '@faker-js/faker@10.4.0': {}
+
+  '@fontsource/geist-sans@5.2.5': {}
 
   '@gar/promise-retry@1.0.3': {}
 


### PR DESCRIPTION
## Why

Starbeam needs playable demos that show how a reactive model can feel like ordinary data mutation while the UI updates automatically.

## What changed

- Added `@starbeam-demos/table-core`, a framework-neutral reactive table model with an inventory wrapper.
- Added `@starbeam-demos/table-react`, a React/Vite shell that renders and mutates the shared model with `useReactive()`.
- Included the demo packages in workspace lint/type coverage.

## Reviewer notes

This PR is the first demo slice. #312 adds a Preact shell on top of the same `@starbeam-demos/table-core` package.

## User-facing changes

Adds a playable React inventory table demo under `demos/table-react`.
