### PR TITLE
Add Preact table demo

### DIFF
--- a/demos/table-preact/README.md
+++ b/demos/table-preact/README.md
@@ -1,0 +1,11 @@
+# `@starbeam-demos/table-preact`
+
+Playable Preact shell for the framework-neutral inventory table demo.
+
+```sh
+pnpm --filter @starbeam-demos/table-preact dev
+```
+
+The Preact app imports the same `@starbeam-demos/table-core` model as the React
+demo. Components read the Starbeam-backed inventory directly during render;
+`@starbeam/preact` tracks those render reads after the adapter is installed.

--- a/demos/table-preact/index.html
+++ b/demos/table-preact/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Starbeam Preact Inventory Table Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/demos/table-preact/package.json
+++ b/demos/table-preact/package.json
@@ -14,7 +14,7 @@
     "@fontsource/geist-sans": "^5.2.5",
     "@starbeam/preact": "workspace:^",
     "@starbeam-demos/table-core": "workspace:*",
-    "preact": "^10.29.1",
+    "preact": "10.29.1",
     "vite": "^8.0.8"
   }
 }

--- a/demos/table-preact/package.json
+++ b/demos/table-preact/package.json
@@ -1,0 +1,20 @@
+{
+  "private": true,
+  "name": "@starbeam-demos/table-preact",
+  "type": "module",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite --host 0.0.0.0",
+    "preview": "vite preview --host 0.0.0.0",
+    "test:lint": "eslint . --max-warnings 0",
+    "test:types": "tsc -b"
+  },
+  "dependencies": {
+    "@fontsource/geist-sans": "^5.2.5",
+    "@starbeam/preact": "workspace:^",
+    "@starbeam-demos/table-core": "workspace:*",
+    "preact": "^10.29.1",
+    "vite": "^8.0.8"
+  }
+}

--- a/demos/table-preact/src/App.tsx
+++ b/demos/table-preact/src/App.tsx
@@ -1,0 +1,351 @@
+import type {
+  InventoryCategory,
+  InventoryItem,
+  InventoryViewOptions,
+} from "@starbeam-demos/table-core";
+import type { VNode } from "preact";
+import { useState } from "preact/hooks";
+
+import { inventory, resetInventory } from "./demo.js";
+
+const CATEGORIES: readonly InventoryCategory[] = [
+  "produce",
+  "bakery",
+  "pantry",
+  "dairy",
+];
+
+const CATEGORY_LABELS = {
+  produce: "Produce",
+  bakery: "Bakery",
+  pantry: "Pantry",
+  dairy: "Dairy",
+} satisfies Record<InventoryCategory, string>;
+
+type CategoryFilter = InventoryCategory | "all";
+type SortMode = NonNullable<InventoryViewOptions["sort"]>;
+
+const NO_ITEMS = 0;
+const ONE_ITEM = 1;
+const LOW_STOCK_THRESHOLD = 5;
+
+export function App(): VNode {
+  const [category, setCategory] = useState<CategoryFilter>("all");
+  const [lowStockOnly, setLowStockOnly] = useState(false);
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<SortMode>("name");
+  const [draftName, setDraftName] = useState("");
+
+  const view = inventory.view({ category, lowStockOnly, search, sort });
+  const stats = inventory.stats;
+
+  const categoryCounts = CATEGORIES.map((itemCategory) => ({
+    category: itemCategory,
+    count: stats.categories.get(itemCategory) ?? NO_ITEMS,
+  }));
+
+  function addItem(): void {
+    const name = draftName.trim();
+
+    if (name === "") {
+      return;
+    }
+
+    const slug = name.toLowerCase().replaceAll(/[^a-z0-9]+/gu, "-");
+    const id = `${slug}-${Date.now()}`;
+
+    inventory.add({
+      id,
+      name,
+      category: "pantry",
+      price: 3,
+      stock: 1,
+    });
+    setDraftName("");
+  }
+
+  return (
+    <main className="shell">
+      <section className="hero">
+        <p className="eyebrow">Starbeam demo</p>
+        <h1>Reactive inventory table</h1>
+        <p>
+          The table model lives in a framework-neutral package. This Preact app
+          reads it directly during render and calls model methods from event
+          handlers.
+        </p>
+      </section>
+
+      <section className="stats" aria-label="Inventory summary">
+        <StatCard label="Items" value={stats.totalItems.toString()} />
+        <StatCard label="Low stock" value={stats.lowStockCount.toString()} />
+        <StatCard
+          label="Inventory value"
+          value={formatCurrency(stats.inventoryValue)}
+        />
+      </section>
+
+      <section className="panel controls" aria-label="Inventory controls">
+        <label>
+          Search
+          <input
+            value={search}
+            onInput={(event) => {
+              setSearch(inputValue(event));
+            }}
+            placeholder="Filter by name"
+          />
+        </label>
+
+        <label>
+          Category
+          <select
+            value={category}
+            onChange={(event) => {
+              setCategory(selectValue(event) as CategoryFilter);
+            }}
+          >
+            <option value="all">All</option>
+            {CATEGORIES.map((itemCategory) => (
+              <option key={itemCategory} value={itemCategory}>
+                {CATEGORY_LABELS[itemCategory]}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Sort
+          <select
+            value={sort}
+            onChange={(event) => {
+              setSort(selectValue(event) as SortMode);
+            }}
+          >
+            <option value="name">Name</option>
+            <option value="category">Category</option>
+            <option value="stock">Stock</option>
+            <option value="value">Value</option>
+          </select>
+        </label>
+
+        <label className="checkbox">
+          <input
+            type="checkbox"
+            checked={lowStockOnly}
+            onChange={(event) => {
+              setLowStockOnly(checkedValue(event));
+            }}
+          />
+          Low stock only
+        </label>
+
+        <button
+          className="button-secondary"
+          type="button"
+          onClick={resetInventory}
+        >
+          Restore data
+        </button>
+      </section>
+
+      <div className="supporting-panels">
+        <section className="panel add-item" aria-label="Add inventory item">
+          <label>
+            Add an item
+            <input
+              value={draftName}
+              onInput={(event) => {
+                setDraftName(inputValue(event));
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  addItem();
+                }
+              }}
+              placeholder="Item name"
+            />
+          </label>
+          <button className="button-primary" type="button" onClick={addItem}>
+            Add
+          </button>
+        </section>
+
+        <section className="panel category-counts" aria-label="Category counts">
+          <h2>Categories</h2>
+          <dl>
+            {categoryCounts.map(({ category: itemCategory, count }) => (
+              <div key={itemCategory}>
+                <dt>{CATEGORY_LABELS[itemCategory]}</dt>
+                <dd>{count}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+      </div>
+
+      <section className="panel table-panel">
+        <div className="table-header">
+          <h2>Inventory</h2>
+          <span>{formatItemCount(view.count)}</span>
+        </div>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Category</th>
+              <th>Price</th>
+              <th>Stock</th>
+              <th>Value</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {view.rows.map((item) => (
+              <InventoryRow key={item.id} item={item} />
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </main>
+  );
+}
+
+function InventoryRow({ item }: { readonly item: InventoryItem }): VNode {
+  const categoryId = `${item.id}-category`;
+  const priceId = `${item.id}-price`;
+  const stockId = `${item.id}-stock`;
+  const isLowStock = item.stock <= LOW_STOCK_THRESHOLD;
+
+  function updateItem(updater: (item: InventoryItem) => InventoryItem): void {
+    inventory.update(item.id, updater);
+  }
+
+  return (
+    <tr className={isLowStock ? "is-low-stock" : undefined}>
+      <td>
+        <input
+          aria-label={`${item.name} name`}
+          value={item.name}
+          onInput={(event) => {
+            updateItem((current) => ({
+              ...current,
+              name: inputValue(event),
+            }));
+          }}
+        />
+      </td>
+      <td>
+        <label className="sr-only" htmlFor={categoryId}>
+          {item.name} category
+        </label>
+        <select
+          id={categoryId}
+          value={item.category}
+          onChange={(event) => {
+            updateItem((current) => ({
+              ...current,
+              category: selectValue(event) as InventoryCategory,
+            }));
+          }}
+        >
+          {CATEGORIES.map((category) => (
+            <option key={category} value={category}>
+              {CATEGORY_LABELS[category]}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td>
+        <label className="sr-only" htmlFor={priceId}>
+          {item.name} price
+        </label>
+        <input
+          id={priceId}
+          type="number"
+          min="0"
+          step="0.25"
+          value={item.price}
+          onInput={(event) => {
+            updateItem((current) => ({
+              ...current,
+              price: Number(inputValue(event)),
+            }));
+          }}
+        />
+      </td>
+      <td>
+        <label className="sr-only" htmlFor={stockId}>
+          {item.name} stock
+        </label>
+        <input
+          id={stockId}
+          type="number"
+          min="0"
+          value={item.stock}
+          onInput={(event) => {
+            updateItem((current) => ({
+              ...current,
+              stock: Number(inputValue(event)),
+            }));
+          }}
+        />
+      </td>
+      <td>
+        <span className="row-value">
+          {formatCurrency(item.price * item.stock)}
+        </span>
+      </td>
+      <td>
+        <button
+          className="button-danger"
+          type="button"
+          onClick={() => {
+            inventory.delete(item.id);
+          }}
+        >
+          Delete
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+}: {
+  readonly label: string;
+  readonly value: string;
+}): VNode {
+  return (
+    <article className="stat-card">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </article>
+  );
+}
+
+function inputValue(event: Event): string {
+  return (event.currentTarget as HTMLInputElement).value;
+}
+
+function selectValue(event: Event): string {
+  return (event.currentTarget as HTMLSelectElement).value;
+}
+
+function checkedValue(event: Event): boolean {
+  return (event.currentTarget as HTMLInputElement).checked;
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en", {
+    currency: "USD",
+    style: "currency",
+  }).format(value);
+}
+
+function formatItemCount(count: number): string {
+  return count === ONE_ITEM ? "1 item shown" : `${count} items shown`;
+}

--- a/demos/table-preact/src/App.tsx
+++ b/demos/table-preact/src/App.tsx
@@ -3,6 +3,7 @@ import type {
   InventoryItem,
   InventoryViewOptions,
 } from "@starbeam-demos/table-core";
+import { LOW_STOCK_THRESHOLD } from "@starbeam-demos/table-core";
 import type { VNode } from "preact";
 import { useState } from "preact/hooks";
 
@@ -27,7 +28,7 @@ type SortMode = NonNullable<InventoryViewOptions["sort"]>;
 
 const NO_ITEMS = 0;
 const ONE_ITEM = 1;
-const LOW_STOCK_THRESHOLD = 5;
+let nextCustomItemId = 1;
 
 export function App(): VNode {
   const [category, setCategory] = useState<CategoryFilter>("all");
@@ -51,8 +52,7 @@ export function App(): VNode {
       return;
     }
 
-    const slug = name.toLowerCase().replaceAll(/[^a-z0-9]+/gu, "-");
-    const id = `${slug}-${Date.now()}`;
+    const id = createInventoryId(name);
 
     inventory.add({
       id,
@@ -210,6 +210,12 @@ export function App(): VNode {
       </section>
     </main>
   );
+}
+
+function createInventoryId(name: string): string {
+  const slug = name.toLowerCase().replaceAll(/[^a-z0-9]+/gu, "-");
+
+  return `${slug}-${nextCustomItemId++}`;
 }
 
 function InventoryRow({ item }: { readonly item: InventoryItem }): VNode {

--- a/demos/table-preact/src/demo.ts
+++ b/demos/table-preact/src/demo.ts
@@ -1,0 +1,43 @@
+import type { InventoryItem } from "@starbeam-demos/table-core";
+import { createInventory } from "@starbeam-demos/table-core";
+
+export const STARTING_ITEMS: readonly InventoryItem[] = [
+  {
+    id: "apples",
+    name: "Apples",
+    category: "produce",
+    price: 1.25,
+    stock: 12,
+  },
+  {
+    id: "bread",
+    name: "Sourdough Bread",
+    category: "bakery",
+    price: 4,
+    stock: 3,
+  },
+  {
+    id: "coffee",
+    name: "Coffee Beans",
+    category: "pantry",
+    price: 14,
+    stock: 8,
+  },
+  {
+    id: "milk",
+    name: "Oat Milk",
+    category: "dairy",
+    price: 5,
+    stock: 6,
+  },
+];
+
+export const inventory = createInventory(STARTING_ITEMS);
+
+export function resetInventory(): void {
+  inventory.clear();
+
+  for (const item of STARTING_ITEMS) {
+    inventory.add(item);
+  }
+}

--- a/demos/table-preact/src/fontsource.d.ts
+++ b/demos/table-preact/src/fontsource.d.ts
@@ -1,0 +1,1 @@
+declare module "@fontsource/geist-sans";

--- a/demos/table-preact/src/main.tsx
+++ b/demos/table-preact/src/main.tsx
@@ -1,0 +1,17 @@
+import "@fontsource/geist-sans";
+import "./styles.css";
+
+import { install } from "@starbeam/preact";
+import { options, render } from "preact";
+
+import { App } from "./App.js";
+
+install(options);
+
+const element = document.getElementById("root");
+
+if (!element) {
+  throw new Error("Missing #root element");
+}
+
+render(<App />, element);

--- a/demos/table-preact/src/styles.css
+++ b/demos/table-preact/src/styles.css
@@ -1,0 +1,1 @@
+@import "../../table-react/src/styles.css";

--- a/demos/table-preact/tsconfig.json
+++ b/demos/table-preact/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../.config/tsconfig/tsconfig.shared.json",
+  "compilerOptions": {
+    "composite": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "types": ["../../packages/env.d.ts"],
+    "noEmit": true
+  },
+  "include": ["src/**/*", "vite.config.mjs"],
+  "references": [{ "path": "../table-core/tsconfig.json" }]
+}

--- a/demos/table-preact/vite.config.mjs
+++ b/demos/table-preact/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+    jsxImportSource: "preact",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,24 @@ importers:
         specifier: ^4.1.4
         version: 4.1.4(@edge-runtime/vm@5.0.0)(@types/node@25.6.0)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  demos/table-preact:
+    dependencies:
+      '@fontsource/geist-sans':
+        specifier: ^5.2.5
+        version: 5.2.5
+      '@starbeam-demos/table-core':
+        specifier: workspace:*
+        version: link:../table-core
+      '@starbeam/preact':
+        specifier: workspace:^
+        version: link:../../packages/preact/preact
+      preact:
+        specifier: 10.29.1
+        version: 10.29.1
+      vite:
+        specifier: ^8.0.8
+        version: 8.0.13(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   demos/table-react:
     dependencies:
       '@fontsource/geist-sans':
@@ -13474,7 +13492,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@edge-runtime/vm@5.0.0)(@types/node@25.6.0)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@edge-runtime/vm@5.0.0)(@types/node@25.6.0)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@3.2.4':
     dependencies:


### PR DESCRIPTION
## Why

The demo should make it obvious that the same Starbeam model works across framework adapters.

## What changed

- Added `@starbeam-demos/table-preact`, a Preact/Vite shell for the inventory table demo.
- Installed `@starbeam/preact` at the app boundary and read the shared inventory model directly during render.
- Reused the same inventory UI so the framework difference stays focused on the adapter edge.

## Reviewer notes

#311 is merged; this PR now targets `main` and should only show the Preact shell plus its lockfile entry.

## User-facing changes

Adds a playable Preact inventory table demo under `demos/table-preact`.
