### PR TITLE
Run CI on main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [main]
   merge_group:
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
## Why

The repository default branch is `main`, but the CI workflow still only listened for pushes to `master`. That means post-merge pushes to the default branch do not trigger CI from the `push` event.

## What changed

- Updated the CI `push` branch filter from `master` to `main`.

## Reviewer notes

This probably does not explain the Copilot Code Review 401 by itself. The Copilot failure happens in GitHub's dynamic `Copilot` workflow while calling Copilot/SWE agent APIs, not in this repository's CI workflow. This change still fixes a stale default-branch configuration issue.

## User-facing changes

None.