### PR TITLE
Tighten framework demo docs coherence

### DIFF
--- a/workspace/docs/src/content/docs/frameworks/overview.md
+++ b/workspace/docs/src/content/docs/frameworks/overview.md
@@ -1,14 +1,14 @@
 ---
 title: Framework guides
-description: "Starbeam's framework adapters connect the same reactive model to React, Preact, Ember, Vue, and Svelte as each adapter matures."
+description: "Starbeam's framework adapters connect the same reactive model to React, Preact, Vue, Svelte, and Ember as each adapter matures."
 ---
 
 Starbeam's state model is framework-neutral. Framework adapters make it feel
 native by connecting Starbeam's reactive model to each framework's rendering and
 lifecycle rules.
 
-The goal is not one framework with incidental ports. React, Preact, Ember, Vue,
-and Svelte are public docs targets, with adapter coverage maturing at different
+The goal is not one framework with incidental ports. React, Preact, Vue, Svelte,
+and Ember are public docs targets, with adapter coverage maturing at different
 speeds.
 
 ## Same model, native edges
@@ -30,8 +30,9 @@ Svelte.
 Need the package list first? Start with [Install Starbeam](/start/install/).
 
 Want to see the same model running inside the docs site? The
-[inventory table demo](/demos/inventory-table/) embeds React and Preact versions
-that both use the same `@starbeam-demos/table-core` package.
+[inventory table demo](/demos/inventory-table/) embeds React, Preact, Vue,
+Svelte, and Ember shells that all use the same `@starbeam-demos/table-core`
+package. The model stays unchanged; each tab shows the framework edge.
 
 ## Guides
 
@@ -39,13 +40,13 @@ that both use the same `@starbeam-demos/table-core` package.
   services, and element resources.
 - [**Preact**](/frameworks/preact/): adapter installation, reactive reads,
   resources, services, and element resources.
-- [**Ember**](/frameworks/ember/): native Glimmer autotracking for Starbeam
-  reads, plus resources, services, and element resources.
 - [**Vue**](/frameworks/vue/): setup helpers and directives for reactive state,
   resources, services, and element resources.
-- [**Svelte**](/frameworks/svelte/): current Svelte 5 slice with experimental
+- [**Svelte**](/frameworks/svelte/): Svelte 5 adapter with experimental
   `fromStarbeam()` reads and element-resource attachments. Component-resource and
   service helpers are not exposed yet.
+- [**Ember**](/frameworks/ember/): native Glimmer autotracking for Starbeam
+  reads, plus resources, services, and element resources.
 
 Some guide details may mature at different speeds. The top-level posture stays
 the same: Starbeam is designed to make the same domain-shaped reactive model work

--- a/workspace/docs/src/content/docs/reference/framework-adapters.md
+++ b/workspace/docs/src/content/docs/reference/framework-adapters.md
@@ -1,6 +1,6 @@
 ---
 title: Framework adapters
-description: "Reference for Starbeam's React, Preact, Ember, Vue, and Svelte adapter surfaces."
+description: "Reference for Starbeam's React, Preact, Vue, Svelte, and Ember adapter surfaces."
 ---
 
 Framework adapters connect Starbeam reads, resources, services, and element

--- a/workspace/docs/src/content/docs/start/install.md
+++ b/workspace/docs/src/content/docs/start/install.md
@@ -104,6 +104,25 @@ Vue uses `useReactive()` for direct template reads, `setupReactive()` when you
 want a specific Starbeam read as a Vue ref, and directives for element resources:
 [Vue](/frameworks/vue/).
 
+### Svelte
+
+```sh
+pnpm add @starbeam/svelte @starbeam/universal @starbeam/collections
+```
+
+```ts
+import {
+  elementResource,
+  elementResourceAttachment,
+  elementResourceStore,
+  fromStarbeam,
+} from "@starbeam/svelte";
+```
+
+Svelte currently exposes experimental Starbeam reads through `fromStarbeam()` and
+DOM element resources through Svelte 5 element-resource attachments. Component-resource and
+app-service helpers are not exposed yet. See [Svelte](/frameworks/svelte/).
+
 ### Ember
 
 ```sh
@@ -122,25 +141,6 @@ Ember's adapter mirrors Starbeam reads into Glimmer autotracking, so templates
 and getters can read Starbeam-backed domain objects directly. Use
 `setupResource()` for component-owned resources, `setupService()` for
 owner-scoped services, and modifiers for element resources: [Ember](/frameworks/ember/).
-
-### Svelte
-
-```sh
-pnpm add @starbeam/svelte @starbeam/universal @starbeam/collections
-```
-
-```ts
-import {
-  elementResource,
-  elementResourceAttachment,
-  elementResourceStore,
-  fromStarbeam,
-} from "@starbeam/svelte";
-```
-
-Svelte currently exposes experimental Starbeam reads through `fromStarbeam()` and
-DOM element resources through Svelte 5 attachments. Component-resource and
-app-service helpers are not exposed yet. See [Svelte](/frameworks/svelte/).
 
 ## Direct packages
 

--- a/workspace/docs/src/content/docs/start/install.md
+++ b/workspace/docs/src/content/docs/start/install.md
@@ -8,15 +8,15 @@ Install the packages you import directly. Most apps need one framework adapter,
 
 ## What are you building?
 
-| If you are building…      | Install…                                                     | Start with…                                                                            |
-| ------------------------- | ------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| A framework-neutral model | `@starbeam/universal @starbeam/collections`                  | `reactive` collections, domain objects, and `Resource`                                 |
-| A React app               | `@starbeam/react @starbeam/universal @starbeam/collections`  | `useReactive()`, `useResource()`, `useService()`, `useElementResource()`               |
-| A Preact app              | `@starbeam/preact @starbeam/universal @starbeam/collections` | `install(options)`, direct render reads, resource/service hooks                        |
-| An Ember app              | `@starbeam/ember @starbeam/universal @starbeam/collections`  | direct Glimmer-tracked reads, `setupResource()`, `setupService()`, element modifiers   |
-| A Vue app                 | `@starbeam/vue @starbeam/universal @starbeam/collections`    | `useReactive()`, `setupResource()`, `setupService()`, element-resource directives      |
-| A Svelte app              | `@starbeam/svelte @starbeam/universal @starbeam/collections` | current Svelte 5 slice: experimental `fromStarbeam()` and element-resource attachments |
-| A reusable library        | `@starbeam/universal @starbeam/collections`                  | framework-neutral state and domain-shaped APIs                                         |
+| If you are building…      | Install…                                                     | Start with…                                                                          |
+| ------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| A framework-neutral model | `@starbeam/universal @starbeam/collections`                  | `reactive` collections, domain objects, and `Resource`                               |
+| A React app               | `@starbeam/react @starbeam/universal @starbeam/collections`  | `useReactive()`, `useResource()`, `useService()`, `useElementResource()`             |
+| A Preact app              | `@starbeam/preact @starbeam/universal @starbeam/collections` | `install(options)`, direct render reads, resource/service hooks                      |
+| An Ember app              | `@starbeam/ember @starbeam/universal @starbeam/collections`  | direct Glimmer-tracked reads, `setupResource()`, `setupService()`, element modifiers |
+| A Vue app                 | `@starbeam/vue @starbeam/universal @starbeam/collections`    | `useReactive()`, `setupResource()`, `setupService()`, element-resource directives    |
+| A Svelte app              | `@starbeam/svelte @starbeam/universal @starbeam/collections` | Svelte 5 read bridge: experimental `fromStarbeam()` and element-resource attachments |
+| A reusable library        | `@starbeam/universal @starbeam/collections`                  | framework-neutral state and domain-shaped APIs                                       |
 
 ## Framework-neutral state
 

--- a/workspace/docs/src/content/docs/start/install.md
+++ b/workspace/docs/src/content/docs/start/install.md
@@ -13,9 +13,9 @@ Install the packages you import directly. Most apps need one framework adapter,
 | A framework-neutral model | `@starbeam/universal @starbeam/collections`                  | `reactive` collections, domain objects, and `Resource`                               |
 | A React app               | `@starbeam/react @starbeam/universal @starbeam/collections`  | `useReactive()`, `useResource()`, `useService()`, `useElementResource()`             |
 | A Preact app              | `@starbeam/preact @starbeam/universal @starbeam/collections` | `install(options)`, direct render reads, resource/service hooks                      |
-| An Ember app              | `@starbeam/ember @starbeam/universal @starbeam/collections`  | direct Glimmer-tracked reads, `setupResource()`, `setupService()`, element modifiers |
 | A Vue app                 | `@starbeam/vue @starbeam/universal @starbeam/collections`    | `useReactive()`, `setupResource()`, `setupService()`, element-resource directives    |
 | A Svelte app              | `@starbeam/svelte @starbeam/universal @starbeam/collections` | Svelte 5 read bridge: experimental `fromStarbeam()` and element-resource attachments |
+| An Ember app              | `@starbeam/ember @starbeam/universal @starbeam/collections`  | direct Glimmer-tracked reads, `setupResource()`, `setupService()`, element modifiers |
 | A reusable library        | `@starbeam/universal @starbeam/collections`                  | framework-neutral state and domain-shaped APIs                                       |
 
 ## Framework-neutral state

--- a/workspace/docs/src/pages/demos/index.astro
+++ b/workspace/docs/src/pages/demos/index.astro
@@ -50,8 +50,9 @@ import "../../styles/tokens.css";
           <span class="demo-card__status">React + Preact + Vue + Svelte + Ember</span>
           <h3>Inventory table</h3>
           <p>
-            Edit rows, filter stock, add items, and watch derived table state stay
-            current through the same shared Starbeam model.
+            Compare the same inventory model in React, Preact, Vue, Svelte, and
+            Ember. Edit rows, filter stock, add items, and watch derived table
+            state stay current through the shared Starbeam model.
           </p>
           <span class="demo-card__cta">Open demo</span>
         </a>

--- a/workspace/docs/src/pages/demos/inventory-table.astro
+++ b/workspace/docs/src/pages/demos/inventory-table.astro
@@ -42,7 +42,7 @@ const SOURCE_URLS = {
     <title>Inventory table demo · Starbeam</title>
     <meta
       name="description"
-      content="A Starbeam inventory table demo embedded in the docs with React, Preact, Vue, and Svelte shells."
+      content="A Starbeam inventory table demo embedded in the docs with React, Preact, Vue, Svelte, and Ember shells."
     />
   </head>
   <body>
@@ -75,7 +75,7 @@ const SOURCE_URLS = {
         label="Shared source"
         title="Table model"
         path="@starbeam-demos/table-core/src/table.ts"
-        hint="React, Preact, Vue, Svelte, and future shells import this package."
+        hint="React, Preact, Vue, Svelte, and Ember shells import this package."
       >
         <p>
           Ordinary TypeScript owns the table state. The framework shells only
@@ -99,7 +99,7 @@ const SOURCE_URLS = {
       <div class="docs-demo-heading-row">
         <div>
           <p class="docs-demo-label">Framework shells</p>
-          <h2 id="framework-demo-heading">Same model, different adapter.</h2>
+          <h2 id="framework-demo-heading">Same model, five framework edges.</h2>
         </div>
       </div>
 

--- a/workspace/docs/src/pages/index.astro
+++ b/workspace/docs/src/pages/index.astro
@@ -180,9 +180,9 @@ import "../styles/tokens.css";
               <span aria-hidden="true">Svelte</span>
               <h3>Svelte</h3>
               <p>
-                The current Svelte 5 slice exposes experimental
-                <code>fromStarbeam()</code> reads, and element resources work
-                through Svelte attachments today.
+                The Svelte 5 adapter exposes experimental
+                <code>fromStarbeam()</code> reads today, while element resources
+                attach through Svelte attachments.
               </p>
             </a>
           </div>

--- a/workspace/docs/src/pages/index.astro
+++ b/workspace/docs/src/pages/index.astro
@@ -167,6 +167,15 @@ import "../styles/tokens.css";
                 services, and element resources to Vue components.
               </p>
             </a>
+            <a class="adapter-card" href="/frameworks/svelte/">
+              <span aria-hidden="true">Svelte</span>
+              <h3>Svelte</h3>
+              <p>
+                The Svelte 5 adapter exposes experimental
+                <code>fromStarbeam()</code> reads today, while element resources
+                attach through element-resource attachments.
+              </p>
+            </a>
             <a class="adapter-card" href="/frameworks/ember/">
               <span aria-hidden="true">Ember</span>
               <h3>Ember</h3>
@@ -174,15 +183,6 @@ import "../styles/tokens.css";
                 Glimmer autotracking sees Starbeam reads directly, while
                 helpers and modifiers connect resources, services, and element
                 resources to Ember lifetimes.
-              </p>
-            </a>
-            <a class="adapter-card" href="/frameworks/svelte/">
-              <span aria-hidden="true">Svelte</span>
-              <h3>Svelte</h3>
-              <p>
-                The Svelte 5 adapter exposes experimental
-                <code>fromStarbeam()</code> reads today, while element resources
-                attach through Svelte attachments.
               </p>
             </a>
           </div>


### PR DESCRIPTION
## Why

The five-framework demo arc is complete (React, Preact, Vue, Svelte, Ember), but several docs pages still described the older state — "React and Preact" embeds, "future shells", and an inconsistent framework ordering that listed Ember in different positions on different pages. This tightens the copy so the docs match what actually ships.

## What changed

- **Consistent framework ordering** (React, Preact, Vue, Svelte, Ember) across the frameworks overview, adapter reference, install table, demo index, and inventory-table page.
- **Updated stale demo copy**: the inventory demo is now described as embedding all five framework shells (was "React and Preact" / "future shells"), with wording that keeps the "same model, different edge" framing.
- **Tightened the Svelte adapter description** ("Svelte 5 read bridge" / "Svelte 5 adapter") so it reads consistently with the other entries.

## Reviewer notes

- Docs-copy only — no demo or component logic changed.
- Validated locally: docs lint, `astro check` (0 errors), build (29 pages), and the inventory-table E2E (all six tabs) pass.

## User-facing changes

- The docs now consistently present the full five-framework demo set and describe the inventory demo accurately.